### PR TITLE
xrefcheck.nix: bump hs.nix, remove unneccesary flags

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "b6a8a97249624583498d37541b0ca85d72a8e4db",
-        "sha256": "12n2na5b9pjwnmrdpk9dbi7m9zv6bhc647vf4rf557z5zz7dq6j4",
+        "rev": "0933c58908816bca525fbf8873abdbc3e072a87e",
+        "sha256": "1shgaaqj0j2d5f7967xssp69nn6dv34dfvkvqkiakb99ggycgdyg",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/b6a8a97249624583498d37541b0ca85d72a8e4db.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/0933c58908816bca525fbf8873abdbc3e072a87e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {

--- a/xrefcheck.nix
+++ b/xrefcheck.nix
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2019 Serokell <https://serokell.io>
+# SPDX-FileCopyrightText: 2020 Serokell <https://serokell.io>
 #
 # SPDX-License-Identifier: MPL-2.0
 
@@ -6,30 +6,15 @@
 let
   sources = import ./nix/sources.nix;
   nixpkgs = import sources.nixpkgs (import sources."haskell.nix");
-  hn = if static then
-    nixpkgs.pkgsCross.musl64.haskell-nix
-  else
-    nixpkgs.haskell-nix;
-  project = hn.stackProject {
-    src = hn.haskellLib.cleanGit { src = ./.; };
-    modules = [
-      {
+  pkgs = if static then nixpkgs.pkgsCross.musl64 else nixpkgs;
+  project = pkgs.haskell-nix.stackProject {
+    src = pkgs.haskell-nix.haskellLib.cleanGit { src = ./.; };
+    modules = [{
       packages.xrefcheck = {
         package.ghcOptions = "-Werror";
-        configureFlags =
-          with nixpkgs.pkgsStatic;
+        configureFlags = with pkgs;
           lib.optionals static [
-            "--disable-executable-dynamic"
-            "--disable-shared"
-            "--ghc-option=-optl=-pthread"
-            "--ghc-option=-optl=-static"
-            "--ghc-option=-optl=-lc"
-            "--ghc-option=-optl=-lz"
-            "--ghc-option=-optl=-lgmp"
-            "--ghc-option=-optl=-lffi"
-            "--ghc-option=-optl=-L${gmp6}/lib"
             "--ghc-option=-optl=-L${zlib.static}/lib"
-            "--ghc-option=-optl=-L${libffi}/lib"
           ];
       };
     }];


### PR DESCRIPTION
https://github.com/input-output-hk/haskell.nix/commit/775c8cf756c08a779bbc587013c27f4f4b3df71a fixed a bunch of problems with musl, we can now simplify and only need the custom zlib.
