### PR TITLE
[#40] Mention GitHub action in `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Both relative and absolute local links are supported out of the box.
 
 We provide the following ways for you to use xrefcheck:
 
+- [GitHub action](https://github.com/marketplace/actions/xrefcheck)
 - [statically linked binaries](https://github.com/serokell/xrefcheck/releases)
 - [Docker image](https://hub.docker.com/r/serokell/xrefcheck)
 - [building from source](#build-instructions-)


### PR DESCRIPTION
## Description

Problem: @gromakovsky has recently implemented a github action which
adds xrefcheck pass to CI and it resides in a separate repository, we
want it to be visible in our documentation here.

Solution: mention it in `Usage` section.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #1 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](/README.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](docs/code-style.md).
