### PR TITLE
Add ability to build with docker

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -17,3 +17,14 @@ steps:
       - NIX_PATH=nixpkgs=$(nix eval --raw '(import ./nix/sources.nix).nixpkgs') nix-shell -p curl git gitAndTools.hub --run "curl https://raw.githubusercontent.com/serokell/scratch/release-binary/scripts/release-binary.sh | bash"
     label: Create a pre-release
     branches: master
+  - command:
+      - nix-build docker
+      - NIX_PATH=nixpkgs=$(nix eval --raw '(import ./nix/sources.nix).nixpkgs') nix run nixpkgs.skopeo -c skopeo copy --dest-creds "serokell:${DOCKERHUB_PASSWORD}" "docker-archive:$(readlink result)" "docker://docker.io/serokell/xrefcheck:latest"
+    label: Push to dockerhub
+    branches: master
+  - command:
+      - nix-build docker
+      - NIX_PATH=nixpkgs=$(nix eval --raw '(import ./nix/sources.nix).nixpkgs') nix run nixpkgs.skopeo -c skopeo copy --dest-creds "serokell:${DOCKERHUB_PASSWORD}" "docker-archive:$(readlink result)" "docker://docker.io/serokell/xrefcheck:${BUILDKITE_BRANCH}"
+    label: Push release to dockerhub
+    if: |
+      build.branch =~ /^v[0-9]+.*/

--- a/README.md
+++ b/README.md
@@ -45,22 +45,16 @@ Both relative and absolute local links are supported out of the box.
 * [url-checker](https://github.com/paramt/url-checker) - GitHub action which checks links in specified files.
 * [broken-link-checker](https://github.com/stevenvachon/broken-link-checker) - advanced checker for `HTML` files.
 
-## Build instructions [↑](#xrefcheck)
-
-Run `stack install` to build everything and install the executable.
-
-### CI and nix [↑](#xrefcheck)
-
-To build only the executables, run `nix-build`. You can use this line on your CI to use xrefcheck:
-```
-nix run -f https://github.com/serokell/xrefcheck/archive/master.tar.gz -c xrefcheck
-```
-
-Our CI uses `nix-build xrefcheck.nix` to build the whole project, including tests and Haddock.
-It is based on the [`haskell.nix`](https://input-output-hk.github.io/haskell.nix/) project.
-You can do that too if you wish.
 
 ## Usage [↑](#xrefcheck)
+
+We provide the following ways for you to use xrefcheck:
+
+- [statically linked binaries](https://github.com/serokell/xrefcheck/releases)
+- [Docker image](https://hub.docker.com/r/serokell/xrefcheck)
+- [building from source](#build-instructions-)
+
+If none of those are suitable for you, please open an issue!
 
 To find all broken links in a repository, run from within its folder:
 
@@ -91,6 +85,21 @@ xrefcheck dump-config
 Currently supported options include:
 * Timeout for checking external references;
 * List of ignored folders.
+
+## Build instructions [↑](#xrefcheck)
+
+Run `stack install` to build everything and install the executable.
+
+### CI and nix [↑](#xrefcheck)
+
+To build only the executables, run `nix-build`. You can use this line on your CI to use xrefcheck:
+```
+nix run -f https://github.com/serokell/xrefcheck/archive/master.tar.gz -c xrefcheck
+```
+
+Our CI uses `nix-build xrefcheck.nix` to build the whole project, including tests and Haddock.
+It is based on the [`haskell.nix`](https://input-output-hk.github.io/haskell.nix/) project.
+You can do that too if you wish.
 
 ## For further work [↑](#xrefcheck)
 

--- a/docker/default.nix
+++ b/docker/default.nix
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2019 Serokell <https://serokell.io>
+# SPDX-FileCopyrightText: 2020 Serokell <https://serokell.io>
 #
 # SPDX-License-Identifier: MPL-2.0
 

--- a/docker/default.nix
+++ b/docker/default.nix
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2019 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+{ pkgs ? import (import ../nix/sources.nix).nixpkgs { } }:
+let
+  executable =
+    (import ../xrefcheck.nix { static = true; }).components.exes.xrefcheck;
+  binOnly = pkgs.runCommand "xrefcheck-bin" { } ''
+    mkdir -p $out/bin
+    cp ${executable}/bin/xrefcheck $out/bin
+    ${pkgs.nukeReferences}/bin/nuke-refs $out/bin/xrefcheck
+  '';
+in pkgs.dockerTools.buildImage {
+  name = "xrefcheck";
+  contents = [ binOnly pkgs.cacert ];
+  config.Entrypoint = "xrefcheck";
+}


### PR DESCRIPTION
## Description

Having a docker image built and uploaded is vital for a tool like xrefcheck. Docker is the universal "package manager" for CIs.

## Related issue(s)

None

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](/README.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](docs/code-style.md).
