### PR TITLE
[#72] Fix anchor generation of headers with spaces

### DIFF
--- a/src/Xrefcheck/Scanners/Markdown.hs
+++ b/src/Xrefcheck/Scanners/Markdown.hs
@@ -59,7 +59,7 @@ nodeFlatten :: Node -> [NodeType]
 nodeFlatten (Node _pos ty subs) = ty : concatMap nodeFlatten subs
 
 nodeExtractText :: Node -> Text
-nodeExtractText = mconcat . map extractText . nodeFlatten
+nodeExtractText = T.strip . mconcat . map extractText . nodeFlatten
   where
     extractText = \case
       TEXT t -> t

--- a/tests/Test/Xrefcheck/AnchorsSpec.hs
+++ b/tests/Test/Xrefcheck/AnchorsSpec.hs
@@ -5,18 +5,27 @@
 
 module Test.Xrefcheck.AnchorsSpec where
 
-import Test.Hspec (Spec, describe, it)
+import Test.Hspec (Spec, describe, it, shouldBe)
 import Test.QuickCheck ((===))
 
-import Xrefcheck.Core (Flavor (..), headerToAnchor)
+import Test.Xrefcheck.Util
+import Xrefcheck.Core
 
 checkHeaderConversions
   :: HasCallStack
   => Flavor -> [(Text, Text)] -> Spec
 checkHeaderConversions fl suites =
-  describe (show fl) $
+  describe (show fl) $ do
     forM_ suites $ \(a, b) ->
       it (show a <> " == " <> show b) $ headerToAnchor fl a === b
+    it "Non-stripped header name should be stripped" $ do
+      fi <- getFI fl "tests/markdowns/without-annotations/non_stripped_spaces.md"
+      getAnchors fi `shouldBe` [ case fl of GitHub -> "header--with-leading-spaces"
+                                            GitLab -> "header-with-leading-spaces"
+                               ]
+  where
+    getAnchors :: FileInfo -> [Text]
+    getAnchors fi = map aName $ fi ^. fiAnchors
 
 spec :: Spec
 spec = do

--- a/tests/Test/Xrefcheck/IgnoreAnnotationsSpec.hs
+++ b/tests/Test/Xrefcheck/IgnoreAnnotationsSpec.hs
@@ -5,30 +5,29 @@
 
 module Test.Xrefcheck.IgnoreAnnotationsSpec where
 
-import qualified Data.ByteString.Lazy as BSL
 import Test.Hspec (Spec, describe, it, shouldBe)
 
+import Test.Xrefcheck.Util
 import Xrefcheck.Core
-import Xrefcheck.Scanners.Markdown
 
 spec :: Spec
 spec = do
   describe "Parsing failures" $ do
     it "Check if parsing incorrect markdowns produce exceptions" $ do
-      areIncorrect <- mapM isIncorrectMD failPaths
+      areIncorrect <- mapM (isIncorrectMD GitHub) failPaths
       or areIncorrect `shouldBe` True
   describe "\"ignore link\" mode" $ do
     it "Check \"ignore link\" performance" $ do
-      fi <- getFI "tests/markdowns/with-annotations/ignore_link.md"
+      fi <- getFI GitHub "tests/markdowns/with-annotations/ignore_link.md"
       getRefs fi `shouldBe`
         ["team", "team", "team", "hire-us", "how-we-work", "privacy"]
   describe "\"ignore paragraph\" mode" $ do
     it "Check \"ignore paragraph\" performance" $ do
-      fi <- getFI "tests/markdowns/with-annotations/ignore_paragraph.md"
+      fi <- getFI GitHub "tests/markdowns/with-annotations/ignore_paragraph.md"
       getRefs fi `shouldBe` ["blog", "contacts"]
   describe "\"ignore file\" mode" $ do
     it "Check \"ignore file\" performance" $ do
-      fi <- getFI "tests/markdowns/with-annotations/ignore_file.md"
+      fi <- getFI GitHub "tests/markdowns/with-annotations/ignore_file.md"
       getRefs fi `shouldBe` []
   where
     failPaths :: [FilePath]
@@ -39,19 +38,10 @@ spec = do
       , "tests/markdowns/with-annotations/unrecognised_option.md"
       ]
 
-    parse :: FilePath -> IO (Either Text FileInfo)
-    parse path =
-      parseFileInfo defGithubMdConfig . decodeUtf8 <$> BSL.readFile path
-
-    getFI :: FilePath -> IO FileInfo
-    getFI path =
-      let errOrFI = parse path
-      in either error id <$> errOrFI
-
     getRefs :: FileInfo -> [Text]
     getRefs fi = map rName $ fi ^. fiReferences
 
-    isIncorrectMD :: FilePath -> IO Bool
-    isIncorrectMD path = do
-      errOrInfo <- parse path
+    isIncorrectMD :: Flavor -> FilePath -> IO Bool
+    isIncorrectMD fl path = do
+      errOrInfo <- parse fl path
       return $ isLeft errOrInfo

--- a/tests/Test/Xrefcheck/Util.hs
+++ b/tests/Test/Xrefcheck/Util.hs
@@ -1,0 +1,20 @@
+{- SPDX-FileCopyrightText: 2019 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -}
+
+module Test.Xrefcheck.Util where
+
+import qualified Data.ByteString.Lazy as BSL
+
+import Xrefcheck.Core
+import Xrefcheck.Scanners.Markdown
+
+parse :: Flavor -> FilePath -> IO (Either Text FileInfo)
+parse fl path =
+  parseFileInfo MarkdownConfig{ mcFlavor = fl } . decodeUtf8 <$> BSL.readFile path
+
+getFI :: Flavor -> FilePath -> IO FileInfo
+getFI fl path =
+  let errOrFI = parse fl path
+  in either error id <$> errOrFI

--- a/tests/markdowns/without-annotations/non_stripped_spaces.md
+++ b/tests/markdowns/without-annotations/non_stripped_spaces.md
@@ -1,0 +1,9 @@
+<!--
+ - SPDX-FileCopyrightText: 2019 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -->
+
+## <a name="edge-case"></a>    Header , with leading spaces!
+
+[My link](#edge-case)


### PR DESCRIPTION
## Description

Problem: 
A header name with its custom anchor appended after the octothorpe symbol(s) is parsed with the leading spaces present, thus generating an anchor from it will result in having a leading hyphen prepended to its beginning.

Solution: 
Having retrieved the header name, strip it to eradicate the leading spaces. This will result in the correct generation of the anchor which won't contain a hyphen at its beginning.

## Related issue(s)

Resolves #72 by applying `Data.Text.strip` to the extracted name of either a link or a header in `nodeExtractText`.

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](/README.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [ ] I added an entry to the [changelog](/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](docs/code-style.md).
