### PR TITLE
Add trailing whitespace check to CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: MPL-2.0
 
 steps:
+  - command: nix-build ci.nix -A trailing-whitespace-check
+    label: Check trailing whitespaces
   - command: nix-build ci.nix -A xrefcheck-lib-and-tests
     label: Library and tests
   - command: nix-build ci.nix -A xrefcheck-static

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,32 +3,32 @@
 # SPDX-License-Identifier: MPL-2.0
 
 steps:
-  - command: nix-build xrefcheck.nix
+  - command: nix-build ci.nix -A xrefcheck-lib-and-tests
     label: Library and tests
-  - command: nix-build
+  - command: nix-build ci.nix -A xrefcheck-static
     label: Executable
     artifact_paths:
       - "result/bin/xrefcheck"
-  - command: nix-build --argstr platform windows
+  - command: nix-build ci.nix -A xrefcheck-windows
     label: Windows executable
     artifact_paths:
       - "result/bin/*"
-  - command: nix run -f. -c xrefcheck --ignored tests/markdowns
+  - command: nix run -f ci.nix xrefcheck-static -c xrefcheck --ignored tests/markdowns
     label: Xrefcheck itself
-  - command: nix run -f $(nix eval --raw '((import ./nix/sources.nix).nixpkgs)') reuse -c reuse lint
+  - command: nix run -f ci.nix pkgs.reuse -c reuse lint
     label: REUSE lint
   - command:
-      - NIX_PATH=nixpkgs=$(nix eval --raw '(import ./nix/sources.nix).nixpkgs') nix-shell -p curl git gitAndTools.hub --run "curl https://raw.githubusercontent.com/serokell/scratch/release-binary/scripts/release-binary.sh | bash"
+      - nix run -f ci.nix pkgs.gitAndTools.hub -c bash -c "curl https://raw.githubusercontent.com/serokell/scratch/release-binary/scripts/release-binary.sh | bash"
     label: Create a pre-release
     branches: master
   - command:
       - nix-build docker
-      - NIX_PATH=nixpkgs=$(nix eval --raw '(import ./nix/sources.nix).nixpkgs') nix run nixpkgs.skopeo -c skopeo --insecure-policy copy --dest-creds "serokell:${DOCKERHUB_PASSWORD}" "docker-archive:$(readlink result)" "docker://docker.io/serokell/xrefcheck:latest"
+      - nix run -f ci.nix pkgs.skopeo -c skopeo --insecure-policy copy --dest-creds "serokell:${DOCKERHUB_PASSWORD}" "docker-archive:$(readlink result)" "docker://docker.io/serokell/xrefcheck:latest"
     label: Push to dockerhub
     branches: master
   - command:
       - nix-build docker
-      - NIX_PATH=nixpkgs=$(nix eval --raw '(import ./nix/sources.nix).nixpkgs') nix run nixpkgs.skopeo -c skopeo --insecure-policy copy --dest-creds "serokell:${DOCKERHUB_PASSWORD}" "docker-archive:$(readlink result)" "docker://docker.io/serokell/xrefcheck:${BUILDKITE_BRANCH}"
+      - nix run -f ci.nix pkgs.skopeo -c skopeo --insecure-policy copy --dest-creds "serokell:${DOCKERHUB_PASSWORD}" "docker-archive:$(readlink result)" "docker://docker.io/serokell/xrefcheck:${BUILDKITE_BRANCH}"
     label: Push release to dockerhub
     if: |
       build.branch =~ /^v[0-9]+.*/

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ xrefcheck --help
 
 1. Add the regular expression that matches the ignoring link to the optional `ignoreRefs` parameter of your config file.
 
-    For example: 
+    For example:
     ```yaml
     ignoreRefs:
       - https://bad.reference.(org|com)(/?)

--- a/ci.nix
+++ b/ci.nix
@@ -4,9 +4,26 @@
 
 rec {
   sources = import ./nix/sources.nix;
-  pkgs = import sources.nixpkgs {};
+  haskell-nix = import sources."haskell.nix" {
+    sourcesOverride = { hackage = sources."hackage.nix"; stackage = sources."stackage.nix"; };
+  };
+  serokell-nix = import sources."serokell.nix";
+  pkgs = import sources.nixpkgs (
+    haskell-nix.nixpkgsArgs // {
+      overlays =
+        haskell-nix.nixpkgsArgs.overlays
+        ++ [ serokell-nix.overlay ]; # contains trailing whitespace check
+    }
+  );
+
+  project-src = pkgs.haskell-nix.haskellLib.cleanGit {
+    name = "xrefcheck";
+    src = ./.;
+  };
 
   xrefcheck-lib-and-tests = (import ./xrefcheck.nix { linux = true; });
   xrefcheck-static = (import ./xrefcheck.nix { linux-static = true; }).components.exes.xrefcheck;
   xrefcheck-windows = (import ./xrefcheck.nix { windows = true; }).components.exes.xrefcheck;
+
+  trailing-whitespace-check = pkgs.build.checkTrailingWhitespace project-src;
 }

--- a/ci.nix
+++ b/ci.nix
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2021 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+rec {
+  sources = import ./nix/sources.nix;
+  pkgs = import sources.nixpkgs {};
+
+  xrefcheck-lib-and-tests = (import ./xrefcheck.nix { linux = true; });
+  xrefcheck-static = (import ./xrefcheck.nix { linux-static = true; }).components.exes.xrefcheck;
+  xrefcheck-windows = (import ./xrefcheck.nix { windows = true; }).components.exes.xrefcheck;
+}

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -35,6 +35,18 @@
         "url": "https://github.com/serokell/nixpkgs/archive/cc2f27a5b70d89cbb987027d86c477befadfd08f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
+    "serokell.nix": {
+        "branch": "master",
+        "description": "Serokell Nix infrastructure library",
+        "homepage": null,
+        "owner": "serokell",
+        "repo": "serokell.nix",
+        "rev": "652105c5fc5564f5d8e682d61bdc0d51bbc1f939",
+        "sha256": "19zkjhyjbksf2fw32h7m3x0v8nvgdy2qkjkxg2qzzb25as245vmj",
+        "type": "tarball",
+        "url": "https://github.com/serokell/serokell.nix/archive/652105c5fc5564f5d8e682d61bdc0d51bbc1f939.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "stackage.nix": {
         "branch": "master",
         "description": "Automatically generated Nix expressions of Stackage snapshots",

--- a/src-files/def-config.yaml
+++ b/src-files/def-config.yaml
@@ -53,6 +53,6 @@ verification:
 
   # POSIX extended regular expressions that match external references
   # that have to be ignored (not verified).
-  # It is an optional parameter, so it can be omitted. 
+  # It is an optional parameter, so it can be omitted.
   ignoreRefs:
     []

--- a/src/Xrefcheck/CLI.hs
+++ b/src/Xrefcheck/CLI.hs
@@ -174,7 +174,7 @@ ignoreModesMsg = text $ header <> body
             , ("  \"file\"",      L.words $ "This mode can only be used at the top of markdown \
                                             \or right after comments at the top.")
             ]
-            
+
         modeIndent = length ("\"paragraph\"" :: String) + 2
         descrIndent = 27 - modeIndent
 

--- a/src/Xrefcheck/Scanners/Markdown.hs
+++ b/src/Xrefcheck/Scanners/Markdown.hs
@@ -85,7 +85,7 @@ nodeExtractInfo (Node _ _ docNodes) =
                 case ty of
                     PARAGRAPH -> loop nodes Nothing
                     _         -> returnError toIgnore (prettyType ty) pos
-            | otherwise = 
+            | otherwise =
                 case ty of
                     HTML_BLOCK _ -> processHtmlNode node pos nodes toIgnore
                     HEADING lvl -> do
@@ -127,7 +127,7 @@ nodeExtractInfo (Node _ _ docNodes) =
                 getHTMLText _ = Nothing
 
         getXrefcheckContent :: Node -> Maybe Text
-        getXrefcheckContent node = 
+        getXrefcheckContent node =
             let notStripped = T.stripPrefix "xrefcheck:" . T.strip =<<
                                  getCommentContent node
             in T.strip <$> notStripped
@@ -178,11 +178,11 @@ nodeExtractInfo (Node _ _ docNodes) =
         afterIgnoredLink _ = Nothing
 
         prettyPos :: Maybe PosInfo -> Text
-        prettyPos pos = 
+        prettyPos pos =
             let posToText :: Position -> Text
                 posToText (Position mPos) = fromMaybe "" mPos
             in "(" <> (posToText $ toPosition pos) <> ")"
-        
+
         prettyType :: NodeType -> Text
         prettyType ty =
             let mType = safeHead $ words $ show ty
@@ -211,7 +211,7 @@ nodeExtractInfo (Node _ _ docNodes) =
             , "perhaps you meant \
                \<\"ignore link\"|\"ignore paragraph\"|\"ignore file\"> "
             ]
-        
+
         returnError :: Maybe IgnoreMode -> Text -> Maybe PosInfo -> StateT FileInfo (Except Text) ()
         returnError mode txt pos =
             let errMsg = case mode of

--- a/src/Xrefcheck/Verify.hs
+++ b/src/Xrefcheck/Verify.hs
@@ -270,7 +270,7 @@ checkExternalResource VerifyConfig{..} link
             Right res -> case res of
                 Just (before, match, after, _) -> null before && null after && not (null match)
                 Nothing -> False
-            Left _ -> False 
+            Left _ -> False
 
     makeRequest :: _ => method -> RatioNat -> IO (Either VerifyError ())
     makeRequest method timeoutFrac = runExceptT $ do

--- a/tests/Test/Xrefcheck/IgnoreAnnotationsSpec.hs
+++ b/tests/Test/Xrefcheck/IgnoreAnnotationsSpec.hs
@@ -37,7 +37,7 @@ spec = do
             , "tests/markdowns/with-annotations/unexpected_ignore_file.md"
             , "tests/markdowns/with-annotations/unrecognised_option.md"
             ]
-        
+
         parse :: FilePath -> IO (Either Text FileInfo)
         parse path = parseFileInfo . decodeUtf8 <$> BSL.readFile path
 
@@ -45,9 +45,9 @@ spec = do
         getFI path =
             let errOrFI = parse path
             in either error id <$> errOrFI
-        
+
         getRefs :: FileInfo -> [Text]
-        getRefs fi = map rName $ fi ^. fiReferences 
+        getRefs fi = map rName $ fi ^. fiReferences
 
         isIncorrectMD :: FilePath -> IO Bool
         isIncorrectMD path = do

--- a/tests/Test/Xrefcheck/IgnoreRegexSpec.hs
+++ b/tests/Test/Xrefcheck/IgnoreRegexSpec.hs
@@ -69,7 +69,7 @@ spec = do
 
     where
         pickBrokenLinks :: VerifyResult (WithReferenceLoc VerifyError) -> [Text]
-        pickBrokenLinks verifyRes = 
+        pickBrokenLinks verifyRes =
             case verifyErrors verifyRes of
                 Just neWithRefLoc -> map (rLink . wrlReference) $ toList neWithRefLoc
                 Nothing -> []

--- a/xrefcheck.nix
+++ b/xrefcheck.nix
@@ -4,11 +4,8 @@
 
 { linux ? false, linux-static ? false, windows ? false }:
 let
-  sources = import ./nix/sources.nix;
-  haskell-nix = import sources."haskell.nix" {
-    sourcesOverride = { hackage = sources."hackage.nix"; stackage = sources."stackage.nix"; };
-  };
-  nixpkgs = import sources.nixpkgs haskell-nix.nixpkgsArgs;
+  nixpkgs = (import ./ci.nix).pkgs;
+  src = (import ./ci.nix).project-src;
   pkgs = if linux-static then nixpkgs.pkgsCross.musl64 else if windows then nixpkgs.pkgsCross.mingwW64 else nixpkgs;
   project = pkgs.haskell-nix.stackProject {
     src = pkgs.haskell-nix.haskellLib.cleanGit { src = ./.; };


### PR DESCRIPTION
## Description

Adds trailing whitespace check from serokell.nix to the pipeline. I've put it into ci.nix file and moved some other nix expressions used in buidlkite there, and I had to refactor nix a bit to use `cleanGit` from `haskell.nix` for the check
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

https://issues.serokell.io/issue/OPS-1178
<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #1 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](/README.md)
    - Haddock

- Public contracts
  - [ ] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [ ] I added an entry to the [changelog](/CHANGES.md) if my changes are visible to the users
        and
  - [ ] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [ ] My code complies with the [style guide](docs/code-style.md).
