### PR TITLE
Various nix changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,19 +60,6 @@ Our CI uses `nix-build xrefcheck.nix` to build the whole project, including test
 It is based on the [`haskell.nix`](https://input-output-hk.github.io/haskell.nix/) project.
 You can do that too if you wish.
 
-<details>
-  <summary>Details</summary>
-
-There is a [bug](https://github.com/input-output-hk/haskell.nix/issues/335) which causes us to put some redundancy into Nix files:
-1. [`nix/sources.json`](nix/sources.json) lists all such dependencies that we obtain using `git`.
-It specifies concrete git revisions and SHA256 checksums.
-2. [`xrefcheck.nix`](xrefcheck.nix) lists all such dependencies as well, but without revisions.
-
-As a consequence, you may have to update these files when you update [`stack.yaml`](stack.yaml).
-You can use [`niv update`](https://github.com/nmattia/niv#update) to update [`nix/sources.json`](nix/sources.json).
-
-</details>
-
 ## Usage [↑](#xrefcheck)
 
 To find all broken links in a repository, run from within its folder:

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -11,18 +11,6 @@
         "url": "https://github.com/input-output-hk/haskell.nix/archive/64a27464a7a59901f011971df5716c05aab9bd58.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
-    "lootbox": {
-        "branch": "master",
-        "description": "Toolbox for your cool project",
-        "homepage": "",
-        "owner": "serokell",
-        "repo": "lootbox",
-        "rev": "18ced0d493348b4d6bae8517dff7ee6de6e0c9d9",
-        "sha256": "0y8gfdivjxx0jj8g651k5nzzwjg8mj9qw2s3v75vbpr8p008ymnr",
-        "type": "tarball",
-        "url": "https://github.com/serokell/lootbox/archive/18ced0d493348b4d6bae8517dff7ee6de6e0c9d9.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
     "nixpkgs": {
         "branch": "nixos-19.09",
         "description": "A read-only mirror of NixOS/nixpkgs tracking the released channels. Send issues and PRs to",


### PR DESCRIPTION
## Description

Updates various stuff in nix.

- Drops `lootbox` from `sources.json`, since the dependency is not auto-generated;
- Updates README.md to reflect the updated `haskell.nix`.

## Related issue(s)

None

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](/README.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](docs/code-style.md).
