### PR TITLE
[#113] Improve error message of dump-config option

### DIFF
--- a/src/Xrefcheck/CLI.hs
+++ b/src/Xrefcheck/CLI.hs
@@ -188,12 +188,14 @@ dumpConfigOptions = hsubparser $
   where
     parser = DumpConfig <$> repoTypeOption <*> outputOption
 
+    allRepoTypes = "(" <> intercalate " | " (map (show @String) allFlavors) <> ")"
+
     repoTypeOption =
       option repoTypeReadM $
       short 't' <>
       long "type" <>
       metavar "REPOSITORY TYPE" <>
-      help "Git repository type."
+      help ("Git repository type. Can be " <> allRepoTypes <> ". Case insensitive.")
 
     outputOption =
       filepathOption $


### PR DESCRIPTION

## Description

Updated help message. Now list of git repository types is listed separated by |. allFlaviors is chosen as source of truth in this case.

## Related issue(s)

- Fixed #113 
