### PR TITLE
[#126] Make `ignoreRefs` a required parameter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,8 @@ Unreleased
   + Fix the issue of having the lowest level context duplicated, caused by the root's trailing path separator.
 * [#31](https://github.com/serokell/xrefcheck/pull/88)
   + Handle the "429 too many requests" errors & attempt to eliminate them during verification.
+* [#128](https://github.com/serokell/xrefcheck/pull/128)
+  + Make `ignoreRefs` a required parameter.
 
 0.2.1
 ==========

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ xrefcheck --help
 
   If you want some external links to not be verified, you can use one of the following ways to ignore those links:
 
-1. Add the regular expression that matches the ignoring link to the optional `ignoreRefs` parameter of your config file.
+1. Add the regular expression that matches the ignoring link to the `ignoreRefs` parameter of your config file.
 
     For example:
     ```yaml

--- a/src/Xrefcheck/Config.hs
+++ b/src/Xrefcheck/Config.hs
@@ -55,7 +55,7 @@ data VerifyConfig = VerifyConfig
     -- ^ Files which we pretend do exist.
   , vcNotScanned                :: [FilePath]
     -- ^ Prefixes of files, references in which we should not analyze.
-  , vcIgnoreRefs                :: Maybe [Regex]
+  , vcIgnoreRefs                :: [Regex]
     -- ^ Regular expressions that match external references we should not verify.
   , vcCheckLocalhost            :: Bool
     -- ^ If True - we will check localhost links.

--- a/src/Xrefcheck/Config/Default.hs
+++ b/src/Xrefcheck/Config/Default.hs
@@ -45,7 +45,6 @@ verification:
 
   # POSIX extended regular expressions that match external references
   # that have to be ignored (not verified).
-  # It is an optional parameter, so it can be omitted.
   ignoreRefs: []
 
   # Check localhost links.

--- a/src/Xrefcheck/Verify.hs
+++ b/src/Xrefcheck/Verify.hs
@@ -434,7 +434,7 @@ checkExternalResource VerifyConfig{..} link
   where
     skipCheck = isIgnored || (not vcCheckLocalhost && isLocalLink)
       where
-        isIgnored =  maybe False (doesMatchAnyRegex link) vcIgnoreRefs
+        isIgnored = doesMatchAnyRegex link vcIgnoreRefs
         isLocalLink = any (`T.isInfixOf` link) ["://localhost", "://127.0.0.1"]
 
     doesMatchAnyRegex :: Text -> ([Regex] -> Bool)

--- a/tests/Test/Xrefcheck/IgnoreRegexSpec.hs
+++ b/tests/Test/Xrefcheck/IgnoreRegexSpec.hs
@@ -77,11 +77,10 @@ spec = do
             Just neWithRefLoc -> map (rLink . wrlReference) $ toList neWithRefLoc
             Nothing -> []
 
-      linksToRegexs :: [Text] -> Maybe [Regex]
+      linksToRegexs :: [Text] -> [Regex]
       linksToRegexs links =
         let errOrRegexs = map (decodeEither' . encodeUtf8) links
-            maybeRegexs = map (either (error . show) Just) errOrRegexs
-        in sequence maybeRegexs
+        in map (either (error . show) id) errOrRegexs
 
-      setIgnoreRefs :: Maybe [Regex] -> Config -> Config
+      setIgnoreRefs :: [Regex] -> Config -> Config
       setIgnoreRefs regexs = (cVerificationL . vcIgnoreRefsL) .~ regexs

--- a/tests/configs/github-config.yaml
+++ b/tests/configs/github-config.yaml
@@ -36,7 +36,6 @@ verification:
 
   # POSIX extended regular expressions that match external references
   # that have to be ignored (not verified).
-  # It is an optional parameter, so it can be omitted.
   ignoreRefs: []
 
   # Check localhost links.


### PR DESCRIPTION
## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->
Makes `ignoreRefs` a required parameter in the config file.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #1 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Fixes #126

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](/README.md)
    - Haddock

- Public contracts
  - [ ] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](/CHANGES.md) if my changes are visible to the users
        and
  - [ ] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [ ] My code complies with the [style guide](/docs/code-style.md).
