### PR TITLE
[#49] Allow certain reserved characters in the URLs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,12 +25,14 @@ Unreleased
   + Add the duplication detection & verification result caching algorithm for external references.
 * [#82](https://github.com/serokell/xrefcheck/pull/82)
   + Fix the issue of having the lowest level context duplicated, caused by the root's trailing path separator.
-* [#31](https://github.com/serokell/xrefcheck/pull/88)
+* [#88](https://github.com/serokell/xrefcheck/pull/88)
   + Handle the "429 too many requests" errors & attempt to eliminate them during verification.
 * [#128](https://github.com/serokell/xrefcheck/pull/128)
   + Make `ignoreRefs` a required parameter.
 * [#129](https://github.com/serokell/xrefcheck/pull/129)
-  + Add support for the `id` attribute in anchors
+  + Add support for the `id` attribute in anchors.
+* [#116](https://github.com/serokell/xrefcheck/pull/116)
+  + Allow certain reserved characters to be present in the query strings of the URLs.
 
 0.2.1
 ==========

--- a/package.yaml
+++ b/package.yaml
@@ -107,6 +107,7 @@ library:
     - th-lift-instances
     - time
     - universum
+    - uri-bytestring
     - yaml
 
 executables:
@@ -149,6 +150,7 @@ tests:
       - regex-tdfa
       - time
       - universum
+      - modern-uri
       - yaml
     build-tools:
       - hspec-discover

--- a/tests/Test/Xrefcheck/URIParsingSpec.hs
+++ b/tests/Test/Xrefcheck/URIParsingSpec.hs
@@ -1,0 +1,44 @@
+{- SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -}
+
+{-# LANGUAGE QuasiQuotes #-}
+
+module Test.Xrefcheck.URIParsingSpec where
+
+import Universum
+
+import Test.Hspec (Spec, describe, it, shouldReturn)
+import Text.URI (URI)
+import Text.URI.QQ (uri)
+
+import Xrefcheck.Verify (parseUri, VerifyError (..))
+
+spec :: Spec
+spec = do
+  describe "URI parsing should be successful" $ do
+    it "Without the special characters in the query strings" do
+      parseUri' "https://example.com/?q=a&p=b#fragment" `shouldReturn`
+        Right [uri|https://example.com/?q=a&p=b#fragment|]
+
+      parseUri' "https://example.com/path/to/smth?q=a&p=b" `shouldReturn`
+        Right [uri|https://example.com/path/to/smth?q=a&p=b|]
+
+    it "With the special characters in the query strings" do
+      parseUri' "https://example.com/?q=[a]&<p>={b}#fragment" `shouldReturn`
+        Right [uri|https://example.com/?q=%5Ba%5D&%3Cp%3E=%7Bb%7D#fragment|]
+
+      parseUri' "https://example.com/path/to/smth?q=[a]&<p>={b}" `shouldReturn`
+        Right [uri|https://example.com/path/to/smth?q=%5Ba%5D&%3Cp%3E=%7Bb%7D|]
+
+  describe "URI parsing should be unsuccessful" $ do
+    it "With the special characters anywhere else" do
+      parseUri' "https://exa<mple.co>m/?q=a&p=b#fra{g}ment" `shouldReturn`
+        Left ExternalResourceInvalidUri
+
+      parseUri' "https://example.com/pa[t]h/to[/]smth?q=a&p=b" `shouldReturn`
+        Left ExternalResourceInvalidUri
+  where
+    parseUri' :: Text -> IO $ Either VerifyError URI
+    parseUri' = runExceptT . parseUri


### PR DESCRIPTION
## Description

Problem: The current version of xrefcheck doesn't allow the square
brackets and some other special characters, like the angle brackets and
the curly brackets, to be present in the URLs, even in the query
strings, as they need to be percent-encoded first.

Solution: Allow some of the reserved characters, like the brackets, to
be present in the query strings of the URLs.
There exist two main standards of URL parsing: RFC 3986 and the Web
Hypertext Application Technology Working Group's URL standard. Ideally,
we want to be able to parse the URLs in accordance with the latter
standard, because it provides a much less ambiguous set of rules for
percent-encoding special characters, and is essentially a living
standard that gets updated constantly.
We allow these characters to be present in the query strings by using
the `parseURI` function from the `uri-bytestring` library with
`laxURIParseOptions`.

## Related issue(s)

Fixes #49

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](/README.md)
    - Haddock

- Public contracts
  - [ ] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](/docs/code-style.md).
