### PR TITLE
[#106] Fix using ./ in paths

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,7 +9,7 @@ steps:
   - command: nix-build ci.nix -A xrefcheck-lib-and-tests
     label: Library and tests
 
-  - command: nix run -f ci.nix pkgs.bats pkgs.diffutils xrefcheck-static -c bash -c "cd tests/golden && bats ./"
+  - command: nix run -f ci.nix pkgs.bats pkgs.diffutils xrefcheck-static -c bash -c "cd tests/golden/ && bats ./**"
     label: Golden tests (bats)
 
   - command: nix-build ci.nix -A xrefcheck-static
@@ -22,7 +22,7 @@ steps:
     artifact_paths:
       - "result/bin/*"
 
-  - command: nix run -f ci.nix xrefcheck-static -c xrefcheck --ignored tests/markdowns
+  - command: nix run -f ci.nix xrefcheck-static -c xrefcheck --ignored tests/markdowns --ignored tests/golden/
     label: Xrefcheck itself
 
   - label: lint

--- a/package.yaml
+++ b/package.yaml
@@ -21,6 +21,7 @@ extra-source-files:
 default-extensions:
   - AllowAmbiguousTypes
   - BangPatterns
+  - BlockArguments
   - ConstraintKinds
   - DataKinds
   - DefaultSignatures

--- a/src/Xrefcheck/Command.hs
+++ b/src/Xrefcheck/Command.hs
@@ -14,7 +14,7 @@ import Fmt (blockListF', build, fmt, fmtLn, indentF)
 import System.Directory (doesFileExist)
 
 import Xrefcheck.CLI (Options (..), addTraversalOptions, addVerifyOptions, defaultConfigPaths)
-import Xrefcheck.Config (Config (..), ScannersConfig (..), defConfig)
+import Xrefcheck.Config (Config (..), ScannersConfig (..), defConfig, normaliseConfigFilePaths)
 import Xrefcheck.Core (Flavor (..))
 import Xrefcheck.Progress (allowRewrite)
 import Xrefcheck.Scan (FormatsSupport, gatherRepoInfo, specificFormatsSupport)
@@ -23,9 +23,9 @@ import Xrefcheck.System (askWithinCI)
 import Xrefcheck.Verify (verifyErrors, verifyRepo)
 
 readConfig :: FilePath -> IO Config
-readConfig path =
+readConfig path = fmap normaliseConfigFilePaths do
   decodeFileEither path
-  >>= either (error . toText . prettyPrintParseException) pure
+    >>= either (error . toText . prettyPrintParseException) pure
 
 formats :: ScannersConfig -> FormatsSupport
 formats ScannersConfig{..} = specificFormatsSupport

--- a/src/Xrefcheck/System.hs
+++ b/src/Xrefcheck/System.hs
@@ -7,6 +7,7 @@ module Xrefcheck.System
   ( readingSystem
   , askWithinCI
   , RelGlobPattern (..)
+  , normaliseGlobPattern
   , bindGlobPattern
   ) where
 
@@ -19,6 +20,8 @@ import System.Directory (canonicalizePath)
 import System.Environment (lookupEnv)
 import System.FilePath ((</>))
 import System.FilePath.Glob qualified as Glob
+import Data.Coerce (coerce)
+import Xrefcheck.Util (normaliseWithNoTrailing)
 
 -- | We can quite safely treat surrounding filesystem as frozen,
 -- so IO reading operations can be turned into pure values.
@@ -35,6 +38,9 @@ askWithinCI = lookupEnv "CI" <&> \case
 
 -- | Glob pattern relative to repository root.
 newtype RelGlobPattern = RelGlobPattern FilePath
+
+normaliseGlobPattern :: RelGlobPattern -> RelGlobPattern
+normaliseGlobPattern = RelGlobPattern . normaliseWithNoTrailing . coerce
 
 bindGlobPattern :: FilePath -> RelGlobPattern -> Glob.Pattern
 bindGlobPattern root (RelGlobPattern relPat) = readingSystem $ do

--- a/src/Xrefcheck/Util.hs
+++ b/src/Xrefcheck/Util.hs
@@ -11,7 +11,7 @@ module Xrefcheck.Util
   , postfixFields
   , (-:)
   , aesonConfigOption
-  ) where
+  , normaliseWithNoTrailing) where
 
 import Universum
 
@@ -20,6 +20,7 @@ import Data.Aeson qualified as Aeson
 import Data.Aeson.Casing (aesonPrefix, camelCase)
 import Fmt (Builder, build, fmt, nameF)
 import System.Console.Pretty (Pretty (..), Style (Faint))
+import System.FilePath (dropTrailingPathSeparator, normalise)
 
 instance Pretty Builder where
     colorize s c = build @Text . colorize s c . fmt
@@ -43,3 +44,6 @@ infixr 0 -:
 -- | Options that we use to derive JSON instances for config types.
 aesonConfigOption :: Aeson.Options
 aesonConfigOption = aesonPrefix camelCase
+
+normaliseWithNoTrailing :: FilePath -> FilePath
+normaliseWithNoTrailing =  dropTrailingPathSeparator . normalise

--- a/src/Xrefcheck/Verify.hs
+++ b/src/Xrefcheck/Verify.hs
@@ -43,7 +43,7 @@ import Network.HTTP.Req
 import Network.HTTP.Types.Status (Status, statusCode, statusMessage)
 import System.Console.Pretty (Style (..), style)
 import System.Directory (canonicalizePath, doesDirectoryExist, doesFileExist)
-import System.FilePath (takeDirectory, (</>))
+import System.FilePath (takeDirectory, (</>), normalise)
 import System.FilePath.Glob qualified as Glob
 import Text.Regex.TDFA.Text (Regex, regexec)
 import Text.URI (Authority (..), URI (..), mkURI)
@@ -211,7 +211,7 @@ verifyRepo
     = do
   let toScan = do
         (file, fileInfo) <- M.toList repoInfo
-        guard . not $ any ((`isPrefixOf` file) . (root </>)) vcNotScanned
+        guard . not $ any ((`isPrefixOf` file) . normalise . (root </>)) vcNotScanned
         ref <- _fiReferences fileInfo
         return (file, ref)
 

--- a/tests/golden/check-cli/check-cli.bats
+++ b/tests/golden/check-cli/check-cli.bats
@@ -1,0 +1,79 @@
+#!/usr/bin/env bats
+
+# SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+load '../helpers/bats-support/load'
+load '../helpers/bats-assert/load'
+load '../helpers'
+
+@test "No redundant slashes" {
+  run xrefcheck \
+    --ignored to-ignore \
+    --root .
+
+  assert_output --partial "All repository links are valid."
+}
+
+@test "Redundant slashes in root and ignored" {
+  run xrefcheck \
+    --ignored ./././././././//to-ignore \
+    --root ./
+
+  assert_output --partial "All repository links are valid."
+}
+
+@test "Redundant slashes in root" {
+  run xrefcheck \
+    -c config-no-scan-ignored.yaml \
+    --root ./
+
+  assert_output --partial "All repository links are valid."
+}
+
+@test "Reduchant slashes in ignored" {
+  run xrefcheck \
+    --ignored ./././././././//to-ignore \
+    --root .
+
+  assert_output --partial "All repository links are valid."
+}
+
+@test "Basic root, check errors report" {
+  xrefcheck \
+    --root . \
+    | prepare > /tmp/check-cli.test || true
+
+  diff /tmp/check-cli.test expected.gold \
+    --ignore-space-change \
+    --ignore-blank-lines \
+    --new-file # treat absent files as empty
+
+  rm /tmp/check-cli.test
+}
+
+@test "Root with redundant slashes, check errors report" {
+  xrefcheck \
+    --root ././///././././//./ \
+    | prepare > /tmp/check-cli.test || true
+
+  diff /tmp/check-cli.test expected.gold \
+    --ignore-space-change \
+    --ignore-blank-lines \
+    --new-file # treat absent files as empty
+
+  rm /tmp/check-cli.test
+}
+
+@test "No root, check errors report" {
+  xrefcheck \
+    | prepare > /tmp/check-cli.test || true
+
+  diff /tmp/check-cli.test expected.gold \
+    --ignore-space-change \
+    --ignore-blank-lines \
+    --new-file # treat absent files as empty
+
+  rm /tmp/check-cli.test
+}

--- a/tests/golden/check-cli/config-no-scan-ignored.yaml
+++ b/tests/golden/check-cli/config-no-scan-ignored.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2021 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: Unlicense
+
+traversal:
+  ignored: []
+
+verification:
+  anchorSimilarityThreshold: 0.5
+  externalRefCheckTimeout: 10s
+  notScanned: [ "to-ignore/broken-link.md" ]
+  virtualFiles: []
+  ignoreRefs: []
+  checkLocalhost: false
+  ignoreAuthFailures: true
+
+scanners:
+  markdown:
+    flavor: GitHub

--- a/tests/golden/check-cli/expected.gold
+++ b/tests/golden/check-cli/expected.gold
@@ -1,0 +1,13 @@
+=== Invalid references found ===
+
+  ➥  In file to-ignore/broken-link.md
+     bad reference (absolute) at src:7:1-25:
+       - text: "my link"
+       - link: /one/two/three
+       - anchor: -
+
+     ⛀  File does not exist:
+        ./one/two/three
+
+
+Invalid references dumped, 1 in total.

--- a/tests/golden/check-cli/expected.gold.license
+++ b/tests/golden/check-cli/expected.gold.license
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+# SPDX-License-Identifier: Unlicense

--- a/tests/golden/check-cli/to-ignore/broken-link.md
+++ b/tests/golden/check-cli/to-ignore/broken-link.md
@@ -1,0 +1,7 @@
+<!--
+ - SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -->
+
+[my link](/one/two/three)

--- a/tests/golden/check-localhost/check-localhost.bats
+++ b/tests/golden/check-localhost/check-localhost.bats
@@ -4,36 +4,26 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-load 'helpers/bats-support/load'
-load 'helpers/bats-assert/load'
-
-# this function is used for:
-# - delete all color characters
-# - replace socket port with N
-# - replace multiple connection retry errors with single one
-#   (because at some machine there are one error and at others - two)
-prepare () {
-  sed -r "s/[[:cntrl:]]\[[0-9]{1,3}m//g" \
-    | sed 's/socket: [0-9]*/socket: N/g' \
-    | sed 's/Network.Socket.connect: <socket: N>: does not exist (Connection refused),//g'
-}
+load '../helpers/bats-support/load'
+load '../helpers/bats-assert/load'
+load '../helpers'
 
 @test "Config: check-localhost=false, CLA --check-localhost not provided" {
   run xrefcheck \
-    -c check-localhost/config-check-disabled.yaml \
-    -r check-localhost
+    -c config-check-disabled.yaml \
+    -r .
 
   assert_output --partial "All repository links are valid."
 }
 
 @test "Config: check-localhost=false, CLA --check-localhost provided" {
   xrefcheck \
-    -c check-localhost/config-check-disabled.yaml \
-    -r check-localhost \
+    -c config-check-disabled.yaml \
+    -r . \
     --check-localhost \
     | prepare > /tmp/check-localhost.test || true
 
-  diff /tmp/check-localhost.test check-localhost/expected.gold \
+  diff /tmp/check-localhost.test expected.gold \
     --ignore-space-change \
     --ignore-blank-lines \
     --new-file # treat absent files as empty
@@ -43,11 +33,11 @@ prepare () {
 
 @test "Config: check-localhost=true, CLA --check-localhost not provided" {
   xrefcheck \
-    -c check-localhost/config-check-enabled.yaml \
-    -r check-localhost \
+    -c config-check-enabled.yaml \
+    -r . \
     | prepare > /tmp/check-localhost.test || true
 
-  diff /tmp/check-localhost.test check-localhost/expected.gold \
+  diff /tmp/check-localhost.test expected.gold \
     --ignore-space-change \
     --ignore-blank-lines \
     --new-file # treat absent files as empty
@@ -57,12 +47,12 @@ prepare () {
 
 @test "Config: check-localhost=true, CLA --check-localhost provided" {
   xrefcheck \
-    -c check-localhost/config-check-enabled.yaml \
-    -r check-localhost \
+    -c config-check-enabled.yaml \
+    -r . \
     --check-localhost \
     | prepare > /tmp/check-localhost.test || true
 
-  diff /tmp/check-localhost.test check-localhost/expected.gold \
+  diff /tmp/check-localhost.test expected.gold \
     --ignore-space-change \
     --ignore-blank-lines \
     --new-file # treat absent files as empty
@@ -81,7 +71,7 @@ prepare () {
     --check-localhost \
     | prepare > /tmp/check-localhost.test || true
 
-  diff /tmp/check-localhost.test check-localhost/expected.gold \
+  diff /tmp/check-localhost.test expected.gold \
     --ignore-space-change \
     --ignore-blank-lines \
     --new-file # treat absent files as empty

--- a/tests/golden/check-localhost/expected.gold
+++ b/tests/golden/check-localhost/expected.gold
@@ -1,6 +1,6 @@
 === Invalid references found ===
 
-  ➥  In file ./check-localhost/check-localhost.md
+  ➥  In file check-localhost.md
      bad reference (external) at src:7:10-47:
        - text: "web-site"
        - link: https://localhost/web-site
@@ -10,7 +10,7 @@
 
 
 
-  ➥  In file ./check-localhost/check-localhost.md
+  ➥  In file check-localhost.md
      bad reference (external) at src:9:10-39:
        - text: "team"
        - link: https://127.0.0.1/team
@@ -20,7 +20,7 @@
 
 
 
-  ➥  In file ./check-localhost/check-localhost.md
+  ➥  In file check-localhost.md
      bad reference (external) at src:11:10-38:
        - text: "blog"
        - link: http://localhost/blog
@@ -30,7 +30,7 @@
 
 
 
-  ➥  In file ./check-localhost/check-localhost.md
+  ➥  In file check-localhost.md
      bad reference (external) at src:13:10-38:
        - text: "labs"
        - link: http://127.0.0.1/labs

--- a/tests/golden/helpers.bash
+++ b/tests/golden/helpers.bash
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+setup () {
+  # change working directory to the location of the running `bats` suite.
+  cd "$( dirname "$BATS_TEST_FILENAME")"
+}
+
+# this function is used for:
+# - delete all color characters
+# - replace socket port with N
+# - replace multiple connection retry errors with single one
+#   (because at some machine there are one error and at others - two)
+prepare () {
+  sed -r "s/[[:cntrl:]]\[[0-9]{1,3}m//g" \
+    | sed 's/socket: [0-9]*/socket: N/g' \
+    | sed 's/Network.Socket.connect: <socket: N>: does not exist (Connection refused),//g'
+}


### PR DESCRIPTION
## Description

We used strings equality on file path, but we can have different strings for the same path, for example `./` and `././`, so I added path normalisation at code where we compare them.

Happily, in 9.6 will be new opaque FilePath type, so nobody will use (==) from strings on them.

## Related issue(s)

- Fixed #106

