### PR TITLE
[#99] Support `Retry-After` headers with dates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 
 Unreleased
 ==========
+* [#127](https://github.com/serokell/xrefcheck/pull/127)
+  + Support `Retry-After` headers with dates.
 * [#117](https://github.com/serokell/xrefcheck/pull/117)
   + Forbid verifying a single file using `--root` command line option.
 * [#115](https://github.com/serokell/xrefcheck/pull/115)

--- a/src/Xrefcheck/Util.hs
+++ b/src/Xrefcheck/Util.hs
@@ -13,6 +13,7 @@ module Xrefcheck.Util
   , aesonConfigOption
   , normaliseWithNoTrailing
   , posixTimeToTimeSecond
+  , utcTimeToTimeSecond
   ) where
 
 import Universum
@@ -22,8 +23,9 @@ import Data.Aeson qualified as Aeson
 import Data.Aeson.Casing (aesonPrefix, camelCase)
 import Data.Fixed (Fixed (MkFixed), HasResolution (resolution))
 import Data.Ratio ((%))
+import Data.Time (UTCTime)
 import Data.Time.Clock (nominalDiffTimeToSeconds)
-import Data.Time.Clock.POSIX (POSIXTime)
+import Data.Time.Clock.POSIX (POSIXTime, utcTimeToPOSIXSeconds)
 import Fmt (Builder, build, fmt, nameF)
 import System.Console.Pretty (Pretty (..), Style (Faint))
 import System.FilePath (dropTrailingPathSeparator, normalise)
@@ -59,3 +61,6 @@ posixTimeToTimeSecond :: POSIXTime -> Time Second
 posixTimeToTimeSecond posixTime =
   let picos@(MkFixed ps) = nominalDiffTimeToSeconds posixTime
   in sec . fromRational $ ps % resolution picos
+
+utcTimeToTimeSecond :: UTCTime -> Time Second
+utcTimeToTimeSecond = posixTimeToTimeSecond . utcTimeToPOSIXSeconds


### PR DESCRIPTION
This adds some bytes to parse `Retry-After` headers as dates for `429: Too many requests`

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #1 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Fixes #99 

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](/README.md)
    - Haddock

- Public contracts
  - [ ] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [ ] I added an entry to the [changelog](/CHANGES.md) if my changes are visible to the users
        and
  - [ ] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](/docs/code-style.md).
