### PR TITLE
Ignoring global links in markdown files

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,7 +13,7 @@ steps:
     label: Windows executable
     artifact_paths:
       - "result/bin/*"
-  - command: nix run -f. -c xrefcheck
+  - command: nix run -f. -c xrefcheck --ignored tests/markdowns
     label: Xrefcheck itself
   - command: nix run -f $(nix eval --raw '((import ./nix/sources.nix).nixpkgs)') reuse -c reuse lint
     label: REUSE lint

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,13 @@
 Unreleased
 ==========
 
+* [#53](https://github.com/serokell/xrefcheck/pull/53)
+  + Make possible to include a regular expression in
+  `ignoreRefs` parameter of config to ignore external
+  references.
+  + Add support of right in-place ignoring annotations
+  such as `ignore file`, `ignore paragraph` and `ignore link`.
+
 0.1.2
 =======
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,79 @@ For description of other options:
 xrefcheck --help
 ```
 
+
+### Special functionality
+
+<details>
+  <summary>Ignoring external links</summary>
+
+  If you want some external links to not be verified, you can use one of the following ways to ignore those links:
+
+1. Add the regular expression that matches the ignoring link to the optional `ignoreRefs` parameter of your config file.
+
+    For example: 
+    ```yaml
+    ignoreRefs:
+      - https://bad.reference.(org|com)(/?)
+    ```
+    allows to ignore both `https://bad.reference.org` and `https://bad.reference.com` with or without last "/".
+
+2. Add right in-place annotation using one of the following ignoring modes (each mode is just a comment with a certain syntax).
+
+    * Ignore the link:
+
+        There are several ways to add this annotation:
+
+      * Just add it like a regular text before the ignoring link.
+
+        ```markdown
+        Bad ['com' reference](https://bad.reference.com) <!-- xrefcheck: ignore link --> and bad ['org' reference](https://bad.reference.org)
+        ```
+
+      * Separate the ignoring link from the annotation and the following text with single new lines.
+
+        ```markdown
+        Bad ['com' reference](https://bad.reference.com) and bad <!-- xrefcheck: ignore link -->
+        ['org'](https://bad.reference.org)
+        reference
+        ```
+
+        Therefore only `https://bad.reference.org` will be ignored.
+
+      * If the ignoring link is the first in a paragraph, then the annotation can also be added before a paragraph.
+
+        ```markdown
+        <!-- xrefcheck: ignore link -->
+        [Bad 'org' reference](https://bad.reference.org)
+        [Bad 'com' reference](https://bad.reference.com)
+        ```
+
+        It is still the same `https://bad.reference.org` will be ignored in this case.
+
+    * Ignore the paragraph:
+
+        ```markdown
+        <!-- xrefcheck: ignore paragraph -->
+        Bad ['org' reference](https://bad.reference.org)
+        Bad ['com' reference](https://bad.reference.com)
+
+        Bad ['io' reference](https://bad.reference.io)
+        ```
+
+        In this way, `https://bad.reference.org` and `https://bad.reference.com` will be ignored and `https://bad.reference.io` will still be verified.
+
+    * Ignore the whole file:
+        ```markdown
+        <!-- a comment -->
+        <!-- another comment -->
+
+        <!-- xrefcheck: ignore file -->
+        ...the rest of the file...
+        ```
+
+        Using this you can ignore the whole file.
+        </details>
+
 ## Configuring
 
 Configuration template (with all options explained) can be dumped with:

--- a/package.yaml
+++ b/package.yaml
@@ -52,6 +52,7 @@ default-extensions:
 ghc-options:
   - -Wall
   - -Wincomplete-record-updates
+  - -Wincomplete-uni-patterns
 
 dependencies:
   - aeson
@@ -87,6 +88,7 @@ dependencies:
   - text-metrics
   - th-lift-instances
   - th-utilities
+  - transformers
   - name: universum
     mixin: [(Universum as Prelude), (Universum.Unsafe as Unsafe)]
   - yaml

--- a/package.yaml
+++ b/package.yaml
@@ -74,6 +74,7 @@ dependencies:
   - Glob
   - http-client
   - http-types
+  - HUnit
   - lens
   - pretty-terminal
   - modern-uri

--- a/package.yaml
+++ b/package.yaml
@@ -79,6 +79,7 @@ dependencies:
   - mtl
   - o-clock
   - optparse-applicative
+  - regex-tdfa
   - req
   - roman-numerals
   - template-haskell

--- a/src-files/def-config.yaml
+++ b/src-files/def-config.yaml
@@ -13,6 +13,7 @@ traversal:
     # Stack files
     - .stack-work
 
+
 # Verification parameters.
 verification:
   # On 'anchor not found' error, how much similar anchors should be displayed as

--- a/src-files/def-config.yaml
+++ b/src-files/def-config.yaml
@@ -49,3 +49,9 @@ verification:
     - ../../issues/*
     - ../../merge_requests
     - ../../merge_requests/*
+
+  # POSIX extended regular expressions that match external references
+  # that have to be ignored (not verified).
+  # It is an optional parameter, so it can be omitted. 
+  ignoreRefs:
+    []

--- a/src/Xrefcheck/Config.hs
+++ b/src/Xrefcheck/Config.hs
@@ -7,6 +7,7 @@
 
 module Xrefcheck.Config where
 
+import Control.Lens (makeLensesWith)
 import Data.Aeson.Options (defaultOptions)
 import Data.Aeson.TH (deriveFromJSON)
 import Data.Yaml (FromJSON (..), decodeEither', prettyPrintParseException, withText)
@@ -21,6 +22,7 @@ import Data.FileEmbed (embedFile)
 import Time (KnownRatName, Second, Time, unitsP)
 
 import Xrefcheck.System (RelGlobPattern)
+import Xrefcheck.Util (postfixFields)
 
 -- | Overall config.
 data Config = Config
@@ -45,6 +47,9 @@ data VerifyConfig = VerifyConfig
     , vcIgnoreRefs                :: Maybe [Regex]
       -- ^ Regular expressions that match external references we should not verify.
     }
+
+makeLensesWith postfixFields ''Config
+makeLensesWith postfixFields ''VerifyConfig
 
 -----------------------------------------------------------
 -- Default config
@@ -93,7 +98,6 @@ defaultCompOption =
     , lastStarGreedy = False
     }
 
--- Default boolean value according to
--- https://hackage.haskell.org/package/regex-tdfa-1.3.1.0/docs/Text-Regex-TDFA.html#t:ExecOption
+-- ExecOption value to improve speed
 defaultExecOption :: ExecOption
 defaultExecOption = ExecOption {captureGroups = False}

--- a/src/Xrefcheck/Scanners/Markdown.hs
+++ b/src/Xrefcheck/Scanners/Markdown.hs
@@ -10,6 +10,7 @@
 module Xrefcheck.Scanners.Markdown
     ( markdownScanner
     , markdownSupport
+    , parseFileInfo
     ) where
 
 import CMarkGFM (Node (..), NodeType (..), PosInfo (..), commonmarkToNode)

--- a/src/Xrefcheck/Scanners/Markdown.hs
+++ b/src/Xrefcheck/Scanners/Markdown.hs
@@ -14,12 +14,13 @@ module Xrefcheck.Scanners.Markdown
 
 import CMarkGFM (Node (..), NodeType (..), PosInfo (..), commonmarkToNode)
 import Control.Lens ((%=))
+import Control.Monad.Trans.Except (Except, runExcept, throwE)
 import qualified Data.ByteString.Lazy as BSL
+import Data.Char (isSpace)
 import Data.Default (Default (..))
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as LT
 import Fmt (Buildable (..), blockListF, nameF, (+|), (|+))
-import GHC.Conc (par)
 
 import Xrefcheck.Core
 import Xrefcheck.Scan
@@ -49,54 +50,196 @@ nodeExtractText = mconcat . map extractText . nodeFlatten
         CODE t -> t
         _ -> ""
 
-nodeExtractInfo :: Node -> ExceptT Text Identity FileInfo
-nodeExtractInfo docNode = fmap finaliseFileInfo $ execStateT (loop docNode) def
-  where
-    loop node@(Node pos ty subs) = case ty of
-        DOCUMENT ->
-            mapM_ loop subs
-        PARAGRAPH ->
-            mapM_ loop subs
-        HEADING lvl ->
-            let text = nodeExtractText node
-                aType = HeaderAnchor lvl
-                aName = headerToAnchor text
-                aPos = toPosition pos
-            in fiAnchors %= (Anchor{..} :)
-        LIST _ ->
-            mapM_ loop subs
-        ITEM ->
-            mapM_ loop subs
-        HTML_INLINE htmlText -> do
-            let mName = T.stripSuffix "\">" =<< T.stripPrefix "<a name=\"" htmlText
-            whenJust mName $ \aName -> do
-                let aType = HandAnchor
-                    aPos = toPosition pos
-                fiAnchors %= (Anchor{..} :)
-        LINK url _ -> do
-            let rName = nodeExtractText node
-                rPos = toPosition pos
-                link = if null url then rName else url
-            let (rLink, rAnchor) = case T.splitOn "#" link of
-                    [t]    -> (t, Nothing)
-                    t : ts -> (t, Just $ T.intercalate "#" ts)
-                    []     -> error "impossible"
-            fiReferences %= (Reference{..} :)
-        _ -> pass
+data IgnoreMode
+    = Link
+    | Paragraph
+    | File
+    deriving Eq
 
-parseFileInfo :: FilePath -> LT.Text -> FileInfo
-parseFileInfo path input =
-    let outcome = runIdentity . runExceptT $
-                  nodeExtractInfo $ commonmarkToNode [] [] $ toStrict input
-    in case outcome of
-        Left err  -> error $ "Failed to parse file " <> show path <>
-                             ": " <> show err
-        Right res -> res
+nodeExtractInfo :: Node -> Except Text FileInfo
+nodeExtractInfo (Node _ _ docNodes) =
+    if checkIgnoreFile docNodes
+    then return def
+    else finaliseFileInfo <$> extractionResult
+    where
+        extractionResult :: Except Text FileInfo
+        extractionResult =
+            execStateT (loop docNodes Nothing) def
+
+        loop :: [Node] -> Maybe IgnoreMode -> StateT FileInfo (Except Text) ()
+        loop [] _ = pass
+        loop (node@(Node pos ty subs) : nodes) toIgnore
+            | toIgnore == Just File = returnError toIgnore "" pos
+            | toIgnore == Just Link = do
+                let (Node startPos _ _) = maybe defNode id $ safeHead subs
+                let mNext = case ty of
+                        PARAGRAPH -> afterIgnoredLink subs <> Just nodes
+                        TEXT txt | null (dropWhile isSpace $ T.unpack txt) -> afterIgnoredLink nodes
+                        SOFTBREAK -> afterIgnoredLink nodes
+                        _ -> afterIgnoredLink (node : nodes)
+                case mNext of
+                    Just next -> loop next Nothing
+                    Nothing   -> returnError toIgnore "" startPos
+            | toIgnore == Just Paragraph =
+                case ty of
+                    PARAGRAPH -> loop nodes Nothing
+                    _         -> returnError toIgnore (prettyType ty) pos
+            | otherwise = 
+                case ty of
+                    HTML_BLOCK _ -> processHtmlNode node pos nodes toIgnore
+                    HEADING lvl -> do
+                        let aType = HeaderAnchor lvl
+                        let aName = headerToAnchor $ nodeExtractText node
+                        let aPos = toPosition pos
+                        fiAnchors %= (Anchor{..} :)
+                        loop nodes toIgnore
+                    HTML_INLINE htmlText -> do
+                        let mName = T.stripSuffix "\">" =<< T.stripPrefix "<a name=\"" htmlText
+                        whenJust mName $ \aName -> do
+                            let aType = HandAnchor
+                                aPos = toPosition pos
+                            fiAnchors %= (Anchor{..} :)
+                        processHtmlNode node pos nodes toIgnore
+                    LINK url _ -> do
+                        let rName = nodeExtractText node
+                            rPos = toPosition pos
+                            link = if null url then rName else url
+                        let (rLink, rAnchor) = case T.splitOn "#" link of
+                                [t]    -> (t, Nothing)
+                                t : ts -> (t, Just $ T.intercalate "#" ts)
+                                []     -> error "impossible"
+                        fiReferences %= (Reference{..} :)
+                        loop nodes toIgnore
+                    _ -> loop (subs ++ nodes) toIgnore
+
+        defNode :: Node
+        defNode = Node Nothing DOCUMENT [] -- hard-coded default Node
+
+        getCommentContent :: Node -> Maybe Text
+        getCommentContent node = do
+            txt <- getHTMLText node
+            T.stripSuffix "-->" =<< T.stripPrefix "<!--" (T.strip txt)
+            where
+                getHTMLText :: Node -> Maybe Text
+                getHTMLText (Node _ (HTML_BLOCK txt) _) = Just txt
+                getHTMLText (Node _ (HTML_INLINE txt) _) = Just txt
+                getHTMLText _ = Nothing
+
+        getXrefcheckContent :: Node -> Maybe Text
+        getXrefcheckContent node = 
+            let notStripped = T.stripPrefix "xrefcheck:" . T.strip =<<
+                                 getCommentContent node
+            in T.strip <$> notStripped
+
+        getIgnoreMode :: Node -> Maybe IgnoreMode
+        getIgnoreMode node =
+            let mContent = getXrefcheckContent node
+
+                textToMode :: [Text] -> Maybe IgnoreMode
+                textToMode ("ignore" : [x])
+                    | x == "link"      = return Link
+                    | x == "paragraph" = return Paragraph
+                    | x == "file"      = return File
+                    | otherwise        = Nothing
+                textToMode _           = Nothing
+            in textToMode . words =<< mContent
+
+        isComment :: Node -> Bool
+        isComment = isJust . getCommentContent
+
+        isIgnoreFile :: Node -> Bool
+        isIgnoreFile = (Just File ==) . getIgnoreMode
+
+        checkIgnoreFile :: [Node] -> Bool
+        checkIgnoreFile nodes =
+            let isSimpleComment :: Node -> Bool
+                isSimpleComment node = isComment node && not (isIgnoreFile node)
+
+                mIgnoreFile = safeHead $ dropWhile isSimpleComment nodes
+            in maybe False isIgnoreFile mIgnoreFile
+
+        isLink :: Node -> Bool
+        isLink (Node _ (LINK _ _) _) = True
+        isLink _ = False
+
+        isText :: Node -> Bool
+        isText (Node _ (TEXT _) _) = True
+        isText _ = False
+
+        afterIgnoredLink :: [Node] -> Maybe [Node]
+        afterIgnoredLink (fNode : nodes)
+            | isLink fNode = return nodes
+            | sNode : nodes' <- nodes =
+                if isText fNode && isLink sNode
+                then return nodes'
+                else Nothing
+            | otherwise = Nothing
+        afterIgnoredLink _ = Nothing
+
+        prettyPos :: Maybe PosInfo -> Text
+        prettyPos pos = 
+            let posToText :: Position -> Text
+                posToText (Position mPos) = fromMaybe "" mPos
+            in "(" <> (posToText $ toPosition pos) <> ")"
+        
+        prettyType :: NodeType -> Text
+        prettyType ty =
+            let mType = safeHead $ words $ show ty
+            in maybe "" id mType
+
+        fileMsg :: Text
+        fileMsg =
+            "\"ignore file\" must be at the top of \
+            \markdown or right after comments at the top"
+
+        linkMsg :: Text
+        linkMsg = "expected a LINK after \"ignore link\" "
+
+        paragraphMsg :: Text -> Text
+        paragraphMsg txt = unwords
+            [ "expected a PARAGRAPH after \
+               \\"ignore paragraph\", but found"
+            , txt
+            , ""
+            ]
+
+        unrecognisedMsg :: Text -> Text
+        unrecognisedMsg txt = unwords
+            [ "unrecognised option"
+            , "\"" <> txt <> "\""
+            , "perhaps you meant \
+               \<\"ignore link\"|\"ignore paragraph\"|\"ignore file\"> "
+            ]
+        
+        returnError :: Maybe IgnoreMode -> Text -> Maybe PosInfo -> StateT FileInfo (Except Text) ()
+        returnError mode txt pos =
+            let errMsg = case mode of
+                    Just Link      -> linkMsg
+                    Just Paragraph -> paragraphMsg txt
+                    Just File      -> fileMsg
+                    Nothing        -> unrecognisedMsg txt
+                posInfo = prettyPos pos
+            in lift $ throwE $ errMsg <> posInfo
+
+        processHtmlNode :: Node -> Maybe PosInfo -> [Node] -> Maybe IgnoreMode -> StateT FileInfo (Except Text) ()
+        processHtmlNode node pos nodes toIgnore = do
+            let xrefcheckContent = getXrefcheckContent node
+            case xrefcheckContent of
+                Just content -> maybe (returnError Nothing content pos)
+                    (loop nodes . pure) $ getIgnoreMode node
+                Nothing -> loop nodes toIgnore
+
+parseFileInfo :: LT.Text -> Either Text FileInfo
+parseFileInfo input = runExcept $ nodeExtractInfo $
+    commonmarkToNode [] [] $ toStrict input
 
 markdownScanner :: ScanAction
-markdownScanner path = liftIO $ do
-    res <- parseFileInfo path . decodeUtf8 <$> BSL.readFile path
-    force res `par` return res
+markdownScanner path = do
+    errOrInfo <- parseFileInfo . decodeUtf8 <$> BSL.readFile path
+    case errOrInfo of
+        Left errTxt -> do
+            die $ "Error when scanning " <> path <> ": " <> T.unpack errTxt
+        Right fileInfo -> return fileInfo
 
 markdownSupport :: ([Extension], ScanAction)
 markdownSupport = ([".md"], markdownScanner)

--- a/src/Xrefcheck/Util.hs
+++ b/src/Xrefcheck/Util.hs
@@ -8,8 +8,10 @@
 module Xrefcheck.Util
     ( nameF'
     , paren
+    , postfixFields
     ) where
 
+import Control.Lens (LensRules, lensField, lensRules, mappingNamer)
 import Fmt (Builder, build, fmt, nameF)
 import System.Console.Pretty (Pretty (..), Style (Faint))
 
@@ -24,3 +26,6 @@ paren :: Builder -> Builder
 paren a
     | a == "" = ""
     | otherwise = "(" <> a <> ")"
+
+postfixFields :: LensRules
+postfixFields = lensRules & lensField .~ mappingNamer (\n -> [n ++ "L"])

--- a/tests/Test/Xrefcheck/IgnoreAnnotationsSpec.hs
+++ b/tests/Test/Xrefcheck/IgnoreAnnotationsSpec.hs
@@ -1,0 +1,55 @@
+{- SPDX-FileCopyrightText: 2019 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -}
+
+module Test.Xrefcheck.IgnoreAnnotationsSpec where
+
+import qualified Data.ByteString.Lazy as BSL
+import Test.Hspec (Spec, describe, it, shouldBe)
+
+import Xrefcheck.Core
+import Xrefcheck.Scanners.Markdown
+
+spec :: Spec
+spec = do
+    describe "Parsing failures" $ do
+        it "Check if parsing incorrect markdowns produce exceptions" $ do
+            areIncorrect <- mapM isIncorrectMD failPaths
+            or areIncorrect `shouldBe` True
+    describe "\"ignore link\" mode" $ do
+        it "Check \"ignore link\" performance" $ do
+            fi <- getFI "tests/markdowns/with-annotations/ignore_link.md"
+            (getRefs fi) `shouldBe` ["team", "team", "team", "hire-us", "how-we-work", "privacy"]
+    describe "\"ignore paragraph\" mode" $ do
+        it "Check \"ignore paragraph\" performance" $ do
+            fi <- getFI "tests/markdowns/with-annotations/ignore_paragraph.md"
+            (getRefs fi) `shouldBe` ["blog", "contacts"]
+    describe "\"ignore file\" mode" $ do
+        it "Check \"ignore file\" performance" $ do
+            fi <- getFI "tests/markdowns/with-annotations/ignore_file.md"
+            (getRefs fi) `shouldBe` []
+    where
+        failPaths :: [FilePath]
+        failPaths =
+            [ "tests/markdowns/with-annotations/no_link.md"
+            , "tests/markdowns/with-annotations/no_paragraph.md"
+            , "tests/markdowns/with-annotations/unexpected_ignore_file.md"
+            , "tests/markdowns/with-annotations/unrecognised_option.md"
+            ]
+        
+        parse :: FilePath -> IO (Either Text FileInfo)
+        parse path = parseFileInfo . decodeUtf8 <$> BSL.readFile path
+
+        getFI :: FilePath -> IO FileInfo
+        getFI path =
+            let errOrFI = parse path
+            in either error id <$> errOrFI
+        
+        getRefs :: FileInfo -> [Text]
+        getRefs fi = map rName $ fi ^. fiReferences 
+
+        isIncorrectMD :: FilePath -> IO Bool
+        isIncorrectMD path = do
+            errOrInfo <- parse path
+            return $ isLeft errOrInfo

--- a/tests/Test/Xrefcheck/IgnoreRegexSpec.hs
+++ b/tests/Test/Xrefcheck/IgnoreRegexSpec.hs
@@ -1,0 +1,84 @@
+{- SPDX-FileCopyrightText: 2019 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -}
+
+module Test.Xrefcheck.IgnoreRegexSpec where
+
+import Data.Yaml (decodeEither')
+import Test.Hspec (Spec, describe, it)
+import Test.HUnit (assertFailure)
+import Text.Regex.TDFA (Regex)
+
+import Xrefcheck.Config
+import Xrefcheck.Core
+import Xrefcheck.Progress (allowRewrite)
+import Xrefcheck.Scan (gatherRepoInfo, specificFormatsSupport)
+import Xrefcheck.Scanners.Markdown
+import Xrefcheck.Verify
+    (VerifyError, VerifyResult, WithReferenceLoc(..), verifyErrors, verifyRepo)
+
+spec :: Spec
+spec = do
+    describe "Regular expressions performance" $ do
+        let root = "tests/markdowns/without-annotations"
+        let showProgressBar = False
+        let formats = specificFormatsSupport [markdownSupport]
+        let verifyMode = ExternalOnlyMode
+
+        let linksTxt =
+                [ "https://bad.((external.)?)reference(/?)"
+                , "https://bad.reference.(org|com)"
+                ]
+        let regexs = linksToRegexs linksTxt
+        let config = setIgnoreRefs regexs defConfig
+
+        it "Check that only not matched links are verified" $ do
+            repoInfo <- allowRewrite showProgressBar $ \rw ->
+                gatherRepoInfo rw formats (config ^. cTraversalL) root
+
+            verifyRes <- allowRewrite showProgressBar $ \rw ->
+                verifyRepo rw (config ^. cVerificationL) verifyMode root repoInfo
+
+            let brokenLinks = pickBrokenLinks verifyRes
+
+            let matchedLinks =
+                    [ "https://bad.referenc/"
+                    , "https://bad.reference"
+                    , "https://bad.external.reference/"
+                    , "https://bad.external.reference"
+                    , "https://bad.reference.org"
+                    , "https://bad.reference.com"
+                    ]
+
+            let notMatchedLinks =
+                    [ "https://non-existent.reference/"
+                    , "https://bad.externall.reference"
+                    , "https://bad.reference.io"
+                    ]
+
+            forM_ matchedLinks $ \link -> do
+                when (link `elem` brokenLinks) $
+                    assertFailure $ "Link \"" <> show link <>
+                                    "\" is considered as broken but it should be ignored"
+
+            forM_ notMatchedLinks $ \link -> do
+                when (link `notElem` brokenLinks) $
+                    assertFailure $ "Link \"" <> show link <>
+                                    "\" is not considered as broken but it is (and shouldn't be ignored)"
+
+    where
+        pickBrokenLinks :: VerifyResult (WithReferenceLoc VerifyError) -> [Text]
+        pickBrokenLinks verifyRes = 
+            case verifyErrors verifyRes of
+                Just neWithRefLoc -> map (rLink . wrlReference) $ toList neWithRefLoc
+                Nothing -> []
+
+        linksToRegexs :: [Text] -> Maybe [Regex]
+        linksToRegexs links =
+            let errOrRegexs = map (decodeEither' . encodeUtf8) links
+                maybeRegexs = map (either (error . show) Just) errOrRegexs
+            in sequence maybeRegexs
+
+        setIgnoreRefs :: Maybe [Regex] -> Config -> Config
+        setIgnoreRefs regexs = (cVerificationL . vcIgnoreRefsL) .~ regexs

--- a/tests/markdowns/with-annotations/ignore_file.md
+++ b/tests/markdowns/with-annotations/ignore_file.md
@@ -1,0 +1,19 @@
+<!--
+ - SPDX-FileCopyrightText: 2018-2019 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -->
+
+ <!-- a comment -->
+ <!-- another comment -->
+
+<!-- xrefcheck:ignore file -->
+
+Serokell [web-site](https://serokell.io/)
+Serokell [team](https://serokell.io/team)
+
+Serokell [blog](https://serokell.io/blog)
+
+Serokell [labs](https://serokell.io/labs)
+
+Serokell [contacts](https://serokell.io/contacts)

--- a/tests/markdowns/with-annotations/ignore_link.md
+++ b/tests/markdowns/with-annotations/ignore_link.md
@@ -1,0 +1,32 @@
+<!--
+ - SPDX-FileCopyrightText: 2018-2019 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -->
+
+### Ignore the first link in the paragraph
+
+<!-- xrefcheck: ignore link-->
+Serokell [web-site](https://serokell.io/)
+Serokell [team](https://serokell.io/team)
+
+<!-- xrefcheck: ignore link-->
+
+Serokell [blog](https://serokell.io/blog)
+
+Serokell <!-- xrefcheck: ignore link --> [labs](https://serokell.io/labs)
+
+Serokell <!-- xrefcheck: ignore link -->
+[contacts](https://serokell.io/contacts) and again
+[team](https://serokell.io/team)
+
+### Ignore not the first link in the paragraph
+
+[team](https://serokell.io/team) again and <!-- xrefcheck: ignore link --> [projects](https://serokell.io/projects)
+
+Also [hire-us](https://serokell.io/hire-us) and <!--xrefcheck: ignore link -->
+[fintech](https://serokell.io/fintech-development)
+development
+
+Here are [how-we-work](https://serokell.io/how-we-work) and [privacy](https://serokell.io/privacy)
+and <!-- xrefcheck: ignore link -->     [ml consulting](https://serokell.io/machine-learning-consulting)

--- a/tests/markdowns/with-annotations/ignore_paragraph.md
+++ b/tests/markdowns/with-annotations/ignore_paragraph.md
@@ -1,0 +1,16 @@
+<!--
+ - SPDX-FileCopyrightText: 2018-2019 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -->
+
+<!-- xrefcheck:ignore paragraph  -->
+Serokell [web-site](https://serokell.io/)
+Serokell [team](https://serokell.io/team)
+
+Serokell [blog](https://serokell.io/blog)
+
+<!-- xrefcheck: ignore paragraph -->
+Serokell [labs](https://serokell.io/labs)
+
+Serokell [contacts](https://serokell.io/contacts)

--- a/tests/markdowns/with-annotations/no_link.md
+++ b/tests/markdowns/with-annotations/no_link.md
@@ -1,0 +1,8 @@
+<!--
+ - SPDX-FileCopyrightText: 2018-2019 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -->
+
+<!-- xrefcheck: ignore link -->
+not a link

--- a/tests/markdowns/with-annotations/no_paragraph.md
+++ b/tests/markdowns/with-annotations/no_paragraph.md
@@ -1,0 +1,9 @@
+<!--
+ - SPDX-FileCopyrightText: 2018-2019 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -->
+
+<!-- xrefcheck:ignore paragraph -->
+
+# not a paragraph

--- a/tests/markdowns/with-annotations/unexpected_ignore_file.md
+++ b/tests/markdowns/with-annotations/unexpected_ignore_file.md
@@ -1,0 +1,11 @@
+<!--
+ - SPDX-FileCopyrightText: 2018-2019 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -->
+
+the first paragraph
+
+<!--xrefcheck: ignore file -->
+
+the second paragraph

--- a/tests/markdowns/with-annotations/unrecognised_option.md
+++ b/tests/markdowns/with-annotations/unrecognised_option.md
@@ -1,0 +1,8 @@
+<!--
+ - SPDX-FileCopyrightText: 2018-2019 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -->
+
+<!-- xrefcheck: ignore link -->
+Serokell [web-site](https://serokell.io/)

--- a/tests/markdowns/without-annotations/all_checked.md
+++ b/tests/markdowns/without-annotations/all_checked.md
@@ -1,0 +1,11 @@
+<!--
+ - SPDX-FileCopyrightText: 2018-2019 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -->
+
+[Non-existent reference](https://non-existent.reference/)
+
+[Bad externall reference](https://bad.externall.reference)
+
+[Bad 'io' reference](https://bad.reference.io)

--- a/tests/markdowns/without-annotations/all_ignored.md
+++ b/tests/markdowns/without-annotations/all_ignored.md
@@ -1,0 +1,14 @@
+<!--
+ - SPDX-FileCopyrightText: 2018-2019 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -->
+
+[Bad reference with '/'](https://bad.reference/)
+[Bad reference without '/'](https://bad.reference)
+
+[Bad external reference with '/'](https://bad.external.reference/)
+[Bad external reference without '/'](https://bad.external.reference)
+
+[Bad 'org' reference](https://bad.reference.org)
+[Bad 'com' reference](https://bad.reference.com)


### PR DESCRIPTION
## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

Sometimes we want to ignore some global links in markdown files. The reasons can be different. For example, we know that CI runner does not have the certain level of access. Or we just want to have broken link in our markdown. This PR adds a couple of ways to do it.

**The first** is about including links we want to ignore in config file. It enables including not only links, but regular expressions for them.
Example:

If you want to ignore https://gitlab.com/morley-framework/morley/-/issues/new and https://gitlab.com/morley-framework/morley/-/merge_requests/new, you should include these lines in your config yaml file (`src-files/def-config.yaml` by default):
```
ignoreRefs:
    - https://gitlab.com/morley-framework/morley/-/(issues|merge_requests)/new
```
If you don't want any link in your repository to be ignored, leave `ignoreRefs` empty:

```
ignoreRefs:
   []
```

**The second** way to ignore a link is to annotate it right in-place. There are 3 modes of ignoring supported - link, paragraph and file. It becomes clear by example:
Example:
1. Use `<!-- xrefcheck: ignore file -->`  to ignore the whole file. It won't be scanned by parser. Note that it must be either at the top of markdown:
```
<!-- xrefcheck:ignore file -->

file content
```
or right after the comment blocks:
```
<!-- the comment -->
<!-- another comment -->
<!-- xrefcheck:ignore file -->

file content
```
otherwise the following error will be produced (`11:1-20` is a position where "ignore file" occurred):
`Error when scanning ./tests/markdowns/unexpected_ignore_file.md: "ignore file" must be at the top of markdown or right after comments at the top (11:1-20)`

2. Use `<!-- xrefcheck: ignore paragraph -->`  to ignore the following paragraph.

`web-site` and `team` links will be ignored, `blog` will be still validated:
```
<!-- xrefcheck:ignore paragraph  -->
Serokell [web-site](https://serokell.io/)
[team](https://serokell.io/team)

Serokell [blog](https://serokell.io/blog)
```
 If there is not a paragraph ignore comment is followed by, then it will be the respected error (`9:1-17` is a position of element that follows ignore comment):
`Error when scanning ./tests/markdowns/no_paragraph.md: expected a PARAGRAPH after "ignore paragraph", but found HEADING (9:1-17)`

3. Use ` <!-- xrefcheck: ignore link-->` to ignore the following link.

You can include a text before link, but there must not be line breaks.
So there are correct usages (ignore `web-site`, but not `team`)
```
<!-- xrefcheck: ignore link-->
Serokell [web-site](https://serokell.io/)
Serokell [team](https://serokell.io/team)
```
```
<!-- xrefcheck: ignore link-->
[web-site](https://serokell.io/)
[team](https://serokell.io/team)
```
and this one is not:
```
<!-- xrefcheck: ignore link-->
Serokell
[web-site](https://serokell.io/)
```
So the result will be (`8:1-10` is a position of "not-a-link" element):
`Error when scanning ./tests/markdowns/no_link.md: expected a LINK after "ignore link" (8:1-10)`


The description of ignoring modes is also located in the footer of help message:
```
To ignore a link in your markdown, include "<!-- xrefcheck: ignore mode -->"
comment with one of these modes:
  "link"                   Ignore the following link after the comment. If there
                           is no link, then throw an error.
  "paragraph"              Ignore the whole paragraph after the comment.
  "file"                   This mode can only be used at the top of markdown or
                           right after comments at the top.
```

## Related issue(s)
INT-135
<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #1 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](/README.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](docs/code-style.md).
