### PR TITLE
[#49] Provide error messages for illegal square brackets in URIs

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -80,6 +80,7 @@ dependencies:
   - HUnit
   - lens
   - pretty-terminal
+  - megaparsec
   - modern-uri
   - mtl
   - o-clock
@@ -90,6 +91,7 @@ dependencies:
   - roman-numerals
   - template-haskell
   - text
+  - text-format
   - text-metrics
   - th-lift-instances
   - th-utilities

--- a/src/Xrefcheck/Util.hs
+++ b/src/Xrefcheck/Util.hs
@@ -11,6 +11,8 @@ module Xrefcheck.Util
   , postfixFields
   , (-:)
   , aesonConfigOption
+  , pairedEnclosingGlyphs
+  , octet
   ) where
 
 import Universum
@@ -18,6 +20,10 @@ import Universum
 import Control.Lens (LensRules, lensField, lensRules, mappingNamer)
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Casing (aesonPrefix, camelCase)
+import Data.Char (toUpper)
+import qualified Data.Map as M
+import qualified Data.Text as T (map)
+import Data.Text.Format (hex)
 import Fmt (Builder, build, fmt, nameF)
 import System.Console.Pretty (Pretty (..), Style (Faint))
 
@@ -43,3 +49,18 @@ infixr 0 -:
 -- | Options that we use to derive JSON instances for config types.
 aesonConfigOption :: Aeson.Options
 aesonConfigOption = aesonPrefix camelCase
+
+pairedEnclosingGlyphs :: M.Map Char Char
+pairedEnclosingGlyphs = M.fromList
+  [ ('(', ')')
+  , (')', '(')
+  , ('[', ']')
+  , (']', '[')
+  , ('{', '}')
+  , ('}', '{')
+  , ('<', '>')
+  , ('>', '<')
+  ]
+
+octet :: Char -> Text
+octet = ("%" <>) . T.map toUpper . fmt @Text . hex . ord

--- a/src/Xrefcheck/Util.hs
+++ b/src/Xrefcheck/Util.hs
@@ -25,7 +25,7 @@ import Data.Text qualified as T
 import Data.Text.Format (hex)
 import Fmt (Builder, build, fmt, nameF)
 import System.Console.Pretty (Pretty (..), Style (..))
-import Text.Megaparsec (ParseError (..), bundleErrors)
+import Text.Megaparsec (ParseError (..), ParseErrorBundle (..), bundleErrors)
 import Text.URI (ParseException (..), URI (..), mkURI)
 
 instance Pretty Builder where
@@ -52,7 +52,7 @@ aesonConfigOption :: Aeson.Options
 aesonConfigOption = aesonPrefix camelCase
 
 -- | Identify the positions of all the non-percent-encoded reserved characters in the URI.
-searchReservedChars :: Text -> ([Int], Text)
+searchReservedChars :: Text -> ([Int], Text, Bool)
 searchReservedChars = withAccumulator 0 []
   where
     -- | At every iteration, call @mkURI@ to attempt the parsing of the link.
@@ -63,37 +63,39 @@ searchReservedChars = withAccumulator 0 []
     -- octet, and call @withAccumulator@ recursively, appending the index to the accumulator.
     -- Each recursive call increments the offset by 2 as a result of replacing a character with
     -- an octet, the length of which is always equal to 3.
-    withAccumulator :: Int -> [Int] -> Text -> ([Int], Text)
+    withAccumulator :: Int -> [Int] -> Text -> ([Int], Text, Bool)
     withAccumulator offset indexAcc link =
       case mkURI link :: Either SomeException URI of
-        Left se -> let (index, link') = reservedCharIndex se link offset
-                   in withAccumulator (offset + 2) (index ++ indexAcc) link'
-        Right _uri -> (reverse indexAcc, link)
+        Left se ->
+          let (index, link', wasReplaced) = reservedCharIndex se link offset
+          in
+            if wasReplaced
+            then withAccumulator (offset + 2) (index ++ indexAcc) link'
+            else (reverse indexAcc, link, False)
+        Right _uri -> (reverse indexAcc, link, True)
 
-    reservedCharIndex :: SomeException -> Text -> Int -> ([Int], Text)
+    reservedCharIndex :: SomeException -> Text -> Int -> ([Int], Text, Bool)
     reservedCharIndex se lnk offset = case (fromException se :: Maybe ParseException) of
-      Nothing -> ([], lnk)
+      Nothing -> ([], lnk, False)
       Just pe ->
         let peBundle = (\(ParseException bundle) -> bundle) pe
             err :| _ = bundleErrors peBundle
         in case err of
           -- The value @position@ contains the location of the first spotted illegal
           -- character after parsing the link.
-          TrivialError position _ _ ->
+          TrivialError position (Just _) _ ->
             let characterInQuestion = lnk `T.index` position
-                newLink = toText . replaceOnce characterInQuestion (octet characterInQuestion) $
+                newLink = toText . replaceOnce position (octet characterInQuestion) $
                   toString lnk
-            in
-              ( [position - offset]
-              , newLink
-              )
-          _ -> ([], lnk)
+            in ([position - offset], newLink, True)
+          _ -> ([], lnk, False)
 
-    replaceOnce :: Eq a => a -> [a] -> [a] -> [a]
-    replaceOnce _ _ [] = []
-    replaceOnce pattern replacement (x : xs)
-      | pattern == x = replacement <> xs
-      | otherwise = x : replaceOnce pattern replacement xs
+    replaceOnce :: Eq a => Int -> [a] -> [a] -> [a]
+    replaceOnce pos replacement lst =
+      let (prefix, rest) = splitAt pos lst
+      in case rest of
+        [] -> lst
+        _ : suffix -> prefix ++ replacement ++ suffix
 
 octet :: Char -> String
 octet = ("%" <>) . map toUpper . fmt @String . hex . ord

--- a/src/Xrefcheck/Util.hs
+++ b/src/Xrefcheck/Util.hs
@@ -11,8 +11,7 @@ module Xrefcheck.Util
   , postfixFields
   , (-:)
   , aesonConfigOption
-  , pairedEnclosingGlyphs
-  , octet
+  , invalidURIVerbose
   ) where
 
 import Universum
@@ -22,10 +21,10 @@ import Data.Aeson qualified as Aeson
 import Data.Aeson.Casing (aesonPrefix, camelCase)
 import Data.Char (toUpper)
 import qualified Data.Map as M
-import qualified Data.Text as T (map)
+import qualified Data.Text as T (map, replicate)
 import Data.Text.Format (hex)
-import Fmt (Builder, build, fmt, nameF)
-import System.Console.Pretty (Pretty (..), Style (Faint))
+import Fmt (Builder, build, fmt, indentF, nameF, unlinesF)
+import System.Console.Pretty (Color (..), Pretty (..), Style (..))
 
 instance Pretty Builder where
     colorize s c = build @Text . colorize s c . fmt
@@ -50,17 +49,53 @@ infixr 0 -:
 aesonConfigOption :: Aeson.Options
 aesonConfigOption = aesonPrefix camelCase
 
-pairedEnclosingGlyphs :: M.Map Char Char
-pairedEnclosingGlyphs = M.fromList
-  [ ('(', ')')
-  , (')', '(')
-  , ('[', ']')
-  , (']', '[')
-  , ('{', '}')
-  , ('}', '{')
-  , ('<', '>')
-  , ('>', '<')
-  ]
+invalidURIVerbose :: Char -> Int -> Text -> Text
+invalidURIVerbose characterInQuestion position link = fmt . indentF 3 . unlinesF $
+  pinpointInvalidCharacter <>
+  suggestPercentEncoding
+  where
+    pinpointInvalidCharacter  =
+      [ "unexpected character " <> show characterInQuestion
+      , style Bold (color Magenta "|")
+      , style Bold (color Magenta "|") <> "  " <>
+        applyPrettyAt position link Bold Magenta
+      , style Bold (color Magenta "|") <> "  " <>
+        T.replicate position " " <> style Bold (color Magenta "^")
+      , show characterInQuestion <>
+        " is not allowed to be explcitily used in the URIs by the WHATWG URL standard"
+      , "Consider using its percent-encoded counterpart: " <>
+        style Bold (color Magenta $ octet characterInQuestion)
+      ]
 
-octet :: Char -> Text
-octet = ("%" <>) . T.map toUpper . fmt @Text . hex . ord
+    suggestPercentEncoding = maybeToList $ do
+      paired <- characterInQuestion `M.lookup` pairedEnclosingGlyphs
+      return $
+        "Similarly for " <> show paired <>
+        " if it is present in the URI: " <>
+        style Bold (color Magenta (octet paired))
+
+    applyPrettyAt :: Int -> Text -> Style -> Color -> Text
+    applyPrettyAt pos text sty col =
+      let s = splitAt pos $ toString text
+      in toText $ case s of
+        (prefix, []) -> prefix
+        ([], suffix@(h : t)) ->
+          if pos < 0
+          then suffix
+          else style sty (color col [h]) <> t
+        (prefix, h : t) -> prefix <> color col [h] <> t
+
+    pairedEnclosingGlyphs :: M.Map Char Char
+    pairedEnclosingGlyphs = M.fromList
+      [ ('(', ')')
+      , (')', '(')
+      , ('[', ']')
+      , (']', '[')
+      , ('{', '}')
+      , ('}', '{')
+      , ('<', '>')
+      , ('>', '<')
+      ]
+
+    octet :: Char -> Text
+    octet = ("%" <>) . T.map toUpper . fmt @Text . hex . ord

--- a/tests/Test/Xrefcheck/ReservedURICharsSpec.hs
+++ b/tests/Test/Xrefcheck/ReservedURICharsSpec.hs
@@ -13,16 +13,16 @@ import Xrefcheck.Util (searchBrackets)
 
 spec :: Spec
 spec =
-  describe "Reserved square brackets should be recognized if present in the URI" $ do
-    it "No square brackets" $
+  describe "Reserved characters, if present, should be recognized in the URI" $ do
+    it "No reserved characters" $
       forM_ noSB $ \link ->
         searchBrackets link `shouldBe` []
-    it "One square bracket per link" $
+    it "One reserved character per link" $
       forM_ oneSB $ \link ->
-        searchBrackets link `shouldBe` findSB (toString link)
-    it "Many square brackets in every link" $
+        searchBrackets link `shouldBe` findSBTrivialCase (toString link)
+    it "Many reserved characters in every link" $
       forM_ manySB $ \link ->
-        searchBrackets link `shouldBe` findSB (toString link)
+        searchBrackets link `shouldBe` findSBTrivialCase (toString link)
   where
     noSB =
       [ "https://example.com/"
@@ -30,15 +30,15 @@ spec =
       , "https://example.com/enter/shikari/alexandra/palace"
       ]
     oneSB =
-      [ "https://example[.com/"
+      [ "https://example{.com/"
       , "https://example.com/whatever/codata?data]=co&universal=eliminator"
-      , "https://example.com/enter/shi[kari/alexandra/palace"
+      , "https://example.com/enter/shi>kari/alexandra/palace"
       ]
     manySB =
-      [ "https://examp[le[.c]o]m/"
-      , "https://example.com/whatever/codata?[data]=[co]&[universal]=[eliminator]"
+      [ "https://examp{le[.c]o}m/"
+      , "https://example.com/whatever/codata?{data}=<co>&{universal}=[eliminator]"
       , "https://example.com/ent[[[[er/sh[]]][i[kari/a]]]lexandra/]palace"
       ]
 
-    findSB :: String -> [Int]
-    findSB = map fst . filter (\(_, ch) -> ch `elem` ("[]" :: String)) . zip [0..]
+    findSBTrivialCase :: String -> [Int]
+    findSBTrivialCase = map fst . filter (\(_, ch) -> ch `elem` ("[]" :: String)) . zip [0..]

--- a/tests/Test/Xrefcheck/ReservedURICharsSpec.hs
+++ b/tests/Test/Xrefcheck/ReservedURICharsSpec.hs
@@ -15,30 +15,30 @@ spec :: Spec
 spec =
   describe "Reserved characters, if present, should be recognized in the URI" $ do
     it "No reserved characters" $
-      forM_ noSB $ \link ->
-        searchReservedChars link `shouldBe` []
+      forM_ noRC $ \link ->
+        fst (searchReservedChars link) `shouldBe` []
     it "One reserved character per link" $
-      forM_ oneSB $ \link ->
-        searchReservedChars link `shouldBe` findSBTrivialCase (toString link)
+      forM_ oneRC $ \link ->
+        fst (searchReservedChars link) `shouldBe` findRCTrivialCase (toString link)
     it "Many reserved characters in every link" $
-      forM_ manySB $ \link ->
-        searchReservedChars link `shouldBe` findSBTrivialCase (toString link)
+      forM_ manyRC $ \link ->
+        fst (searchReservedChars link) `shouldBe` findRCTrivialCase (toString link)
   where
-    noSB =
+    noRC =
       [ "https://example.com/"
       , "https://example.com/whatever/codata?data=co&universal=eliminator"
       , "https://example.com/enter/shikari/alexandra/palace"
       ]
-    oneSB =
+    oneRC =
       [ "https://example{.com/"
       , "https://example.com/whatever/codata?data]=co&universal=eliminator"
       , "https://example.com/enter/shi>kari/alexandra/palace"
       ]
-    manySB =
+    manyRC =
       [ "https://examp{le[.c]o}m/"
       , "https://example.com/whatever/codata?{data}=<co>&{universal}=[eliminator]"
       , "https://example.com/ent[[[[er/sh[]]][i[kari/a]]]lexandra/]palace"
       ]
 
-    findSBTrivialCase :: String -> [Int]
-    findSBTrivialCase = map fst . filter (\(_, ch) -> ch `elem` ("[]" :: String)) . zip [0..]
+    findRCTrivialCase :: String -> [Int]
+    findRCTrivialCase = map fst . filter (\(_, ch) -> ch `elem` ("[]{}<>" :: String)) . zip [0..]

--- a/tests/Test/Xrefcheck/ReservedURICharsSpec.hs
+++ b/tests/Test/Xrefcheck/ReservedURICharsSpec.hs
@@ -1,0 +1,44 @@
+{- SPDX-FileCopyrightText: 2021 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -}
+
+module Test.Xrefcheck.ReservedURICharsSpec where
+
+import Universum
+
+import Test.Hspec (Spec, describe, it, shouldBe)
+
+import Xrefcheck.Util (searchBrackets)
+
+spec :: Spec
+spec =
+  describe "Reserved square brackets should be recognized if present in the URI" $ do
+    it "No square brackets" $
+      forM_ noSB $ \link ->
+        searchBrackets link `shouldBe` []
+    it "One square bracket per link" $
+      forM_ oneSB $ \link ->
+        searchBrackets link `shouldBe` findSB (toString link)
+    it "Many square brackets in every link" $
+      forM_ manySB $ \link ->
+        searchBrackets link `shouldBe` findSB (toString link)
+  where
+    noSB =
+      [ "https://example.com/"
+      , "https://example.com/whatever/codata?data=co&universal=eliminator"
+      , "https://example.com/enter/shikari/alexandra/palace"
+      ]
+    oneSB =
+      [ "https://example[.com/"
+      , "https://example.com/whatever/codata?data]=co&universal=eliminator"
+      , "https://example.com/enter/shi[kari/alexandra/palace"
+      ]
+    manySB =
+      [ "https://examp[le[.c]o]m/"
+      , "https://example.com/whatever/codata?[data]=[co]&[universal]=[eliminator]"
+      , "https://example.com/ent[[[[er/sh[]]][i[kari/a]]]lexandra/]palace"
+      ]
+
+    findSB :: String -> [Int]
+    findSB = map fst . filter (\(_, ch) -> ch `elem` ("[]" :: String)) . zip [0..]

--- a/tests/Test/Xrefcheck/ReservedURICharsSpec.hs
+++ b/tests/Test/Xrefcheck/ReservedURICharsSpec.hs
@@ -9,20 +9,20 @@ import Universum
 
 import Test.Hspec (Spec, describe, it, shouldBe)
 
-import Xrefcheck.Util (searchBrackets)
+import Xrefcheck.Util (searchReservedChars)
 
 spec :: Spec
 spec =
   describe "Reserved characters, if present, should be recognized in the URI" $ do
     it "No reserved characters" $
       forM_ noSB $ \link ->
-        searchBrackets link `shouldBe` []
+        searchReservedChars link `shouldBe` []
     it "One reserved character per link" $
       forM_ oneSB $ \link ->
-        searchBrackets link `shouldBe` findSBTrivialCase (toString link)
+        searchReservedChars link `shouldBe` findSBTrivialCase (toString link)
     it "Many reserved characters in every link" $
       forM_ manySB $ \link ->
-        searchBrackets link `shouldBe` findSBTrivialCase (toString link)
+        searchReservedChars link `shouldBe` findSBTrivialCase (toString link)
   where
     noSB =
       [ "https://example.com/"

--- a/tests/Test/Xrefcheck/ReservedURICharsSpec.hs
+++ b/tests/Test/Xrefcheck/ReservedURICharsSpec.hs
@@ -25,18 +25,18 @@ spec =
         fst (searchReservedChars link) `shouldBe` findRCTrivialCase (toString link)
   where
     noRC =
-      [ "https://example.com/"
+      [ "https://userinfo@example.com:8888"
       , "https://example.com/whatever/codata?data=co&universal=eliminator"
       , "https://example.com/enter/shikari/alexandra/palace"
       ]
     oneRC =
-      [ "https://example{.com/"
+      [ "https://userinf]o@example.com:8888"
       , "https://example.com/whatever/codata?data]=co&universal=eliminator"
       , "https://example.com/enter/shi>kari/alexandra/palace"
       ]
     manyRC =
-      [ "https://examp{le[.c]o}m/"
-      , "https://example.com/whatever/codata?{data}=<co>&{universal}=[eliminator]"
+      [ "https://user{info@example.com:888>8"
+      , "https://example.com/whatever/codata?{data}=<co>&universal=[eliminator]"
       , "https://example.com/ent[[[[er/sh[]]][i[kari/a]]]lexandra/]palace"
       ]
 


### PR DESCRIPTION
## Description

Problem: According to RFC 3986 section 2.2, square brackets are reserved
characters and should be percent-encoded in the URIs; however, when
they are used outside their reserved purpose in the respective context,
they MUST be percent-encoded. Currently, xrefcheck does not provide a
verbose error message when such character is detected in the URI.

Solution: Provide a better means to indicate that such a character has
been detected by supplying an error message describing the location
of the said character and its percent-encoded octet.

## Related issue(s)

#49 

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](/README.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [ ] I added an entry to the [changelog](/CHANGES.md) if my changes are visible to the users
        and
  - [ ] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [ ] My code complies with the [style guide](/docs/code-style.md).
