### PR TITLE
Fix docker image upload

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -25,12 +25,12 @@ steps:
     branches: master
   - command:
       - nix-build docker
-      - nix run -f ci.nix pkgs.skopeo -c skopeo --insecure-policy copy --dest-creds "serokell:${DOCKERHUB_PASSWORD}" "docker-archive:$(readlink result)" "docker://docker.io/serokell/xrefcheck:latest"
+      - nix run -f ci.nix pkgs.skopeo -c ./scripts/upload-docker-image.sh "docker-archive:$(readlink result)" "docker://docker.io/serokell/xrefcheck:latest"
     label: Push to dockerhub
     branches: master
   - command:
       - nix-build docker
-      - nix run -f ci.nix pkgs.skopeo -c skopeo --insecure-policy copy --dest-creds "serokell:${DOCKERHUB_PASSWORD}" "docker-archive:$(readlink result)" "docker://docker.io/serokell/xrefcheck:${BUILDKITE_BRANCH}"
+      - nix run -f ci.nix pkgs.skopeo -c ./scripts/upload-docker-image.sh "docker-archive:$(readlink result)" "docker://docker.io/serokell/xrefcheck:${BUILDKITE_BRANCH}"
     label: Push release to dockerhub
     if: |
       build.branch =~ /^v[0-9]+.*/

--- a/scripts/upload-docker-image.sh
+++ b/scripts/upload-docker-image.sh
@@ -1,3 +1,7 @@
 #!/usr/bin/env bash
 
+# SPDX-FileCopyrightText: 2019 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: MPL-2.0
+
 skopeo --insecure-policy copy --dest-creds "serokell:${DOCKERHUB_PASSWORD}" "$1" "$2"

--- a/scripts/upload-docker-image.sh
+++ b/scripts/upload-docker-image.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+skopeo --insecure-policy copy --dest-creds "serokell:${DOCKERHUB_PASSWORD}" "$1" "$2"

--- a/scripts/upload-docker-image.sh
+++ b/scripts/upload-docker-image.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: 2019 Serokell <https://serokell.io>
+# SPDX-FileCopyrightText: 2021 Serokell <https://serokell.io>
 #
 # SPDX-License-Identifier: MPL-2.0
 


### PR DESCRIPTION
## Description

The previous way of uploading images to dockerhub exposed our password.
Prevent this from happening by using a separate script instead of calling
skopeo directly.