### PR TITLE
Automatically generate haskell.nix cache

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,7 +11,7 @@ steps:
       - "result/bin/xrefcheck"
   - command: nix run -f. -c xrefcheck
     label: Xrefcheck itself
-  - command: nix run -f $(nix eval -f nix/sources.nix --raw nixpkgs) reuse -c reuse lint
+  - command: nix run -f $(nix eval --raw '((import ./nix/sources.nix).nixpkgs)') reuse -c reuse lint
     label: REUSE lint
   - command:
       - NIX_PATH=nixpkgs=$(nix eval --raw '(import ./nix/sources.nix).nixpkgs') nix-shell -p curl git gitAndTools.hub --run "curl https://raw.githubusercontent.com/serokell/scratch/release-binary/scripts/release-binary.sh | bash"

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "5065fe9aaea869e76ca0f11d7b7864aa3ca79553",
-        "sha256": "0x7kjdcxhjy1jfr6dh6blji1vb8x7k8yxz23d8bby4akxr43ws46",
+        "rev": "64a27464a7a59901f011971df5716c05aab9bd58",
+        "sha256": "1961zbw5pcc0cr9i1kv88khzyfr6i6xl3l46sc9ajv0w599dpnlk",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/5065fe9aaea869e76ca0f11d7b7864aa3ca79553.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/64a27464a7a59901f011971df5716c05aab9bd58.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "lootbox": {
@@ -29,10 +29,10 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs-channels",
-        "rev": "dae3575cee5b88de966d06b11861c602975cb23a",
-        "sha256": "0zv948jsw313fmwz3rbwna92hijq8ji3dqlzhliwkvxl1adh8pbg",
+        "rev": "8731aaaf8b30888bc24994096db830993090d7c4",
+        "sha256": "1hcc89rxi47nb0mpk05nl9rbbb04kfw97xfydhpmmgh57yrp3zqa",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs-channels/archive/dae3575cee5b88de966d06b11861c602975cb23a.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs-channels/archive/8731aaaf8b30888bc24994096db830993090d7c4.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -6,20 +6,20 @@ let
   # The fetchers. fetch_<type> fetches specs of type <type>.
   #
 
-  fetch_file = spec:
+  fetch_file = pkgs: spec:
     if spec.builtin or true then
       builtins_fetchurl { inherit (spec) url sha256; }
     else
       pkgs.fetchurl { inherit (spec) url sha256; };
 
-  fetch_tarball = spec:
+  fetch_tarball = pkgs: spec:
     if spec.builtin or true then
       builtins_fetchTarball { inherit (spec) url sha256; }
     else
       pkgs.fetchzip { inherit (spec) url sha256; };
 
   fetch_git = spec:
-      builtins.fetchGit { url = spec.repo; inherit (spec) rev ref; };
+    builtins.fetchGit { url = spec.repo; inherit (spec) rev ref; };
 
   fetch_builtin-tarball = spec:
     builtins.trace
@@ -44,45 +44,35 @@ let
       (builtins_fetchurl { inherit (spec) url sha256; });
 
   #
-  # The sources to fetch.
-  #
-
-  sources = builtins.fromJSON (builtins.readFile ./sources.json);
-
-  #
   # Various helpers
   #
 
   # The set of packages used when specs are fetched using non-builtins.
-  pkgs =
-    if hasNixpkgsPath
-    then
-      if hasThisAsNixpkgsPath
-      then import (builtins_fetchTarball { inherit (sources_nixpkgs) url sha256; }) {}
-      else import <nixpkgs> {}
-    else
-      import (builtins_fetchTarball { inherit (sources_nixpkgs) url sha256; }) {};
-
-  sources_nixpkgs =
-    if builtins.hasAttr "nixpkgs" sources
-    then sources.nixpkgs
-    else abort
-      ''
-        Please specify either <nixpkgs> (through -I or NIX_PATH=nixpkgs=...) or
-        add a package called "nixpkgs" to your sources.json.
-      '';
-
-  hasNixpkgsPath = (builtins.tryEval <nixpkgs>).success;
-  hasThisAsNixpkgsPath =
-    (builtins.tryEval <nixpkgs>).success && <nixpkgs> == ./.;
+  mkPkgs = sources:
+    let
+      sourcesNixpkgs =
+        import (builtins_fetchTarball { inherit (sources.nixpkgs) url sha256; }) {};
+      hasNixpkgsPath = builtins.any (x: x.prefix == "nixpkgs") builtins.nixPath;
+      hasThisAsNixpkgsPath = <nixpkgs> == ./.;
+    in
+      if builtins.hasAttr "nixpkgs" sources
+      then sourcesNixpkgs
+      else if hasNixpkgsPath && ! hasThisAsNixpkgsPath then
+        import <nixpkgs> {}
+      else
+        abort
+          ''
+            Please specify either <nixpkgs> (through -I or NIX_PATH=nixpkgs=...) or
+            add a package called "nixpkgs" to your sources.json.
+          '';
 
   # The actual fetching function.
-  fetch = name: spec:
+  fetch = pkgs: name: spec:
 
     if ! builtins.hasAttr "type" spec then
       abort "ERROR: niv spec ${name} does not have a 'type' attribute"
-    else if spec.type == "file" then fetch_file spec
-    else if spec.type == "tarball" then fetch_tarball spec
+    else if spec.type == "file" then fetch_file pkgs spec
+    else if spec.type == "tarball" then fetch_tarball pkgs spec
     else if spec.type == "git" then fetch_git spec
     else if spec.type == "builtin-tarball" then fetch_builtin-tarball spec
     else if spec.type == "builtin-url" then fetch_builtin-url spec
@@ -117,12 +107,28 @@ let
       else
         fetchurl attrs;
 
+  # Create the final "sources" from the config
+  mkSources = config:
+    mapAttrs (
+      name: spec:
+        if builtins.hasAttr "outPath" spec
+        then abort
+          "The values in sources.json should not have an 'outPath' attribute"
+        else
+          spec // { outPath = fetch config.pkgs name spec; }
+    ) config.sources;
+
+  # The "config" used by the fetchers
+  mkConfig =
+    { sourcesFile ? ./sources.json
+    , sources ? builtins.fromJSON (builtins.readFile sourcesFile)
+    , pkgs ? mkPkgs sources
+    }: rec {
+      # The sources, i.e. the attribute set of spec name to spec
+      inherit sources;
+
+      # The "pkgs" (evaluated nixpkgs) to use for e.g. non-builtin fetchers
+      inherit pkgs;
+    };
 in
-mapAttrs (
-  name: spec:
-    if builtins.hasAttr "outPath" spec
-    then abort
-      "The values in sources.json should not have an 'outPath' attribute"
-    else
-      spec // { outPath = fetch name spec; }
-) sources
+mkSources (mkConfig {}) // { __functor = _: settings: mkSources (mkConfig settings); }

--- a/xrefcheck.nix
+++ b/xrefcheck.nix
@@ -12,13 +12,14 @@ let
     nixpkgs.haskell-nix;
   project = hn.stackProject {
     src = hn.haskellLib.cleanGit { src = ./.; };
-    modules = [{
+    modules = [
+      {
       packages.xrefcheck = {
         # More failures during CI == Less failures in runtime!
         postHaddock = ''
           [[ -z "$(ls -A dist/doc/html)" ]] && exit 1 || echo "haddock successfully generated documentation"'';
         package.ghcOptions = "-Werror";
-        components.exes.xrefcheck.configureFlags =
+        configureFlags =
           with nixpkgs.pkgsStatic;
           lib.optionals static [
             "--disable-executable-dynamic"
@@ -34,12 +35,6 @@ let
             "--ghc-option=-optl=-L${libffi}/lib"
           ];
       };
-    }];
-    cache = with sources; [{
-      name = "loot-prelude";
-      inherit (lootbox) sha256 rev;
-      url = "https://github.com/${lootbox.owner}/${lootbox.repo}.git";
-      subdir = "code/prelude";
     }];
   };
 in project.xrefcheck


### PR DESCRIPTION
## Description

This PR uses a patched `haskell.nix`, which allows to automatically generate the cache instead of explicitly specifying it in `crossref-verifier.nix` and `sources.json`.

## Related issue(s)

None

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](/README.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](docs/code-style.md).