### PR TITLE
Remove haddock enforcer

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-(import ./xrefcheck.nix {}).components.exes.xrefcheck
+(import ./xrefcheck.nix { static = true; }).components.exes.xrefcheck

--- a/xrefcheck.nix
+++ b/xrefcheck.nix
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-{ static ? true }:
+{ static ? false }:
 let
   sources = import ./nix/sources.nix;
   nixpkgs = import sources.nixpkgs (import sources."haskell.nix");
@@ -15,9 +15,6 @@ let
     modules = [
       {
       packages.xrefcheck = {
-        # More failures during CI == Less failures in runtime!
-        postHaddock = ''
-          [[ -z "$(ls -A dist/doc/html)" ]] && exit 1 || echo "haddock successfully generated documentation"'';
         package.ghcOptions = "-Werror";
         configureFlags =
           with nixpkgs.pkgsStatic;


### PR DESCRIPTION
## Description

This removes an extraneous check that haddock finishes correctly. This
is now enforced upstream, so we shouldn't need a secondary check
here. Please, if you have time, make haddock fail and check if it
fails the build now.

## Related issue(s)

None

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](/README.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](docs/code-style.md).