### PR TITLE
[#62] Add anchor recognition in headers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,11 @@
 Unreleased
 ==========
 
+0.2.1
+==========
+* [#68](https://github.com/serokell/xrefcheck/pull/68)
+  + Recognise manual HTML-anchors inside headers.
+
 0.2
 ==========
 * [#57](https://github.com/serokell/xrefcheck/pull/57)

--- a/package.yaml
+++ b/package.yaml
@@ -5,7 +5,7 @@
 spec-version: 0.31.0
 
 name:                xrefcheck
-version:             0.2
+version:             0.2.1
 github:              serokell/xrefcheck
 license:             MPL-2.0
 license-file:        LICENSE

--- a/src/Xrefcheck/Scanners/Markdown.hs
+++ b/src/Xrefcheck/Scanners/Markdown.hs
@@ -108,7 +108,7 @@ nodeExtractInfo config (Node _ _ docNodes) =
                           nodeExtractText node
               let aPos = toPosition pos
               fiAnchors %= (Anchor{..} :)
-              loop nodes toIgnore
+              loop (subs ++ nodes) toIgnore
             HTML_INLINE htmlText -> do
               let mName = T.stripSuffix "\">" =<< T.stripPrefix "<a name=\"" htmlText
               whenJust mName $ \aName -> do

--- a/tests/Test/Xrefcheck/AnchorsInHeadersSpec.hs
+++ b/tests/Test/Xrefcheck/AnchorsInHeadersSpec.hs
@@ -16,7 +16,7 @@ spec = do
     describe "Anchors in headers" $ do
         it "Check if anchors in headers are recognized" $ do
             fi <- getFI "tests/markdowns/without-annotations/anchors_in_headers.md"
-            getAnchors fi `shouldBe` ["-some-stuff", "stuff-section"]
+            getAnchors fi `shouldBe` ["some-stuff", "stuff-section"]
     where
         parse :: FilePath -> IO (Either Text FileInfo)
         parse path =

--- a/tests/Test/Xrefcheck/AnchorsInHeadersSpec.hs
+++ b/tests/Test/Xrefcheck/AnchorsInHeadersSpec.hs
@@ -13,8 +13,8 @@ import Xrefcheck.Scanners.Markdown
 
 spec :: Spec
 spec = do
-    describe "\"ignore link\" mode" $ do
-        it "Check \"ignore link\" performance" $ do
+    describe "Anchors in headers" $ do
+        it "Check if anchors in headers are recognized" $ do
             fi <- getFI "tests/markdowns/without-annotations/anchors_in_headers.md"
             getAnchors fi `shouldBe` ["-some-stuff", "stuff-section"]
     where

--- a/tests/Test/Xrefcheck/AnchorsInHeadersSpec.hs
+++ b/tests/Test/Xrefcheck/AnchorsInHeadersSpec.hs
@@ -1,0 +1,31 @@
+{- SPDX-FileCopyrightText: 2019 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -}
+
+module Test.Xrefcheck.AnchorsInHeadersSpec where
+
+import qualified Data.ByteString.Lazy as BSL
+import Test.Hspec (Spec, describe, it, shouldBe)
+
+import Xrefcheck.Core
+import Xrefcheck.Scanners.Markdown
+
+spec :: Spec
+spec = do
+    describe "\"ignore link\" mode" $ do
+        it "Check \"ignore link\" performance" $ do
+            fi <- getFI "tests/markdowns/without-annotations/anchors_in_headers.md"
+            getAnchors fi `shouldBe` ["-some-stuff", "stuff-section"]
+    where
+        parse :: FilePath -> IO (Either Text FileInfo)
+        parse path =
+            parseFileInfo defGithubMdConfig . decodeUtf8 <$> BSL.readFile path
+
+        getFI :: FilePath -> IO FileInfo
+        getFI path =
+            let errOrFI = parse path
+            in either error id <$> errOrFI
+
+        getAnchors :: FileInfo -> [Text]
+        getAnchors fi = map aName $ fi ^. fiAnchors

--- a/tests/Test/Xrefcheck/AnchorsSpec.hs
+++ b/tests/Test/Xrefcheck/AnchorsSpec.hs
@@ -22,6 +22,7 @@ checkHeaderConversions fl suites =
       fi <- getFI fl "tests/markdowns/without-annotations/non_stripped_spaces.md"
       getAnchors fi `shouldBe` [ case fl of GitHub -> "header--with-leading-spaces"
                                             GitLab -> "header-with-leading-spaces"
+                               , "edge-case"
                                ]
   where
     getAnchors :: FileInfo -> [Text]

--- a/tests/markdowns/without-annotations/anchors_in_headers.md
+++ b/tests/markdowns/without-annotations/anchors_in_headers.md
@@ -1,0 +1,9 @@
+<!--
+ - SPDX-FileCopyrightText: 2018-2019 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -->
+
+## <a name="stuff-section"></a> Some stuff
+
+[My link](#stuff-section)


### PR DESCRIPTION
## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

Problem:
Currently `xrefcheck` ignores HTML-anchors in headers.

Solution:
When traversing node tree, go into `HEADER` subnodes as well.

## Related issue(s)

Resolves #62 

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #1 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](/README.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](docs/code-style.md).
