### PR TITLE
CI: fix pinning hackage and stackage, update hackage and stackage indexes

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "6be2e8a47504a4753dc8786bdc401ace902869cd",
-        "sha256": "1dj3ks79jnh2w2npy8q0yaxngcz0d5r8l8ihqgy7afjy7wpmn1gm",
+        "rev": "9250a9c48138c0f392db4ac476e061f5d05a3d8b",
+        "sha256": "0b2xhk64fjmgjh645bzwp5n5sby2jqs3gb4fxp0lwqsr4f678ca8",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/hackage.nix/archive/6be2e8a47504a4753dc8786bdc401ace902869cd.tar.gz",
+        "url": "https://github.com/input-output-hk/hackage.nix/archive/9250a9c48138c0f392db4ac476e061f5d05a3d8b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "haskell.nix": {
@@ -41,10 +41,10 @@
         "homepage": "",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "f50e24fa7a734f2291e8d940be33d917aa7456ad",
-        "sha256": "0rw35vllm81nnmvjqsl09qs00bw7gmj965p88rd250n80nv1g5c9",
+        "rev": "6b70ecf4bf6b970f8a1b2bae80d7189e745cba64",
+        "sha256": "0l7c59yqpxhghmysm98ggkfl7fms5cbdaa1cwc0s2fw3c2ql1jh8",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/stackage.nix/archive/f50e24fa7a734f2291e8d940be33d917aa7456ad.tar.gz",
+        "url": "https://github.com/input-output-hk/stackage.nix/archive/6b70ecf4bf6b970f8a1b2bae80d7189e745cba64.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/xrefcheck.nix
+++ b/xrefcheck.nix
@@ -6,7 +6,7 @@
 let
   sources = import ./nix/sources.nix;
   haskell-nix = import sources."haskell.nix" {
-    sourceOverrides = { hackage = sources."hackage.nix"; stackage = sources."stackage.nix"; };
+    sourcesOverride = { hackage = sources."hackage.nix"; stackage = sources."stackage.nix"; };
   };
   nixpkgs = import sources.nixpkgs haskell-nix.nixpkgsArgs;
   pkgs = if linux-static then nixpkgs.pkgsCross.musl64 else if windows then nixpkgs.pkgsCross.mingwW64 else nixpkgs;


### PR DESCRIPTION
## Description

Fixes a typo which caused pins for hackage.nix and stackage.nix to be ignored, and bumps hackage and stackage indexes

Trying to update nixpkgs and haskell.nix broke windows build, so they are not updated in this PR. But we should deal with this at some point if we want to keep dependencies fresh. The error can be seen here: https://buildkite.com/serokell/xrefcheck/builds/305#1f85a7f7-18eb-4000-a09d-bf57ab513742/63-125. I found that it is caused by a commit in nixpkgs which updates `mingw-w64`, because reverting this commit fixes the build: https://github.com/nixos/nixpkgs/commit/8b89e0494c5afc511df5463a413c340b43f73ca9

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

https://issues.serokell.io/issue/OPS-1023

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #1 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](/README.md)
    - Haddock

- Public contracts
  - [ ] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [ ] I added an entry to the [changelog](/CHANGES.md) if my changes are visible to the users
        and
  - [ ] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [ ] My code complies with the [style guide](docs/code-style.md).
