### PR TITLE
[#95] Support HTML tag parsing compatible with HTML spec

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -101,6 +101,7 @@ library:
     - regex-tdfa
     - req
     - roman-numerals
+    - tagsoup
     - text
     - text-metrics
     - th-lift-instances

--- a/tests/golden/check-html/check-html.md
+++ b/tests/golden/check-html/check-html.md
@@ -1,0 +1,13 @@
+<!--
+ - SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -->
+
+## <a name='one'> <a name=two> <a NAME="three"> <a name="four"></a> <a     NAME=five   >  Title1
+
+[One](#one)
+[Two](#two)
+[Three](#three)
+[Four](#four)
+[Five](#five)

--- a/tests/golden/check-html/check.html.bats
+++ b/tests/golden/check-html/check.html.bats
@@ -1,0 +1,16 @@
+#!/usr/bin/env bats
+
+# SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+load '../helpers/bats-support/load'
+load '../helpers/bats-assert/load'
+load '../helpers'
+
+
+@test "All HTML anchors should be valid" {
+  run xrefcheck
+
+  assert_output --partial "All repository links are valid."
+}


### PR DESCRIPTION

## Description

Replace manual parsing using Text combinators with tagsoup library, that takes care about compatibility with HTML specification.

## Related issue(s)


- Fixed #95 
