### PR TITLE
Refactor data collection.

### DIFF
--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -16,6 +16,7 @@ steps:
       list_padding: 2
       separate_lists: true
       space_surround: false
+      post_qualify: true
   - trailing_whitespace: {}
 columns: 100
 newline: native
@@ -38,6 +39,7 @@ language_extensions:
   - FunctionalDependencies
   - GADTs
   - GeneralizedNewtypeDeriving
+  - ImportQualifiedPost
   - LambdaCase
   - MultiParamTypeClasses
   - MultiWayIf

--- a/exec/Main.hs
+++ b/exec/Main.hs
@@ -7,7 +7,7 @@ module Main where
 
 import Universum
 
-import qualified Data.ByteString as BS
+import Data.ByteString qualified as BS
 import Main.Utf8 (withUtf8)
 
 import Xrefcheck.CLI (Command (..), getCommand)

--- a/exec/Main.hs
+++ b/exec/Main.hs
@@ -5,6 +5,8 @@
 
 module Main where
 
+import Universum
+
 import qualified Data.ByteString as BS
 import Main.Utf8 (withUtf8)
 

--- a/links-tests/Main.hs
+++ b/links-tests/Main.hs
@@ -6,6 +6,8 @@ module Main
   ( main
   ) where
 
+import Universum
+
 import Test.Tasty (defaultIngredients, defaultMainWithIngredients, includingOptions)
 import Test.Tasty.Ingredients (Ingredient)
 

--- a/links-tests/Test/Xrefcheck/FtpLinks.hs
+++ b/links-tests/Test/Xrefcheck/FtpLinks.hs
@@ -8,6 +8,8 @@ module Test.Xrefcheck.FtpLinks
   , test_FtpLinks
   ) where
 
+import Universum
+
 import Data.Tagged (Tagged, untag)
 import Options.Applicative (help, long, strOption)
 import Test.Tasty (TestTree, askOption, testGroup)

--- a/package.yaml
+++ b/package.yaml
@@ -35,6 +35,7 @@ default-extensions:
   - MultiParamTypeClasses
   - MultiWayIf
   - NamedFieldPuns
+  - NoImplicitPrelude
   - OverloadedStrings
   - RankNTypes
   - RecordWildCards
@@ -57,9 +58,7 @@ dependencies:
   - aeson
   - aeson-casing
   - async
-  - name: base
-    mixin: [hiding (Prelude)]
-    version: "< 4.15"
+  - base
   - bytestring
   - containers
   - cmark-gfm
@@ -91,8 +90,7 @@ dependencies:
   - th-lift-instances
   - th-utilities
   - transformers
-  - name: universum
-    mixin: [(Universum as Prelude), (Universum.Unsafe as Unsafe)]
+  - universum
   - yaml
   - with-utf8
 

--- a/package.yaml
+++ b/package.yaml
@@ -27,6 +27,7 @@ default-extensions:
   - DefaultSignatures
   - DeriveDataTypeable
   - DeriveGeneric
+  - DerivingStrategies
   - FlexibleContexts
   - FlexibleInstances
   - FunctionalDependencies
@@ -67,6 +68,7 @@ dependencies:
   - deepseq
   - directory-tree
   - directory
+  - dlist
   - filepath
   - file-embed
   - fmt

--- a/package.yaml
+++ b/package.yaml
@@ -31,6 +31,7 @@ default-extensions:
   - FlexibleInstances
   - FunctionalDependencies
   - GeneralizedNewtypeDeriving
+  - ImportQualifiedPost
   - LambdaCase
   - MultiParamTypeClasses
   - MultiWayIf

--- a/src/Xrefcheck/CLI.hs
+++ b/src/Xrefcheck/CLI.hs
@@ -21,9 +21,9 @@ module Xrefcheck.CLI
 
 import Universum
 
-import qualified Data.Char as C
-import qualified Data.List as L
-import qualified Data.Text as T
+import Data.Char qualified as C
+import Data.List qualified as L
+import Data.Text qualified as T
 import Data.Version (showVersion)
 import Options.Applicative
   (Parser, ReadM, command, eitherReader, execParser, flag, flag', footerDoc, fullDesc, help, helper,

--- a/src/Xrefcheck/CLI.hs
+++ b/src/Xrefcheck/CLI.hs
@@ -19,6 +19,8 @@ module Xrefcheck.CLI
   , getCommand
   ) where
 
+import Universum
+
 import qualified Data.Char as C
 import qualified Data.List as L
 import qualified Data.Text as T

--- a/src/Xrefcheck/Command.hs
+++ b/src/Xrefcheck/Command.hs
@@ -7,6 +7,8 @@ module Xrefcheck.Command
   ( defaultAction
   ) where
 
+import Universum
+
 import Data.Yaml (decodeFileEither, prettyPrintParseException)
 import Fmt (blockListF', build, fmt, fmtLn, indentF)
 import System.Directory (doesFileExist)

--- a/src/Xrefcheck/Config.hs
+++ b/src/Xrefcheck/Config.hs
@@ -14,14 +14,14 @@ import Universum
 import Control.Exception (assert)
 import Control.Lens (makeLensesWith)
 import Data.Aeson.TH (deriveFromJSON)
-import qualified Data.ByteString as BS
-import qualified Data.Map as Map
+import Data.ByteString qualified as BS
+import Data.Map qualified as Map
 import Data.Yaml (FromJSON (..), decodeEither', prettyPrintParseException, withText)
 import Instances.TH.Lift ()
 import Text.Regex.TDFA (CompOption (..), ExecOption (..), Regex)
-import qualified Text.Regex.TDFA as R
+import Text.Regex.TDFA qualified as R
 import Text.Regex.TDFA.ByteString ()
-import qualified Text.Regex.TDFA.Text as R
+import Text.Regex.TDFA.Text qualified as R
 
 -- FIXME: Use </> from System.FilePath
 -- </> from Posix is used only because we cross-compile to Windows and \ doesn't work on Linux

--- a/src/Xrefcheck/Config.hs
+++ b/src/Xrefcheck/Config.hs
@@ -7,7 +7,9 @@
 
 module Xrefcheck.Config where
 
-import qualified Unsafe
+import qualified Universum.Unsafe as Unsafe
+
+import Universum
 
 import Control.Exception (assert)
 import Control.Lens (makeLensesWith)

--- a/src/Xrefcheck/Core.hs
+++ b/src/Xrefcheck/Core.hs
@@ -27,7 +27,7 @@ import Text.Numeral.Roman (toRoman)
 import Xrefcheck.Progress
 import Xrefcheck.Util
 import Data.DList (DList)
-import qualified Data.DList as DList
+import Data.DList qualified as DList
 
 -----------------------------------------------------------
 -- Types
@@ -103,7 +103,8 @@ data FileInfoDiff = FileInfoDiff
 makeLenses ''FileInfoDiff
 
 diffToFileInfo :: FileInfoDiff -> FileInfo
-diffToFileInfo (FileInfoDiff refs anchors) = FileInfo (DList.toList refs) (DList.toList anchors)
+diffToFileInfo (FileInfoDiff refs anchors) =
+    FileInfo (DList.toList refs) (DList.toList anchors)
 
 instance Semigroup FileInfoDiff where
   FileInfoDiff a b <> FileInfoDiff c d = FileInfoDiff (a <> c) (b <> d)
@@ -123,11 +124,6 @@ instance Default FileInfo where
 
 newtype RepoInfo = RepoInfo (Map FilePath FileInfo)
   deriving (Show)
-
-finaliseFileInfo :: FileInfo -> FileInfo
-finaliseFileInfo = execState $ do
-  fiReferences %= reverse
-  fiAnchors %= reverse
 
 -----------------------------------------------------------
 -- Instances
@@ -296,9 +292,7 @@ stripAnchorDupNo t = do
 -- | Strip './' prefix from local references.
 canonizeLocalRef :: Text -> Text
 canonizeLocalRef ref =
-  case T.stripPrefix localPrefix ref of
-    Nothing -> ref
-    Just r  -> canonizeLocalRef r
+  maybe ref canonizeLocalRef (T.stripPrefix localPrefix ref)
   where
     localPrefix = toText ['.', pathSeparator]
 

--- a/src/Xrefcheck/Core.hs
+++ b/src/Xrefcheck/Core.hs
@@ -14,11 +14,11 @@ import Universum
 import Control.Lens (makeLenses, (%=))
 import Data.Aeson (FromJSON (..), withText)
 import Data.Char (isAlphaNum)
-import qualified Data.Char as C
+import Data.Char qualified as C
 import Data.Default (Default (..))
-import qualified Data.List as L
-import qualified Data.Map as M
-import qualified Data.Text as T
+import Data.List qualified as L
+import Data.Map qualified as M
+import Data.Text qualified as T
 import Fmt (Buildable (..), blockListF, blockListF', nameF, (+|), (|+))
 import System.Console.Pretty (Color (..), Style (..), color, style)
 import System.FilePath (isPathSeparator, pathSeparator)

--- a/src/Xrefcheck/Core.hs
+++ b/src/Xrefcheck/Core.hs
@@ -26,6 +26,8 @@ import Text.Numeral.Roman (toRoman)
 
 import Xrefcheck.Progress
 import Xrefcheck.Util
+import Data.DList (DList)
+import qualified Data.DList as DList
 
 -----------------------------------------------------------
 -- Types
@@ -94,6 +96,21 @@ data Anchor = Anchor
   , aPos  :: Position
   } deriving (Show, Eq, Generic)
 
+data FileInfoDiff = FileInfoDiff
+  { _fidReferences :: DList Reference
+  , _fidAnchors    :: DList Anchor
+  }
+makeLenses ''FileInfoDiff
+
+diffToFileInfo :: FileInfoDiff -> FileInfo
+diffToFileInfo (FileInfoDiff refs anchors) = FileInfo (DList.toList refs) (DList.toList anchors)
+
+instance Semigroup FileInfoDiff where
+  FileInfoDiff a b <> FileInfoDiff c d = FileInfoDiff (a <> c) (b <> d)
+
+instance Monoid FileInfoDiff where
+  mempty = FileInfoDiff mempty mempty
+
 -- | All information regarding a single file we care about.
 data FileInfo = FileInfo
   { _fiReferences :: [Reference]
@@ -102,7 +119,7 @@ data FileInfo = FileInfo
 makeLenses ''FileInfo
 
 instance Default FileInfo where
-  def = FileInfo [] []
+  def = diffToFileInfo mempty
 
 newtype RepoInfo = RepoInfo (Map FilePath FileInfo)
   deriving (Show)

--- a/src/Xrefcheck/Core.hs
+++ b/src/Xrefcheck/Core.hs
@@ -9,6 +9,8 @@
 
 module Xrefcheck.Core where
 
+import Universum
+
 import Control.Lens (makeLenses, (%=))
 import Data.Aeson (FromJSON (..), withText)
 import Data.Char (isAlphaNum)

--- a/src/Xrefcheck/Core.hs
+++ b/src/Xrefcheck/Core.hs
@@ -11,7 +11,7 @@ module Xrefcheck.Core where
 
 import Universum
 
-import Control.Lens (makeLenses, (%=))
+import Control.Lens (makeLenses)
 import Data.Aeson (FromJSON (..), withText)
 import Data.Char (isAlphaNum)
 import Data.Char qualified as C

--- a/src/Xrefcheck/Orphans.hs
+++ b/src/Xrefcheck/Orphans.hs
@@ -9,6 +9,8 @@
 
 module Xrefcheck.Orphans () where
 
+import Universum
+
 import qualified Data.ByteString.Char8 as C
 
 import Fmt (Buildable (..), unlinesF, (+|), (|+))

--- a/src/Xrefcheck/Progress.hs
+++ b/src/Xrefcheck/Progress.hs
@@ -18,6 +18,8 @@ module Xrefcheck.Progress
   , putTextRewrite
   ) where
 
+import Universum
+
 import Data.Ratio ((%))
 import System.Console.Pretty (Color (..), Style (..), color, style)
 import Time (ms, threadDelay)

--- a/src/Xrefcheck/Scan.hs
+++ b/src/Xrefcheck/Scan.hs
@@ -19,10 +19,10 @@ module Xrefcheck.Scan
 import Universum
 
 import Data.Aeson.TH (deriveFromJSON)
-import qualified Data.Foldable as F
-import qualified Data.Map as M
+import Data.Foldable qualified as F
+import Data.Map qualified as M
 import GHC.Err (errorWithoutStackTrace)
-import qualified System.Directory.Tree as Tree
+import System.Directory.Tree qualified as Tree
 import System.FilePath (dropTrailingPathSeparator, takeDirectory, takeExtension, (</>))
 
 import Xrefcheck.Core

--- a/src/Xrefcheck/Scan.hs
+++ b/src/Xrefcheck/Scan.hs
@@ -16,6 +16,8 @@ module Xrefcheck.Scan
   , specificFormatsSupport
   ) where
 
+import Universum
+
 import Data.Aeson.TH (deriveFromJSON)
 import qualified Data.Foldable as F
 import qualified Data.Map as M

--- a/src/Xrefcheck/Scanners/Markdown.hs
+++ b/src/Xrefcheck/Scanners/Markdown.hs
@@ -15,6 +15,8 @@ module Xrefcheck.Scanners.Markdown
   , parseFileInfo
   ) where
 
+import Universum
+
 import CMarkGFM (Node (..), NodeType (..), PosInfo (..), commonmarkToNode)
 import Control.Lens ((%=))
 import Control.Monad.Trans.Except (Except, runExcept, throwE)

--- a/src/Xrefcheck/Scanners/Markdown.hs
+++ b/src/Xrefcheck/Scanners/Markdown.hs
@@ -21,11 +21,11 @@ import CMarkGFM (Node (..), NodeType (..), PosInfo (..), commonmarkToNode)
 import Control.Lens ((%=))
 import Control.Monad.Trans.Except (Except, runExcept, throwE)
 import Data.Aeson.TH (deriveFromJSON)
-import qualified Data.ByteString.Lazy as BSL
+import Data.ByteString.Lazy qualified as BSL
 import Data.Char (isSpace)
 import Data.Default (Default (..))
-import qualified Data.Text as T
-import qualified Data.Text.Lazy as LT
+import Data.Text qualified as T
+import Data.Text.Lazy qualified as LT
 import Fmt (Buildable (..), blockListF, nameF, (+|), (|+))
 
 import Xrefcheck.Core

--- a/src/Xrefcheck/Scanners/Markdown.hs
+++ b/src/Xrefcheck/Scanners/Markdown.hs
@@ -18,12 +18,9 @@ module Xrefcheck.Scanners.Markdown
 import Universum
 
 import CMarkGFM (Node (..), NodeType (..), PosInfo (..), commonmarkToNode)
-import Control.Lens ((%=))
-import Control.Monad.Trans.Except (Except, runExcept, throwE)
+import Control.Monad.Except (MonadError, throwError)
 import Data.Aeson.TH (deriveFromJSON)
 import Data.ByteString.Lazy qualified as BSL
-import Data.Char (isSpace)
-import Data.Default (Default (..))
 import Data.Text qualified as T
 import Data.Text.Lazy qualified as LT
 import Fmt (Buildable (..), blockListF, nameF, (+|), (|+))
@@ -31,6 +28,7 @@ import Fmt (Buildable (..), blockListF, nameF, (+|), (|+))
 import Xrefcheck.Core
 import Xrefcheck.Scan
 import Xrefcheck.Util
+import Data.Default (def)
 
 data MarkdownConfig = MarkdownConfig
   { mcFlavor :: Flavor
@@ -57,9 +55,8 @@ toPosition = Position . \case
         startLine |+ ":" +| startColumn |+ " - " +|
         endLine |+ ":" +| endColumn |+ ""
 
-nodeFlatten :: Node -> [NodeType]
-nodeFlatten (Node _pos ty subs) = ty : concatMap nodeFlatten subs
-
+{- | Extract text from the topmost node.
+-}
 nodeExtractText :: Node -> Text
 nodeExtractText = T.strip . mconcat . map extractText . nodeFlatten
   where
@@ -68,142 +65,152 @@ nodeExtractText = T.strip . mconcat . map extractText . nodeFlatten
       CODE t -> t
       _ -> ""
 
+    nodeFlatten :: Node -> [NodeType]
+    nodeFlatten (Node _pos ty subs) = ty : concatMap nodeFlatten subs
+
 data IgnoreMode
   = Link
   | Paragraph
   | File
+  | None
   deriving Eq
 
-nodeExtractInfo :: MarkdownConfig -> Node -> Except Text FileInfo
-nodeExtractInfo config (Node _ _ docNodes) =
-  if checkIgnoreFile docNodes
-  then return def
-  else finaliseFileInfo <$> extractionResult
+{- | A fold over a `Node`.
+-}
+cataNode :: (Maybe PosInfo -> NodeType -> [c] -> c) -> Node -> c
+cataNode f (Node pos ty subs) = f pos ty (cataNode f <$> subs)
+
+{- | Remove nodes with accordance with global `MarkdownConfig` and local
+     overrides.
+-}
+removeIgnored :: Node -> Either Text Node
+removeIgnored = runIdentity . runExceptT . flip evalStateT None . cataNode remove
   where
-    extractionResult :: Except Text FileInfo
-    extractionResult = execStateT (loop docNodes Nothing) def
+    remove
+      :: (MonadError Text m, MonadState IgnoreMode m)
+      => Maybe PosInfo
+      -> NodeType
+      -> [m Node]
+      -> m Node
+    remove pos ty subs = do
+      mode <- get
+      case (mode, ty) of
+        (Paragraph, PARAGRAPH) -> put None $> defNode
+        (Paragraph, x)         -> throwError (makeError mode (prettyType x) pos)
+        (File, _)              -> throwError (makeError mode "" pos)
+        (Link, LINK {})        -> put None $> defNode
+        (Link, _)              -> Node pos ty <$> sequence subs
+        (None, _) -> do
+          case getIgnoreMode (Node pos ty []) of
+            Just mode' -> put mode' $> defNode
+            Nothing    -> Node pos ty <$> sequence subs
 
-    loop :: [Node] -> Maybe IgnoreMode -> StateT FileInfo (Except Text) ()
-    loop [] _ = pass
-    loop (node@(Node pos ty subs) : nodes) toIgnore
-      | toIgnore == Just File = returnError toIgnore "" pos
-      | toIgnore == Just Link = do
-          let (Node startPos _ _) = maybe defNode id $ safeHead subs
-          let mNext = case ty of
-                PARAGRAPH -> afterIgnoredLink subs <> Just nodes
-                TEXT txt | null (dropWhile isSpace $ T.unpack txt) -> afterIgnoredLink nodes
-                SOFTBREAK -> afterIgnoredLink nodes
-                _ -> afterIgnoredLink (node : nodes)
-          case mNext of
-            Just next -> loop next Nothing
-            Nothing   -> returnError toIgnore "" startPos
-      | toIgnore == Just Paragraph =
-          case ty of
-            PARAGRAPH -> loop nodes Nothing
-            _         -> returnError toIgnore (prettyType ty) pos
-      | otherwise =
-          case ty of
-            HTML_BLOCK _ -> processHtmlNode node pos nodes toIgnore
-            HEADING lvl -> do
-              let aType = HeaderAnchor lvl
-              let aName = headerToAnchor (mcFlavor config) $
-                          nodeExtractText node
-              let aPos = toPosition pos
-              fiAnchors %= (Anchor{..} :)
-              loop (subs ++ nodes) toIgnore
-            HTML_INLINE htmlText -> do
-              let mName = T.stripSuffix "\">" =<< T.stripPrefix "<a name=\"" htmlText
-              whenJust mName $ \aName -> do
-                  let aType = HandAnchor
-                      aPos = toPosition pos
-                  fiAnchors %= (Anchor{..} :)
-              processHtmlNode node pos nodes toIgnore
-            LINK url _ -> do
-              let rName = nodeExtractText node
-                  rPos = toPosition pos
-                  link = if null url then rName else url
-              let (rLink, rAnchor) = case T.splitOn "#" link of
-                      [t]    -> (t, Nothing)
-                      t : ts -> (t, Just $ T.intercalate "#" ts)
-                      []     -> error "impossible"
-              fiReferences %= (Reference{..} :)
-              loop nodes toIgnore
-            _ -> loop (subs ++ nodes) toIgnore
+    prettyType :: NodeType -> Text
+    prettyType ty =
+      let mType = safeHead $ words $ show ty
+      in fromMaybe "" mType
 
-    defNode :: Node
-    defNode = Node Nothing DOCUMENT [] -- hard-coded default Node
+{- | Custom `foldMap` for source tree.
+-}
+foldNode :: (Monoid a, Monad m) => (Node -> m a) -> Node -> m a
+foldNode action node@(Node _ _ subs) = do
+  a <- action node
+  b <- foldM (fmap . (<>)) mempty (foldNode action <$> subs)
+  return (a <> b)
 
-    getCommentContent :: Node -> Maybe Text
-    getCommentContent node = do
-      txt <- getHTMLText node
-      T.stripSuffix "-->" =<< T.stripPrefix "<!--" (T.strip txt)
-      where
-        getHTMLText :: Node -> Maybe Text
-        getHTMLText (Node _ (HTML_BLOCK txt) _) = Just txt
-        getHTMLText (Node _ (HTML_INLINE txt) _) = Just txt
-        getHTMLText _ = Nothing
+{- | Extract information from source tree.
+-}
+nodeExtractInfo
+  :: ( MonadError Text m
+     , MonadState IgnoreMode m
+     , MonadReader MarkdownConfig m
+     )
+  => Node
+  -> m FileInfo
+nodeExtractInfo input@(Node _ _ nSubs) = do
+  if checkIgnoreFile nSubs
+  then return def
+  else case removeIgnored input of
+    Left err -> throwError err
+    Right relevant ->
+      diffToFileInfo <$> foldNode extractor relevant
 
-    getXrefcheckContent :: Node -> Maybe Text
-    getXrefcheckContent node =
-      let notStripped = T.stripPrefix "xrefcheck:" . T.strip =<<
-            getCommentContent node
-      in T.strip <$> notStripped
+  where
+    extractor node@(Node pos ty _) =
+      case ty of
+        HTML_BLOCK _ -> do
+          return mempty
 
-    getIgnoreMode :: Node -> Maybe IgnoreMode
-    getIgnoreMode node =
-      let mContent = getXrefcheckContent node
+        HEADING lvl -> do
+          flavor <- asks mcFlavor
+          let aType = HeaderAnchor lvl
+          let aName = headerToAnchor flavor $ nodeExtractText node
+          let aPos  = toPosition pos
+          return $ FileInfoDiff mempty $ pure $ Anchor {aType, aName, aPos}
 
-          textToMode :: [Text] -> Maybe IgnoreMode
-          textToMode ("ignore" : [x])
-            | x == "link"      = return Link
-            | x == "paragraph" = return Paragraph
-            | x == "file"      = return File
-            | otherwise        = Nothing
-          textToMode _           = Nothing
-      in textToMode . words =<< mContent
+        HTML_INLINE text -> do
+          let mName = T.stripSuffix "\">" =<< T.stripPrefix "<a name=\"" text
+          case mName of
+            Just aName -> do
+              let aType = HandAnchor
+                  aPos  = toPosition pos
+              return $ FileInfoDiff
+                mempty
+                (pure $ Anchor {aType, aName, aPos})
 
+            Nothing -> do
+              return mempty
+
+        LINK url _ -> do
+          let rName = nodeExtractText node
+              rPos = toPosition pos
+              link = if null url then rName else url
+          let (rLink, rAnchor) = case T.splitOn "#" link of
+                  [t]    -> (t, Nothing)
+                  t : ts -> (t, Just $ T.intercalate "#" ts)
+                  []     -> error "impossible"
+          return $ FileInfoDiff
+            (pure $ Reference {rName, rPos, rLink, rAnchor})
+            mempty
+
+        _ -> return mempty
+
+checkIgnoreFile :: [Node] -> Bool
+checkIgnoreFile nodes =
+  let isSimpleComment :: Node -> Bool
+      isSimpleComment node = isComment node && not (isIgnoreFile node)
+
+      mIgnoreFile = safeHead $ dropWhile isSimpleComment nodes
+  in maybe False isIgnoreFile mIgnoreFile
+  where
     isComment :: Node -> Bool
     isComment = isJust . getCommentContent
 
     isIgnoreFile :: Node -> Bool
     isIgnoreFile = (Just File ==) . getIgnoreMode
 
-    checkIgnoreFile :: [Node] -> Bool
-    checkIgnoreFile nodes =
-      let isSimpleComment :: Node -> Bool
-          isSimpleComment node = isComment node && not (isIgnoreFile node)
 
-          mIgnoreFile = safeHead $ dropWhile isSimpleComment nodes
-      in maybe False isIgnoreFile mIgnoreFile
+defNode :: Node
+defNode = Node Nothing DOCUMENT [] -- hard-coded default Node
 
-    isLink :: Node -> Bool
-    isLink (Node _ (LINK _ _) _) = True
-    isLink _ = False
-
-    isText :: Node -> Bool
-    isText (Node _ (TEXT _) _) = True
-    isText _ = False
-
-    afterIgnoredLink :: [Node] -> Maybe [Node]
-    afterIgnoredLink (fNode : nodes)
-      | isLink fNode = return nodes
-      | sNode : nodes' <- nodes =
-          if isText fNode && isLink sNode
-          then return nodes'
-          else Nothing
-      | otherwise = Nothing
-    afterIgnoredLink _ = Nothing
-
-    prettyPos :: Maybe PosInfo -> Text
-    prettyPos pos =
+makeError
+  :: IgnoreMode
+  -> Text
+  -> Maybe PosInfo
+  -> Text
+makeError mode txt pos =
+  let errMsg = case mode of
+        Link      -> linkMsg
+        Paragraph -> paragraphMsg
+        File      -> fileMsg
+        None      -> unrecognisedMsg
+  in errMsg <> posInfo
+  where
+    posInfo :: Text
+    posInfo =
       let posToText :: Position -> Text
           posToText (Position mPos) = fromMaybe "" mPos
       in "(" <> posToText (toPosition pos) <> ")"
-
-    prettyType :: NodeType -> Text
-    prettyType ty =
-      let mType = safeHead $ words $ show ty
-      in maybe "" id mType
 
     fileMsg :: Text
     fileMsg =
@@ -213,52 +220,61 @@ nodeExtractInfo config (Node _ _ docNodes) =
     linkMsg :: Text
     linkMsg = "expected a LINK after \"ignore link\" "
 
-    paragraphMsg :: Text -> Text
-    paragraphMsg txt = unwords
+    paragraphMsg :: Text
+    paragraphMsg = unwords
       [ "expected a PARAGRAPH after \
-         \\"ignore paragraph\", but found"
+          \\"ignore paragraph\", but found"
       , txt
       , ""
       ]
 
-    unrecognisedMsg :: Text -> Text
-    unrecognisedMsg txt = unwords
+    unrecognisedMsg :: Text
+    unrecognisedMsg = unwords
       [ "unrecognised option"
       , "\"" <> txt <> "\""
       , "perhaps you meant \
-         \<\"ignore link\"|\"ignore paragraph\"|\"ignore file\"> "
+          \<\"ignore link\"|\"ignore paragraph\"|\"ignore file\"> "
       ]
 
-    returnError
-      :: Maybe IgnoreMode
-      -> Text
-      -> Maybe PosInfo
-      -> StateT FileInfo (Except Text) ()
-    returnError mode txt pos =
-      let errMsg = case mode of
-            Just Link      -> linkMsg
-            Just Paragraph -> paragraphMsg txt
-            Just File      -> fileMsg
-            Nothing        -> unrecognisedMsg txt
-          posInfo = prettyPos pos
-      in lift $ throwE $ errMsg <> posInfo
+getCommentContent :: Node -> Maybe Text
+getCommentContent node = do
+  txt <- getHTMLText node
+  T.stripSuffix "-->" =<< T.stripPrefix "<!--" (T.strip txt)
+  where
+    getHTMLText :: Node -> Maybe Text
+    getHTMLText (Node _ (HTML_BLOCK txt) _) = Just txt
+    getHTMLText (Node _ (HTML_INLINE txt) _) = Just txt
+    getHTMLText _ = Nothing
 
-    processHtmlNode
-      :: Node
-      -> Maybe PosInfo
-      -> [Node]
-      -> Maybe IgnoreMode
-      -> StateT FileInfo (Except Text) ()
-    processHtmlNode node pos nodes toIgnore = do
-      let xrefcheckContent = getXrefcheckContent node
-      case xrefcheckContent of
-        Just content -> maybe (returnError Nothing content pos)
-          (loop nodes . pure) $ getIgnoreMode node
-        Nothing -> loop nodes toIgnore
+getXrefcheckContent :: Node -> Maybe Text
+getXrefcheckContent node =
+  let notStripped = T.stripPrefix "xrefcheck:" . T.strip =<<
+        getCommentContent node
+  in T.strip <$> notStripped
+
+getIgnoreMode :: Node -> Maybe IgnoreMode
+getIgnoreMode node =
+  let mContent = getXrefcheckContent node
+
+  in textToMode . words =<< mContent
+
+textToMode :: [Text] -> Maybe IgnoreMode
+textToMode ("ignore" : [x])
+  | x == "link"      = return Link
+  | x == "paragraph" = return Paragraph
+  | x == "file"      = return File
+  | otherwise        = return None
+textToMode _         = Nothing
 
 parseFileInfo :: MarkdownConfig -> LT.Text -> Either Text FileInfo
-parseFileInfo config input = runExcept $ nodeExtractInfo config $
-  commonmarkToNode [] [] $ toStrict input
+parseFileInfo config input
+  = runIdentity
+  $ runExceptT
+  $ flip runReaderT config
+  $ flip evalStateT None
+  $ nodeExtractInfo
+  $ commonmarkToNode [] []
+  $ toStrict input
 
 markdownScanner :: MarkdownConfig -> ScanAction
 markdownScanner config path = do

--- a/src/Xrefcheck/Scanners/Markdown.hs
+++ b/src/Xrefcheck/Scanners/Markdown.hs
@@ -115,7 +115,7 @@ removeIgnored = runIdentity . runExceptT . flip evalStateT None . cataNode remov
 foldNode :: (Monoid a, Monad m) => (Node -> m a) -> Node -> m a
 foldNode action node@(Node _ _ subs) = do
   a <- action node
-  b <- foldM (fmap . (<>)) mempty (foldNode action <$> subs)
+  b <- concatForM subs (foldNode action)
   return (a <> b)
 
 {- | Extract information from source tree.

--- a/src/Xrefcheck/System.hs
+++ b/src/Xrefcheck/System.hs
@@ -10,6 +10,8 @@ module Xrefcheck.System
   , bindGlobPattern
   ) where
 
+import Universum
+
 import Data.Aeson (FromJSON (..), withText)
 import qualified Data.Char as C
 import GHC.IO.Unsafe (unsafePerformIO)

--- a/src/Xrefcheck/System.hs
+++ b/src/Xrefcheck/System.hs
@@ -13,12 +13,12 @@ module Xrefcheck.System
 import Universum
 
 import Data.Aeson (FromJSON (..), withText)
-import qualified Data.Char as C
+import Data.Char qualified as C
 import GHC.IO.Unsafe (unsafePerformIO)
 import System.Directory (canonicalizePath)
 import System.Environment (lookupEnv)
 import System.FilePath ((</>))
-import qualified System.FilePath.Glob as Glob
+import System.FilePath.Glob qualified as Glob
 
 -- | We can quite safely treat surrounding filesystem as frozen,
 -- so IO reading operations can be turned into pure values.

--- a/src/Xrefcheck/Util.hs
+++ b/src/Xrefcheck/Util.hs
@@ -16,7 +16,7 @@ module Xrefcheck.Util
 import Universum
 
 import Control.Lens (LensRules, lensField, lensRules, mappingNamer)
-import qualified Data.Aeson as Aeson
+import Data.Aeson qualified as Aeson
 import Data.Aeson.Casing (aesonPrefix, camelCase)
 import Fmt (Builder, build, fmt, nameF)
 import System.Console.Pretty (Pretty (..), Style (Faint))

--- a/src/Xrefcheck/Util.hs
+++ b/src/Xrefcheck/Util.hs
@@ -13,6 +13,8 @@ module Xrefcheck.Util
   , aesonConfigOption
   ) where
 
+import Universum
+
 import Control.Lens (LensRules, lensField, lensRules, mappingNamer)
 import qualified Data.Aeson as Aeson
 import Data.Aeson.Casing (aesonPrefix, camelCase)

--- a/src/Xrefcheck/Verify.hs
+++ b/src/Xrefcheck/Verify.hs
@@ -22,6 +22,8 @@ module Xrefcheck.Verify
   , checkExternalResource
   ) where
 
+import Universum
+
 import Control.Concurrent.Async (wait, withAsync)
 import Control.Exception (throwIO)
 import Control.Monad.Except (MonadError (..))

--- a/src/Xrefcheck/Verify.hs
+++ b/src/Xrefcheck/Verify.hs
@@ -27,13 +27,13 @@ import Universum
 import Control.Concurrent.Async (wait, withAsync)
 import Control.Exception (throwIO)
 import Control.Monad.Except (MonadError (..))
-import qualified Data.ByteString as BS
-import qualified Data.Map as M
-import qualified Data.Text as T
+import Data.ByteString qualified as BS
+import Data.Map qualified as M
+import Data.Text qualified as T
 import Data.Text.Metrics (damerauLevenshteinNorm)
 import Data.Traversable (for)
 import Fmt (Buildable (..), blockListF', listF, (+|), (|+))
-import qualified GHC.Exts as Exts
+import GHC.Exts qualified as Exts
 import Network.FTP.Client
   (FTPException (..), FTPResponse (..), ResponseStatus (..), login, nlst, size, withFTP, withFTPS)
 import Network.HTTP.Client (HttpException (..), HttpExceptionContent (..), responseStatus)
@@ -44,7 +44,7 @@ import Network.HTTP.Types.Status (Status, statusCode, statusMessage)
 import System.Console.Pretty (Style (..), style)
 import System.Directory (canonicalizePath, doesDirectoryExist, doesFileExist)
 import System.FilePath (takeDirectory, (</>))
-import qualified System.FilePath.Glob as Glob
+import System.FilePath.Glob qualified as Glob
 import Text.Regex.TDFA.Text (Regex, regexec)
 import Text.URI (Authority (..), URI (..), mkURI)
 import Time (RatioNat, Second, Time (..), ms, threadDelay, timeout)

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -3,6 +3,8 @@
  - SPDX-License-Identifier: MPL-2.0
  -}
 
+import Universum
+
 import Spec (spec)
 import Test.Hspec (hspec)
 

--- a/tests/Test/Xrefcheck/AnchorsInHeadersSpec.hs
+++ b/tests/Test/Xrefcheck/AnchorsInHeadersSpec.hs
@@ -7,7 +7,7 @@ module Test.Xrefcheck.AnchorsInHeadersSpec where
 
 import Universum
 
-import qualified Data.ByteString.Lazy as BSL
+import Data.ByteString.Lazy qualified as BSL
 import Test.Hspec (Spec, describe, it, shouldBe)
 
 import Xrefcheck.Core

--- a/tests/Test/Xrefcheck/AnchorsInHeadersSpec.hs
+++ b/tests/Test/Xrefcheck/AnchorsInHeadersSpec.hs
@@ -5,6 +5,8 @@
 
 module Test.Xrefcheck.AnchorsInHeadersSpec where
 
+import Universum
+
 import qualified Data.ByteString.Lazy as BSL
 import Test.Hspec (Spec, describe, it, shouldBe)
 

--- a/tests/Test/Xrefcheck/AnchorsSpec.hs
+++ b/tests/Test/Xrefcheck/AnchorsSpec.hs
@@ -5,6 +5,8 @@
 
 module Test.Xrefcheck.AnchorsSpec where
 
+import Universum
+
 import Test.Hspec (Spec, describe, it, shouldBe)
 import Test.QuickCheck ((===))
 

--- a/tests/Test/Xrefcheck/ConfigSpec.hs
+++ b/tests/Test/Xrefcheck/ConfigSpec.hs
@@ -5,8 +5,11 @@
 
 module Test.Xrefcheck.ConfigSpec where
 
+import Universum
+
 import Control.Concurrent (forkIO, killThread)
 import qualified Control.Exception as E
+
 import qualified Data.ByteString as BS
 import Network.HTTP.Types (Status (..))
 import Test.Hspec (Spec, before, describe, it, shouldBe)

--- a/tests/Test/Xrefcheck/ConfigSpec.hs
+++ b/tests/Test/Xrefcheck/ConfigSpec.hs
@@ -8,9 +8,9 @@ module Test.Xrefcheck.ConfigSpec where
 import Universum
 
 import Control.Concurrent (forkIO, killThread)
-import qualified Control.Exception as E
+import Control.Exception qualified as E
 
-import qualified Data.ByteString as BS
+import Data.ByteString qualified as BS
 import Network.HTTP.Types (Status (..))
 import Test.Hspec (Spec, before, describe, it, shouldBe)
 import Test.QuickCheck (counterexample, ioProperty, once)

--- a/tests/Test/Xrefcheck/IgnoreAnnotationsSpec.hs
+++ b/tests/Test/Xrefcheck/IgnoreAnnotationsSpec.hs
@@ -5,6 +5,8 @@
 
 module Test.Xrefcheck.IgnoreAnnotationsSpec where
 
+import Universum
+
 import Test.Hspec (Spec, describe, it, shouldBe)
 
 import Test.Xrefcheck.Util

--- a/tests/Test/Xrefcheck/IgnoreAnnotationsSpec.hs
+++ b/tests/Test/Xrefcheck/IgnoreAnnotationsSpec.hs
@@ -22,7 +22,7 @@ spec = do
     it "Check \"ignore link\" performance" $ do
       fi <- getFI GitHub "tests/markdowns/with-annotations/ignore_link.md"
       getRefs fi `shouldBe`
-        ["team", "team", "team", "hire-us", "how-we-work", "privacy"]
+        ["team", "team", "team", "hire-us", "how-we-work", "privacy", "link2", "link2"]
   describe "\"ignore paragraph\" mode" $ do
     it "Check \"ignore paragraph\" performance" $ do
       fi <- getFI GitHub "tests/markdowns/with-annotations/ignore_paragraph.md"

--- a/tests/Test/Xrefcheck/IgnoreRegexSpec.hs
+++ b/tests/Test/Xrefcheck/IgnoreRegexSpec.hs
@@ -5,6 +5,8 @@
 
 module Test.Xrefcheck.IgnoreRegexSpec where
 
+import Universum
+
 import Data.Yaml (decodeEither')
 import Test.HUnit (assertFailure)
 import Test.Hspec (Spec, describe, it)

--- a/tests/Test/Xrefcheck/LocalSpec.hs
+++ b/tests/Test/Xrefcheck/LocalSpec.hs
@@ -5,6 +5,8 @@
 
 module Test.Xrefcheck.LocalSpec where
 
+import Universum
+
 import Test.Hspec (Spec, describe, it)
 import Test.QuickCheck ((===))
 

--- a/tests/Test/Xrefcheck/TrailingSlashSpec.hs
+++ b/tests/Test/Xrefcheck/TrailingSlashSpec.hs
@@ -5,6 +5,8 @@
 
 module Test.Xrefcheck.TrailingSlashSpec where
 
+import Universum
+
 import Fmt (blockListF, pretty, unlinesF)
 import System.Directory (doesFileExist)
 import Test.Hspec (Spec, describe, expectationFailure, it)

--- a/tests/Test/Xrefcheck/Util.hs
+++ b/tests/Test/Xrefcheck/Util.hs
@@ -7,7 +7,7 @@ module Test.Xrefcheck.Util where
 
 import Universum
 
-import qualified Data.ByteString.Lazy as BSL
+import Data.ByteString.Lazy qualified as BSL
 import Network.HTTP.Types (forbidden403, unauthorized401)
 import Web.Firefly (ToResponse (..), route, run)
 

--- a/tests/Test/Xrefcheck/Util.hs
+++ b/tests/Test/Xrefcheck/Util.hs
@@ -18,7 +18,7 @@ parse :: Flavor -> FilePath -> IO (Either Text FileInfo)
 parse fl path =
   parseFileInfo MarkdownConfig { mcFlavor = fl } . decodeUtf8 <$> BSL.readFile path
 
-getFI :: Flavor -> FilePath -> IO FileInfo
+getFI :: HasCallStack => Flavor -> FilePath -> IO FileInfo
 getFI fl path =
   let errOrFI = parse fl path
   in either error id <$> errOrFI

--- a/tests/Test/Xrefcheck/Util.hs
+++ b/tests/Test/Xrefcheck/Util.hs
@@ -5,6 +5,8 @@
 
 module Test.Xrefcheck.Util where
 
+import Universum
+
 import qualified Data.ByteString.Lazy as BSL
 import Network.HTTP.Types (forbidden403, unauthorized401)
 import Web.Firefly (ToResponse (..), route, run)

--- a/tests/markdowns/with-annotations/ignore_link.md
+++ b/tests/markdowns/with-annotations/ignore_link.md
@@ -30,3 +30,9 @@ development
 
 Here are [how-we-work](https://serokell.io/how-we-work) and [privacy](https://serokell.io/privacy)
 and <!-- xrefcheck: ignore link -->     [ml consulting](https://serokell.io/machine-learning-consulting)
+
+<!-- xrefcheck: ignore link -->
+Ignore link bug _regression test_ [link1](link1) [link2](link2)
+
+<!-- xrefcheck: ignore link -->
+Another ignore link bug _some [link1](link1) emphasis_ [link2](link2)


### PR DESCRIPTION
## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->
Problem: data collection is a function that calls itself 5 screens below the place it starts and is a pile of different, but unrelated actions, performed simultaneously.

Solution: divide the pile into parts and then combine parts externally.

### Concrete changes

1) The `xrefcheck: ignore X` functionality is implemented as a separate function.
3) The data collection is a fold over the tree, and other reducers can be connected.

### Results

`Anchor`/`Reference` colelctor fits into one screen now.

### The Visitor API

```haskell
foldNode :: (Monoid a, Monad m) => (Node -> m a) -> Node -> m a
```
Runs the provided action, collects the results.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #1 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

None, preparing for #64 

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](/README.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [ ] My code complies with the [style guide](docs/code-style.md).
