### PR TITLE
Mention 'Path_*` module in `package.yaml`

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -94,10 +94,15 @@ dependencies:
 library:
   source-dirs: src
 
+  generated-other-modules:
+  - Paths_xrefcheck
+
 executables:
   xrefcheck:
     main:                Main.hs
     source-dirs:         exec
+    generated-other-modules:
+    - Paths_xrefcheck
     ghc-options:
     - -threaded
     - -rtsopts
@@ -110,6 +115,8 @@ tests:
   xrefcheck-tests:
     main:                Main.hs
     source-dirs:         tests
+    generated-other-modules:
+    - Paths_xrefcheck
     dependencies:
     - xrefcheck
     - hspec


### PR DESCRIPTION
Problem: after we started using mixins feature, generated .cabal file
requires cabal 2.0. Attempt to upload our package to Hackage now reports
an error, saying that `autogen-modules` section have to mention `Path_*`
files.

Solution: add `Paths_xrefcheck` to `generated-other-modules` section of
`package.yaml`.

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #1 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](/README.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](docs/code-style.md).
