### PR TITLE
[#107] Update stack resolver to the newer version

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -7,3 +7,7 @@ License: Unlicense
 Files: links-tests/ftp_root/**/*
 Copyright: 2021 Serokell <https://serokell.io>
 License: Unlicense
+
+Files: tests/configs/github-config.yaml
+Copyright: 2019-2021 Serokell <https://serokell.io>
+License: Unlicense

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "c4a3c64af0a33052ba93128fbdc40a2ee1335979",
-        "sha256": "1r74sl8r56r8360zy5kgiqcxxzx0gib314k2csjwgz71g6q5fglm",
+        "rev": "c90cce1583d9efe40dc1367ddf0f843323a7a8f6",
+        "sha256": "1bjjg9cg3ykw9c21hk8ji7djl153jybgj55zgifh7bwwrqjb62w7",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/hackage.nix/archive/c4a3c64af0a33052ba93128fbdc40a2ee1335979.tar.gz",
+        "url": "https://github.com/input-output-hk/hackage.nix/archive/c90cce1583d9efe40dc1367ddf0f843323a7a8f6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "haskell.nix": {
@@ -17,10 +17,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "a4e105dcdb6d2b9d0627b8f0b893cec80485c14e",
-        "sha256": "144cfklhmqrq1kmvnmvcfmn819ijy4hr20whfazypxa72lcs3lz0",
+        "rev": "1b0eac78c61b425ad382427b25a4450c8d6f6771",
+        "sha256": "06m5fa3zndgfngyl2p7v738lv3miljmdwz35c6vqly78agc0xdy9",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/a4e105dcdb6d2b9d0627b8f0b893cec80485c14e.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/1b0eac78c61b425ad382427b25a4450c8d6f6771.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
@@ -53,10 +53,10 @@
         "homepage": "",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "8d07cc6c73717ba19304e6b9231a88504d0846b4",
-        "sha256": "122cpdw8bsbfk6pmp8jblvkfy7g72zxm076i5c4s84rbyw33rd9f",
+        "rev": "0ff7b16dc349ed2b573c777907885f3f270a7b0e",
+        "sha256": "02n4x734q16n906v70hwr4lgpacz1qa7b96p16m4rcckxdqj8ybn",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/stackage.nix/archive/8d07cc6c73717ba19304e6b9231a88504d0846b4.tar.gz",
+        "url": "https://github.com/input-output-hk/stackage.nix/archive/0ff7b16dc349ed2b573c777907885f3f270a7b0e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/package.yaml
+++ b/package.yaml
@@ -17,7 +17,6 @@ description:         Please see the README on GitHub at <https://github.com/sero
 extra-source-files:
   - README.md
   - CHANGES.md
-  - src-files/*
 
 default-extensions:
   - AllowAmbiguousTypes
@@ -71,7 +70,7 @@ dependencies:
   - directory
   - dlist
   - filepath
-  - file-embed  < 0.14
+  - raw-strings-qq
   - fmt
   - ftp-client
   - Glob
@@ -126,6 +125,7 @@ tests:
     dependencies:
       - firefly
       - hspec
+      - hspec-expectations
       - QuickCheck
       - xrefcheck
     build-tools:

--- a/package.yaml
+++ b/package.yaml
@@ -71,7 +71,7 @@ dependencies:
   - directory
   - dlist
   - filepath
-  - file-embed
+  - file-embed  < 0.14
   - fmt
   - ftp-client
   - Glob
@@ -92,7 +92,6 @@ dependencies:
   - text
   - text-metrics
   - th-lift-instances
-  - th-utilities
   - transformers
   - universum
   - yaml

--- a/src/Xrefcheck/Config.hs
+++ b/src/Xrefcheck/Config.hs
@@ -23,10 +23,8 @@ import Text.Regex.TDFA qualified as R
 import Text.Regex.TDFA.ByteString ()
 import Text.Regex.TDFA.Text qualified as R
 
--- FIXME: Use </> from System.FilePath
--- </> from Posix is used only because we cross-compile to Windows and \ doesn't work on Linux
 import Data.FileEmbed (embedFile)
-import System.FilePath.Posix ((</>))
+import System.FilePath ((</>))
 import Time (KnownRatName, Second, Time, unitsP)
 
 import Xrefcheck.Core
@@ -182,6 +180,12 @@ defConfigText flavor =
           ]
     ]
 
+foldMap (deriveFromJSON aesonConfigOption)
+  [ ''VerifyConfig
+  , ''Config
+  , ''ScannersConfig
+  ]
+
 defConfig :: HasCallStack => Flavor -> Config
 defConfig flavor =
   either (error . toText . prettyPrintParseException) id $
@@ -190,10 +194,6 @@ defConfig flavor =
 -----------------------------------------------------------
 -- Yaml instances
 -----------------------------------------------------------
-
-deriveFromJSON aesonConfigOption ''Config
-deriveFromJSON aesonConfigOption ''ScannersConfig
-deriveFromJSON aesonConfigOption ''VerifyConfig
 
 instance KnownRatName unit => FromJSON (Time unit) where
   parseJSON = withText "time" $

--- a/src/Xrefcheck/Config.hs
+++ b/src/Xrefcheck/Config.hs
@@ -23,8 +23,6 @@ import Text.Regex.TDFA qualified as R
 import Text.Regex.TDFA.ByteString ()
 import Text.Regex.TDFA.Text qualified as R
 
-import Data.FileEmbed (embedFile)
-import System.FilePath ((</>))
 import Time (KnownRatName, Second, Time, unitsP)
 
 import Xrefcheck.Core
@@ -32,6 +30,7 @@ import Xrefcheck.Scan
 import Xrefcheck.Scanners.Markdown
 import Xrefcheck.System (RelGlobPattern)
 import Xrefcheck.Util (aesonConfigOption, postfixFields, (-:))
+import Xrefcheck.Config.Default
 
 -- | Overall config.
 data Config = Config
@@ -64,14 +63,6 @@ data ScannersConfig = ScannersConfig
 
 makeLensesWith postfixFields ''Config
 makeLensesWith postfixFields ''VerifyConfig
-
------------------------------------------------------------
--- Default config
------------------------------------------------------------
-
-defConfigUnfilled :: ByteString
-defConfigUnfilled =
-  $(embedFile ("src-files" </> "def-config.yaml"))
 
 -- | Picks raw config with @:PLACEHOLDER:<key>:@ and fills the specified fields
 -- in it, picking a replacement suitable for the given key. Only strings and lists

--- a/src/Xrefcheck/Config/Default.hs
+++ b/src/Xrefcheck/Config/Default.hs
@@ -1,8 +1,19 @@
-# SPDX-FileCopyrightText: 2019-2021 Serokell <https://serokell.io>
-#
-# SPDX-License-Identifier: Unlicense
+{- SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -}
 
-# Parameters of repository traversal.
+{-# LANGUAGE QuasiQuotes #-}
+
+module Xrefcheck.Config.Default where
+
+import Universum
+
+import Text.RawString.QQ
+
+defConfigUnfilled :: ByteString
+defConfigUnfilled =
+  [r|# Parameters of repository traversal.
 traversal:
   # Files and folders which we pretend do not exist
   # (so they are neither analyzed nor can be referenced).
@@ -50,3 +61,4 @@ scanners:
     #
     # This affects which anchors are generated for headers.
     flavor: :PLACEHOLDER:flavor:
+|]

--- a/stack.yaml
+++ b/stack.yaml
@@ -13,6 +13,5 @@ extra-deps:
 - pretty-terminal-0.1.0.0
 - roman-numerals-0.5.1.5
 - with-utf8-1.0.2.3
-- file-embed-0.0.13.0
 - th-utilities-0.2.4.0@sha256:ba19cd8441aa43dbaed40e9055bb5a7cbd7cf9e154f5253c6bf9293af8b1f96b,1869
 - firefly-0.2.1.0@sha256:e9d73486464c3e223ec457e02b30ddd5b550fdbf6292b268c64581e2b07d888b,1519

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,7 +4,7 @@
 
 # To update hackage and stackage indexes used by CI run:
 # $ niv update hackage.nix; niv update stackage.nix
-resolver: lts-17.3
+resolver: lts-19.13
 
 packages:
 - .
@@ -12,6 +12,7 @@ packages:
 extra-deps:
 - pretty-terminal-0.1.0.0
 - roman-numerals-0.5.1.5
-- with-utf8-1.0.2.2
+- with-utf8-1.0.2.3
+- file-embed-0.0.13.0
 - th-utilities-0.2.4.0@sha256:ba19cd8441aa43dbaed40e9055bb5a7cbd7cf9e154f5253c6bf9293af8b1f96b,1869
 - firefly-0.2.1.0@sha256:e9d73486464c3e223ec457e02b30ddd5b550fdbf6292b268c64581e2b07d888b,1519

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,43 +5,50 @@
 
 packages:
 - completed:
-    hackage: pretty-terminal-0.1.0.0@sha256:e9135d86ebb2a8e3aaf5a79088de4628dbd49988388e0fbfc26c5ecb3c399ad9,1638
     pantry-tree:
-      size: 385
       sha256: fecec01e618890c284e57cb873b8f9531f479562b7cf08497aef097da3ef90ec
+      size: 385
+    hackage: pretty-terminal-0.1.0.0@sha256:e9135d86ebb2a8e3aaf5a79088de4628dbd49988388e0fbfc26c5ecb3c399ad9,1638
   original:
     hackage: pretty-terminal-0.1.0.0
 - completed:
-    hackage: roman-numerals-0.5.1.5@sha256:819d04d9d442b24629dd058f6f0b02bd78e9f9ae99538bc44ca448f1cb2b7b01,1208
     pantry-tree:
-      size: 220
       sha256: 2154c0f4a11842593586dc1932e233cd8c802994763f7d3ce3e5916be8bc7ee5
+      size: 220
+    hackage: roman-numerals-0.5.1.5@sha256:819d04d9d442b24629dd058f6f0b02bd78e9f9ae99538bc44ca448f1cb2b7b01,1208
   original:
     hackage: roman-numerals-0.5.1.5
 - completed:
-    hackage: with-utf8-1.0.2.2@sha256:42eed140390b3e93d9482b084d1d0150e8774667f39c33bd47e84815751fad09,3057
     pantry-tree:
+      sha256: 3be938e2612faaab078f77bd8e0def999b6f60fc2adda8d89382b0681b4ba420
       size: 1051
-      sha256: 4b06e9ee43909239a813ccd972eeb444e541efd72aeb0d343206449169227286
+    hackage: with-utf8-1.0.2.3@sha256:3de710e4aa70856ab0845373bfde4746920fd45b8641bfaa3bd5cd2c200c4704,3051
   original:
-    hackage: with-utf8-1.0.2.2
+    hackage: with-utf8-1.0.2.3
 - completed:
-    hackage: th-utilities-0.2.4.0@sha256:ba19cd8441aa43dbaed40e9055bb5a7cbd7cf9e154f5253c6bf9293af8b1f96b,1869
     pantry-tree:
-      size: 882
+      sha256: 6c8f71ca993658844b93a2120f2ff1536400e705890a6fbf0f4e9889ff502649
+      size: 477
+    hackage: file-embed-0.0.13.0@sha256:a819e90b91cab919ffef5895ab6e1b2a44eac395a585f489b0c289a4a12d1c54,1396
+  original:
+    hackage: file-embed-0.0.13.0
+- completed:
+    pantry-tree:
       sha256: 8c577d112a8398a5542aa4205b2e8a470a66d57590e6606d752d71e75d7425ea
+      size: 882
+    hackage: th-utilities-0.2.4.0@sha256:ba19cd8441aa43dbaed40e9055bb5a7cbd7cf9e154f5253c6bf9293af8b1f96b,1869
   original:
     hackage: th-utilities-0.2.4.0@sha256:ba19cd8441aa43dbaed40e9055bb5a7cbd7cf9e154f5253c6bf9293af8b1f96b,1869
 - completed:
-    hackage: firefly-0.2.1.0@sha256:e9d73486464c3e223ec457e02b30ddd5b550fdbf6292b268c64581e2b07d888b,1519
     pantry-tree:
-      size: 600
       sha256: 51d4bf283e1d9ae37e43cd387b112919e45f2fc088f57cbd33c8bad9b0c179f1
+      size: 600
+    hackage: firefly-0.2.1.0@sha256:e9d73486464c3e223ec457e02b30ddd5b550fdbf6292b268c64581e2b07d888b,1519
   original:
     hackage: firefly-0.2.1.0@sha256:e9d73486464c3e223ec457e02b30ddd5b550fdbf6292b268c64581e2b07d888b,1519
 snapshots:
 - completed:
-    size: 563099
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/17/3.yaml
-    sha256: 1e9f31ec160a144f796bc49b91dfc2bab5eca88b1dcc93da569108febaf5b382
-  original: lts-17.3
+    sha256: ef98d70e4018bf01feb00ccdcd33ab26d056dbb71b38057c78fdd0d1ec671c85
+    size: 618740
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/13.yaml
+  original: lts-19.13

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -27,13 +27,6 @@ packages:
     hackage: with-utf8-1.0.2.3
 - completed:
     pantry-tree:
-      sha256: 6c8f71ca993658844b93a2120f2ff1536400e705890a6fbf0f4e9889ff502649
-      size: 477
-    hackage: file-embed-0.0.13.0@sha256:a819e90b91cab919ffef5895ab6e1b2a44eac395a585f489b0c289a4a12d1c54,1396
-  original:
-    hackage: file-embed-0.0.13.0
-- completed:
-    pantry-tree:
       sha256: 8c577d112a8398a5542aa4205b2e8a470a66d57590e6606d752d71e75d7425ea
       size: 882
     hackage: th-utilities-0.2.4.0@sha256:ba19cd8441aa43dbaed40e9055bb5a7cbd7cf9e154f5253c6bf9293af8b1f96b,1869

--- a/tests/Test/Xrefcheck/ConfigSpec.hs
+++ b/tests/Test/Xrefcheck/ConfigSpec.hs
@@ -13,7 +13,8 @@ import Control.Exception qualified as E
 import Data.ByteString qualified as BS
 import Network.HTTP.Types (Status (..))
 import Test.Hspec (Spec, before, describe, it, shouldBe)
-import Test.QuickCheck (counterexample, ioProperty, once)
+import Test.Hspec.Expectations (expectationFailure)
+import Test.QuickCheck (ioProperty, once)
 
 import Xrefcheck.Config (Config (..), VerifyConfig (..), defConfig, defConfigText)
 import Xrefcheck.Core (Flavor (GitHub), allFlavors)
@@ -34,16 +35,13 @@ spec = do
       -- stack exec xrefcheck -- dump-config -t GitHub -o tests/configs/github-config.yaml
       it "Config matches" $
         \config ->
-          let matches =
-                [ "Config does not match the expected format."
-                , "Run"
-                , "`stack exec xrefcheck -- dump-config -t GitHub -o tests/configs/github-config.yaml`"
-                , "and verify changes"
-                ]
-          in
-            counterexample
-            (toString $ unwords matches)
-            (config == defConfigText GitHub)
+          when (config /= defConfigText GitHub) $
+            expectationFailure $ toString $ unwords
+              [ "Config does not match the expected format."
+              , "Run"
+              , "`stack exec xrefcheck -- dump-config -t GitHub -o tests/configs/github-config.yaml`"
+              , "and verify changes"
+              ]
 
   describe "`ignoreAuthFailures` working as expected" $ do
     let config = (cVerification $ defConfig GitHub) { vcCheckLocalhost = True }

--- a/tests/configs/github-config.yaml
+++ b/tests/configs/github-config.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2019-2021 Serokell <https://serokell.io>
-#
-# SPDX-License-Identifier: Unlicense
-
 # Parameters of repository traversal.
 traversal:
   # Files and folders which we pretend do not exist


### PR DESCRIPTION
## Description

I updated stack resolver to lts 19.13, which uses ghc 9.0.2 and update haskell.nix configuration files, so `nix-build` working with new resolver. I moved up template-haskell declarations in Xrefcheck,Config module, because in ghc 9.0.2 were changed rules of module division by TH, and these FromJSON instances were out of scope of `defConfig` function.

## Related issue(s)

- Fixed #107 

