### PR TITLE
Drop autoexporter usage

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,11 @@
 Unreleased
 ==========
 
+0.1.1.2
+=======
+
+* [#34](https://github.com/serokell/xrefcheck/pull/34)
+  + Do not depend on `autoexporter` and `base-noprelude`.
 
 0.1.1.1
 =======

--- a/package.yaml
+++ b/package.yaml
@@ -5,7 +5,7 @@
 spec-version: 0.31.0
 
 name:                xrefcheck
-version:             0.1.1.1
+version:             0.1.1.2
 github:              serokell/xrefcheck
 license:             MPL-2.0
 license-file:        LICENSE

--- a/package.yaml
+++ b/package.yaml
@@ -50,9 +50,6 @@ default-extensions:
   - TypeApplications
   - TypeOperators
 
-build-tools:
-  - autoexporter
-
 ghc-options:
   - -Wall
   - -Wincomplete-record-updates

--- a/package.yaml
+++ b/package.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2018-2019 Serokell <https://serokell.io>
+# SPDX-FileCopyrightText: 2018-2020 Serokell <https://serokell.io>
 #
 # SPDX-License-Identifier: MPL-2.0
 
@@ -58,7 +58,8 @@ dependencies:
   - aeson
   - aeson-options
   - async
-  - base-noprelude
+  - name: base
+    mixin: [hiding (Prelude)]
   - bytestring
   - containers
   - cmark-gfm

--- a/src/Xrefcheck/Scanners.hs
+++ b/src/Xrefcheck/Scanners.hs
@@ -1,6 +1,10 @@
-{- SPDX-FileCopyrightText: 2018-2019 Serokell <https://serokell.io>
+{- SPDX-FileCopyrightText: 2018-2020 Serokell <https://serokell.io>
  -
  - SPDX-License-Identifier: MPL-2.0
  -}
 
-{-# OPTIONS_GHC -F -pgmF autoexporter #-}
+module Xrefcheck.Scanners
+  ( module Xrefcheck.Scanners.Markdown
+  ) where
+
+import Xrefcheck.Scanners.Markdown


### PR DESCRIPTION
## Description

Problem: `autoexporter` is used in one place to re-export one module.
Probably one day it will re-export more, but at this point it's really
overkill.
Moreover, it causes Hackage build to fail for the reasons mentioned
here:
https://github.com/haskell/hackage-server/issues/821

Solution: stop using it, re-export manually.

## Related issue(s)

None

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](/README.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](docs/code-style.md).
