### PR TITLE
Add `ignored` CLI option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,9 @@
 Unreleased
 ==========
 
+0.1.1
+=======
+
 * [#19](https://github.com/serokell/xrefcheck/pull/24)
   + Make `ignored` in config consider only exact matches.
   + Improve virtual files consideration.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,11 @@
 Unreleased
 ==========
 
+* [#19](https://github.com/serokell/xrefcheck/pull/24)
+  + Make `ignored` in config consider only exact matches.
+  + Improve virtual files consideration.
+  + Add `ignored` CLI option.
+
 0.1.0.0
 =======
 

--- a/exec/Main.hs
+++ b/exec/Main.hs
@@ -39,8 +39,9 @@ defaultAction Options{..} = do
       Just configPath -> do
         readConfig configPath
 
-    repoInfo <- allowRewrite oShowProgressBar $ \rw ->
-        gatherRepoInfo rw formats (cTraversal config) root
+    repoInfo <- allowRewrite oShowProgressBar $ \rw -> do
+        let fullConfig = addTraversalOptions (cTraversal config) oTraversalOptions
+        gatherRepoInfo rw formats fullConfig root
 
     when oVerbose $
         fmtLn $ "Repository data:\n\n" <> indentF 2 (build repoInfo)

--- a/exec/Main.hs
+++ b/exec/Main.hs
@@ -44,7 +44,7 @@ defaultAction Options{..} = do
         gatherRepoInfo rw formats fullConfig root
 
     when oVerbose $
-        fmtLn $ "Repository data:\n\n" <> indentF 2 (build repoInfo)
+        fmtLn $ "=== Repository data ===\n\n" <> indentF 2 (build repoInfo)
 
     verifyRes <- allowRewrite oShowProgressBar $ \rw ->
         verifyRepo rw (cVerification config) oMode root repoInfo
@@ -52,7 +52,7 @@ defaultAction Options{..} = do
         Nothing ->
             fmtLn "All repository links are valid."
         Just (toList -> errs) -> do
-            fmt $ "Invalid references found:\n\n" <>
+            fmt $ "=== Invalid references found ===\n\n" <>
                   indentF 2 (blockListF' "➥ " build errs)
             fmtLn $ "Invalid references dumped, " <> build (length errs) <> " in total."
             exitFailure

--- a/package.yaml
+++ b/package.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 name:                xrefcheck
-version:             0.1.0.0
+version:             0.1.1
 github:              serokell/xrefcheck
 license:             MPL-2.0
 license-file:        LICENSE

--- a/src-files/def-config.yaml
+++ b/src-files/def-config.yaml
@@ -4,7 +4,7 @@
 
 # Parameters of repository traversal.
 traversal:
-  # Folders which we pretend do not exist
+  # Files and folders which we pretend do not exist
   # (so they are neither analyzed nor can be referenced).
   ignored:
     # Git files

--- a/src-files/def-config.yaml
+++ b/src-files/def-config.yaml
@@ -23,7 +23,7 @@ verification:
   # declaring "Response timeout".
   externalRefCheckTimeout: 10s
 
-  # File prefixes, references in which should not be analyzed.
+  # Prefixes of files, references in which should not be analyzed.
   notScanned:
     # GitHub-specific files
     - .github/pull_request_template.md

--- a/src/Xrefcheck/CLI.hs
+++ b/src/Xrefcheck/CLI.hs
@@ -11,6 +11,8 @@ module Xrefcheck.CLI
     , shouldCheckExternal
     , Command (..)
     , Options (..)
+    , TraversalOptions (..)
+    , addTraversalOptions
     , defaultConfigPaths
     , getCommand
     ) where
@@ -21,6 +23,7 @@ import Options.Applicative (Parser, ReadM, command, eitherReader, execParser, fu
                             short, strOption, switch, value)
 import Paths_xrefcheck (version)
 
+import Xrefcheck.Config
 import Xrefcheck.Core
 
 modeReadM :: ReadM VerifyMode
@@ -43,12 +46,24 @@ data Command
   | DumpConfig FilePath
 
 data Options = Options
-    { oConfigPath      :: Maybe FilePath
-    , oRoot            :: FilePath
-    , oMode            :: VerifyMode
-    , oVerbose         :: Bool
-    , oShowProgressBar :: Bool
+    { oConfigPath       :: Maybe FilePath
+    , oRoot             :: FilePath
+    , oMode             :: VerifyMode
+    , oVerbose          :: Bool
+    , oShowProgressBar  :: Bool
+    , oTraversalOptions :: TraversalOptions
     }
+
+data TraversalOptions = TraversalOptions
+    { toIgnored :: [FilePath]
+    }
+
+addTraversalOptions :: TraversalConfig -> TraversalOptions -> TraversalConfig
+addTraversalOptions TraversalConfig{..} (TraversalOptions ignored) =
+  TraversalConfig
+  { tcIgnored = tcIgnored ++ ignored
+  , ..
+  }
 
 -- | Where to try to seek configuration if specific path is not set.
 defaultConfigPaths :: [FilePath]
@@ -87,7 +102,16 @@ optionsParser = do
     oShowProgressBar <- fmap not . switch $
         long "no-progress" <>
         help "Do not display progress bar during verification."
+    oTraversalOptions <- traversalOptionsParser
     return Options{..}
+
+traversalOptionsParser :: Parser TraversalOptions
+traversalOptionsParser = do
+    toIgnored <- many . strOption $
+        long "ignored" <>
+        metavar "FILEPATH" <>
+        help "Files of files which we pretend do not exist."
+    return TraversalOptions{..}
 
 dumpConfigOptions :: Parser FilePath
 dumpConfigOptions = hsubparser $

--- a/src/Xrefcheck/CLI.hs
+++ b/src/Xrefcheck/CLI.hs
@@ -110,7 +110,7 @@ traversalOptionsParser = do
     toIgnored <- many . strOption $
         long "ignored" <>
         metavar "FILEPATH" <>
-        help "Files of files which we pretend do not exist."
+        help "Files and folders which we pretend do not exist."
     return TraversalOptions{..}
 
 dumpConfigOptions :: Parser FilePath

--- a/src/Xrefcheck/Config.hs
+++ b/src/Xrefcheck/Config.hs
@@ -12,7 +12,7 @@ import Data.Aeson.TH (deriveFromJSON)
 import Data.Yaml (FromJSON (..), decodeEither', prettyPrintParseException, withText)
 import Instances.TH.Lift ()
 import qualified Language.Haskell.TH.Syntax as TH
-import System.FilePath.Posix ((</>))
+import System.FilePath ((</>))
 import TH.RelativePaths (qReadFileBS)
 import Time (KnownRatName, Second, Time, unitsP)
 

--- a/src/Xrefcheck/Config.hs
+++ b/src/Xrefcheck/Config.hs
@@ -27,7 +27,7 @@ data Config = Config
 -- | Config of repositry traversal.
 data TraversalConfig = TraversalConfig
     { tcIgnored   :: [FilePath]
-      -- ^ Folders, files in which we completely ignore.
+      -- ^ Files and folders, files in which we completely ignore.
     }
 
 -- | Config of verification.

--- a/src/Xrefcheck/Config.hs
+++ b/src/Xrefcheck/Config.hs
@@ -16,7 +16,7 @@ import System.FilePath.Posix ((</>))
 import TH.RelativePaths (qReadFileBS)
 import Time (KnownRatName, Second, Time, unitsP)
 
-import Xrefcheck.System (CanonicalizedGlobPattern)
+import Xrefcheck.System (RelGlobPattern)
 
 -- | Overall config.
 data Config = Config
@@ -34,7 +34,7 @@ data TraversalConfig = TraversalConfig
 data VerifyConfig = VerifyConfig
     { vcAnchorSimilarityThreshold :: Double
     , vcExternalRefCheckTimeout   :: Time Second
-    , vcVirtualFiles              :: [CanonicalizedGlobPattern]
+    , vcVirtualFiles              :: [RelGlobPattern]
       -- ^ Files which we pretend do exist.
     , vcNotScanned                :: [FilePath]
       -- ^ Prefixes of files, references in which we should not analyze.

--- a/src/Xrefcheck/Config.hs
+++ b/src/Xrefcheck/Config.hs
@@ -37,7 +37,7 @@ data VerifyConfig = VerifyConfig
     , vcVirtualFiles              :: [CanonicalizedGlobPattern]
       -- ^ Files which we pretend do exist.
     , vcNotScanned                :: [FilePath]
-      -- ^ Folders, references in files of which we should not analyze.
+      -- ^ Prefixes of files, references in which we should not analyze.
     }
 
 -----------------------------------------------------------

--- a/src/Xrefcheck/Core.hs
+++ b/src/Xrefcheck/Core.hs
@@ -19,7 +19,7 @@ import qualified Data.Map as M
 import qualified Data.Text as T
 import Fmt (Buildable (..), blockListF, blockListF', nameF, (+|), (|+))
 import System.Console.Pretty (Color (..), Style (..), color, style)
-import System.FilePath.Posix (isPathSeparator, pathSeparator)
+import System.FilePath (isPathSeparator, pathSeparator)
 import Text.Numeral.Roman (toRoman)
 
 import Xrefcheck.Progress

--- a/src/Xrefcheck/Scan.hs
+++ b/src/Xrefcheck/Scan.hs
@@ -66,7 +66,7 @@ gatherRepoInfo rw formatsSupport config root = do
     dropSndMaybes l = [(a, b) | (a, Just b) <- l]
 
     ignored = map (root </>) (tcIgnored config)
-    isIgnored path = any (`isPrefixOf` path) ignored
+    isIgnored path = path `elem` ignored
     filterExcludedDirs cur = \case
         Tree.Dir name subfiles ->
             let subfiles' =

--- a/src/Xrefcheck/Scan.hs
+++ b/src/Xrefcheck/Scan.hs
@@ -19,7 +19,7 @@ import qualified Data.Foldable as F
 import qualified Data.Map as M
 import GHC.Err (errorWithoutStackTrace)
 import qualified System.Directory.Tree as Tree
-import System.FilePath.Posix (takeDirectory, takeExtension, (</>))
+import System.FilePath (takeDirectory, takeExtension, (</>))
 
 import Xrefcheck.Config
 import Xrefcheck.Core

--- a/src/Xrefcheck/System.hs
+++ b/src/Xrefcheck/System.hs
@@ -12,8 +12,8 @@ module Xrefcheck.System
 import Data.Aeson (FromJSON (..), withText)
 import GHC.IO.Unsafe (unsafePerformIO)
 import System.Directory (canonicalizePath)
+import System.FilePath ((</>))
 import qualified System.FilePath.Glob as Glob
-import System.FilePath.Posix ((</>))
 
 -- | We can quite safely treat surrounding filesystem as frozen,
 -- so IO reading operations can be turned into pure values.

--- a/src/Xrefcheck/System.hs
+++ b/src/Xrefcheck/System.hs
@@ -5,25 +5,43 @@
 
 module Xrefcheck.System
     ( readingSystem
-    , CanonicalizedGlobPattern (..)
+    , RelGlobPattern (..)
+    , bindGlobPattern
     ) where
 
 import Data.Aeson (FromJSON (..), withText)
 import GHC.IO.Unsafe (unsafePerformIO)
 import System.Directory (canonicalizePath)
 import qualified System.FilePath.Glob as Glob
+import System.FilePath.Posix ((</>))
 
 -- | We can quite safely treat surrounding filesystem as frozen,
 -- so IO reading operations can be turned into pure values.
 readingSystem :: IO a -> a
 readingSystem = unsafePerformIO
 
--- | Glob pattern with 'canonicalizePath' applied O_o.
-newtype CanonicalizedGlobPattern = CanonicalizedGlobPattern Glob.Pattern
+-- | Glob pattern relative to repository root.
+newtype RelGlobPattern = RelGlobPattern FilePath
 
-instance FromJSON CanonicalizedGlobPattern where
-    parseJSON = withText "Repo-rooted glob pattern" $ \path -> do
-        let !cpath = readingSystem $ canonicalizePath (toString path)
-        cpat <- Glob.tryCompileWith Glob.compDefault cpath
-                & either fail pure
-        return $ CanonicalizedGlobPattern cpat
+bindGlobPattern :: FilePath -> RelGlobPattern -> Glob.Pattern
+bindGlobPattern root (RelGlobPattern relPat) = readingSystem $ do
+  -- TODO [#26] try to avoid using canonicalization
+  absPat <- canonicalizePath (root </> relPat)
+  case Glob.tryCompileWith globCompileOptions absPat of
+    Left err ->
+      error $ "Glob pattern compilation failed after canonicalization: " <>
+              toText err
+    Right pat ->
+      return pat
+
+instance FromJSON RelGlobPattern where
+    parseJSON = withText "Repo-relative glob pattern" $ \path -> do
+        let spath = toString path
+        -- Checking path is sane
+        _ <- Glob.tryCompileWith globCompileOptions spath
+             & either fail pure
+        return (RelGlobPattern spath)
+
+-- | Glob compilation options we use.
+globCompileOptions :: Glob.CompOptions
+globCompileOptions = Glob.compDefault

--- a/src/Xrefcheck/Verify.hs
+++ b/src/Xrefcheck/Verify.hs
@@ -207,7 +207,8 @@ verifyReference config@VerifyConfig{..} mode progressRef (RepoInfo repoInfo)
         let cfile = readingSystem $ canonicalizePath file
         let isVirtual = or
                 [ Glob.match pat cfile
-                | CanonicalizedGlobPattern pat <- vcVirtualFiles ]
+                | virtualFile <- vcVirtualFiles
+                , let pat = bindGlobPattern root virtualFile ]
 
         unless (fileExists || dirExists || isVirtual) $
             throwError (FileDoesNotExist file)

--- a/src/Xrefcheck/Verify.hs
+++ b/src/Xrefcheck/Verify.hs
@@ -35,8 +35,8 @@ import Network.HTTP.Req (GET (..), HEAD (..), HttpException (..), NoReqBody (..)
 import Network.HTTP.Types.Status (Status, statusCode, statusMessage)
 import System.Console.Pretty (Style (..), style)
 import System.Directory (canonicalizePath, doesDirectoryExist, doesFileExist)
+import System.FilePath (takeDirectory, (</>))
 import qualified System.FilePath.Glob as Glob
-import System.FilePath.Posix (takeDirectory, (</>))
 import Time (RatioNat, Second, Time (..), ms, threadDelay, timeout)
 
 import Xrefcheck.Config


### PR DESCRIPTION
## Description

Problem: it is often a case that in CI we copy xrefcheck repository into
the verified project, and we want to exclude folder with xrefcheck from
scan. Considering this in config is not too convenient, better add a CLI
option.

Solution: add this CLI option.

As in config, I call it `not-scanned`, because simpler `excluded` is too
general and it's not obvious what exactly it refers to - the set of
verified files or the set of supposedly non-existing files (in the
latter case references _to_ such files should also be prohibited).
## Related issue(s)

- Fixes partially #19 

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](/README.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](docs/code-style.md).
