### PR TITLE
Disable progress bar in CI automatically

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,9 @@
 Unreleased
 ==========
 
+0.1.2
+=======
+
 * [#44](https://github.com/serokell/xrefcheck/pull/44)
   + Decide whether to show progress bar by default depending on `CI` env variable.
   + Added `--progress` option.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,10 @@
 Unreleased
 ==========
 
+* [#44](https://github.com/serokell/xrefcheck/pull/44)
+  + Decide whether to show progress bar by default depending on `CI` env variable.
+  + Added `--progress` option.
+
 0.1.1.2
 =======
 

--- a/package.yaml
+++ b/package.yaml
@@ -5,7 +5,7 @@
 spec-version: 0.31.0
 
 name:                xrefcheck
-version:             0.1.1.2
+version:             0.1.2
 github:              serokell/xrefcheck
 license:             MPL-2.0
 license-file:        LICENSE

--- a/src/Xrefcheck/CLI.hs
+++ b/src/Xrefcheck/CLI.hs
@@ -18,7 +18,7 @@ module Xrefcheck.CLI
     ) where
 
 import Data.Version (showVersion)
-import Options.Applicative (Parser, ReadM, command, eitherReader, execParser, fullDesc, help,
+import Options.Applicative (Parser, ReadM, command, eitherReader, execParser, flag', fullDesc, help,
                             helper, hsubparser, info, infoOption, long, metavar, option, progDesc,
                             short, strOption, switch, value)
 import Paths_xrefcheck (version)
@@ -50,7 +50,7 @@ data Options = Options
     , oRoot             :: FilePath
     , oMode             :: VerifyMode
     , oVerbose          :: Bool
-    , oShowProgressBar  :: Bool
+    , oShowProgressBar  :: Maybe Bool
     , oTraversalOptions :: TraversalOptions
     }
 
@@ -99,9 +99,16 @@ optionsParser = do
         short 'v' <>
         long "verbose" <>
         help "Report repository scan and verification details."
-    oShowProgressBar <- fmap not . switch $
-        long "no-progress" <>
-        help "Do not display progress bar during verification."
+    oShowProgressBar <- asum
+        [ flag' (Just True) $
+            long "progress" <>
+            help "Display progress bar during verification. \
+                 \This is enabled by default unless `CI` env var is set to true."
+        , flag' (Just False) $
+            long "no-progress" <>
+            help "Do not display progress bar during verification."
+        , pure Nothing
+        ]
     oTraversalOptions <- traversalOptionsParser
     return Options{..}
 

--- a/src/Xrefcheck/System.hs
+++ b/src/Xrefcheck/System.hs
@@ -5,13 +5,16 @@
 
 module Xrefcheck.System
     ( readingSystem
+    , askWithinCI
     , RelGlobPattern (..)
     , bindGlobPattern
     ) where
 
 import Data.Aeson (FromJSON (..), withText)
+import qualified Data.Char as C
 import GHC.IO.Unsafe (unsafePerformIO)
 import System.Directory (canonicalizePath)
+import System.Environment (lookupEnv)
 import System.FilePath ((</>))
 import qualified System.FilePath.Glob as Glob
 
@@ -19,6 +22,14 @@ import qualified System.FilePath.Glob as Glob
 -- so IO reading operations can be turned into pure values.
 readingSystem :: IO a -> a
 readingSystem = unsafePerformIO
+
+-- | Heuristics to check whether we are running within CI.
+-- Check the respective env variable which is usually set in all CIs.
+askWithinCI :: IO Bool
+askWithinCI = lookupEnv "CI" <&> \case
+  Just "1"                       -> True
+  Just (map C.toLower -> "true") -> True
+  _                              -> False
 
 -- | Glob pattern relative to repository root.
 newtype RelGlobPattern = RelGlobPattern FilePath


### PR DESCRIPTION
Problem: we have two major use cases:

1. Using xrefcheck in CI, in this case it is annoying for devops to
always pass mostly always reasonable `--no-progress` option.
2. Using it locally, here we want progress bar to be enabled by default
so that user could run `xrefcheck` without any options most of the time.

Solution:

Detect whether are we running in CI and use the respective default for
whether progress bar should be displayed.

Detecting whether we are within CI is possible using `CI` env variable,
at least Github actions, Gitlab CI and Buildkite pass this env.

`--no-progress` option still can be passed if user wants to suppress
progress bar in local run. The opposite `--progress` seems to also make
sense, because in case if high timeouts are set, user probably wants to
track progress somehow to make sure that CI didn't hang. So we add the
latter, and these two options can be used to override the default
behaviour defined by `CI` env var.

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

- Fixed #42.

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](/README.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](docs/code-style.md).
