### PR TITLE
[#103] Specify port in golden test links instead of default one

### DIFF
--- a/tests/golden/check-localhost/check-localhost.md
+++ b/tests/golden/check-localhost/check-localhost.md
@@ -4,10 +4,10 @@
  - SPDX-License-Identifier: MPL-2.0
  -->
 
-Serokell [web-site](https://localhost/web-site)
+Serokell [web-site](https://localhost:20000/web-site)
 
-Serokell [team](https://127.0.0.1/team)
+Serokell [team](https://127.0.0.1:20000/team)
 
-Serokell [blog](http://localhost/blog)
+Serokell [blog](http://localhost:20000/blog)
 
-Serokell [labs](http://127.0.0.1/labs)
+Serokell [labs](http://127.0.0.1:20000/labs)

--- a/tests/golden/check-localhost/expected.gold
+++ b/tests/golden/check-localhost/expected.gold
@@ -1,9 +1,9 @@
 === Invalid references found ===
 
   ➥  In file check-localhost.md
-     bad reference (external) at src:7:10-47:
+     bad reference (external) at src:7:10-53:
        - text: "web-site"
-       - link: https://localhost/web-site
+       - link: https://localhost:20000/web-site
        - anchor: -
 
      ⛂  InternalException (HostCannotConnect "localhost" [Network.Socket.connect: <socket: N>: does not exist (Connection refused)])
@@ -11,9 +11,9 @@
 
 
   ➥  In file check-localhost.md
-     bad reference (external) at src:9:10-39:
+     bad reference (external) at src:9:10-45:
        - text: "team"
-       - link: https://127.0.0.1/team
+       - link: https://127.0.0.1:20000/team
        - anchor: -
 
      ⛂  InternalException (HostCannotConnect "127.0.0.1" [Network.Socket.connect: <socket: N>: does not exist (Connection refused)])
@@ -21,9 +21,9 @@
 
 
   ➥  In file check-localhost.md
-     bad reference (external) at src:11:10-38:
+     bad reference (external) at src:11:10-44:
        - text: "blog"
-       - link: http://localhost/blog
+       - link: http://localhost:20000/blog
        - anchor: -
 
      ⛂  ConnectionFailure Network.Socket.connect: <socket: N>: does not exist (Connection refused)
@@ -31,9 +31,9 @@
 
 
   ➥  In file check-localhost.md
-     bad reference (external) at src:13:10-38:
+     bad reference (external) at src:13:10-44:
        - text: "labs"
-       - link: http://127.0.0.1/labs
+       - link: http://127.0.0.1:20000/labs
        - anchor: -
 
      ⛂  ConnectionFailure Network.Socket.connect: <socket: N>: does not exist (Connection refused)


### PR DESCRIPTION

## Description

Added 20000 port to all links in golden tests and updated expectation

## Related issue(s)

- Fixed #103 by adding ports