### PR TITLE
buildkite: inject GITHUB_TOKEN via vault

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,6 +14,6 @@ steps:
   - command: nix run -f $(nix eval -f nix/sources.nix --raw nixpkgs) reuse -c reuse lint
     label: REUSE lint
   - command:
-      - GITHUB_TOKEN=$(cat ~/niv-bot-token) NIX_PATH=nixpkgs=$(nix eval --raw '(import ./nix/sources.nix).nixpkgs') nix-shell -p curl git gitAndTools.hub --run "curl https://raw.githubusercontent.com/serokell/scratch/release-binary/scripts/release-binary.sh | bash"
+      - NIX_PATH=nixpkgs=$(nix eval --raw '(import ./nix/sources.nix).nixpkgs') nix-shell -p curl git gitAndTools.hub --run "curl https://raw.githubusercontent.com/serokell/scratch/release-binary/scripts/release-binary.sh | bash"
     label: Create a pre-release
     branches: master


### PR DESCRIPTION
We now inject the GITHUB_TOKEN via a vault environment hook, this means there's no longer any need for the niv-bot-token and we should be able to remove it.