### PR TITLE
Avoid loot-prelude dependency

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,13 @@
 Unreleased
 ==========
 
+
+0.1.1.1
+=======
+
+* [#30](https://github.com/serokell/xrefcheck/pull/32)
+  + Do not depend on `loot-prelude` package.
+
 0.1.1
 =======
 

--- a/package.yaml
+++ b/package.yaml
@@ -5,7 +5,7 @@
 spec-version: 0.31.0
 
 name:                xrefcheck
-version:             0.1.1
+version:             0.1.1.1
 github:              serokell/xrefcheck
 license:             MPL-2.0
 license-file:        LICENSE

--- a/package.yaml
+++ b/package.yaml
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
+spec-version: 0.31.0
+
 name:                xrefcheck
 version:             0.1.1
 github:              serokell/xrefcheck
@@ -73,7 +75,6 @@ dependencies:
   - http-client
   - http-types
   - lens
-  - loot-prelude
   - pretty-terminal
   - mtl
   - o-clock
@@ -85,6 +86,8 @@ dependencies:
   - text-metrics
   - th-lift-instances
   - th-utilities
+  - name: universum
+    mixin: [(Universum as Prelude), (Universum.Unsafe as Unsafe)]
   - yaml
   - with-utf8
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -13,8 +13,3 @@ extra-deps:
 - aeson-options-0.1.0
 - o-clock-1.1.0
 - with-utf8-1.0.0.0
-
-- git: https://github.com/serokell/lootbox.git
-  commit: 18ced0d493348b4d6bae8517dff7ee6de6e0c9d9 # master
-  subdirs:
-    - code/prelude

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -33,21 +33,12 @@ packages:
   original:
     hackage: o-clock-1.1.0
 - completed:
-    subdir: code/prelude
-    cabal-file:
-      size: 898
-      sha256: 57621e886108b62e43236c4a9d562a0330a714188193a9cc50ced8024bd138eb
-    name: loot-prelude
-    version: 0.0.0.0
-    git: https://github.com/serokell/lootbox.git
+    hackage: with-utf8-1.0.0.0@sha256:686e47588986d8080451b4e617118b579487dd4e085bba7bb36fac4198c90ae6,2480
     pantry-tree:
-      size: 264
-      sha256: 47da19ed2f317b2f7c6f70a8517c275e7bd8bf25bd628cf271d08d6b5bc5b8ec
-    commit: 18ced0d493348b4d6bae8517dff7ee6de6e0c9d9
+      size: 905
+      sha256: 39176872f0dde9f9e09c9cb9496e2b7b10fa17cb9a6eca8d40ca4b2dcaaacc11
   original:
-    subdir: code/prelude
-    git: https://github.com/serokell/lootbox.git
-    commit: 18ced0d493348b4d6bae8517dff7ee6de6e0c9d9
+    hackage: with-utf8-1.0.0.0
 snapshots:
 - completed:
     size: 524804


### PR DESCRIPTION
## Description

Problem: lootbox is not uploaded to hackage, so when we upload
xrefcheck, its build on hackage fails.

Solution: we can use `mixins` feature to set Universum as prelude
without any intermediate packages.

This seems to be supported even by quite old versions of stack, like
1.7.3, so that should not bring build problems in most cases.

## Related issue(s)

Fixes #30

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](/README.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](docs/code-style.md).
