### PR TITLE
[#94] Add support for the `id` attribute in anchors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,8 @@ Unreleased
   + Handle the "429 too many requests" errors & attempt to eliminate them during verification.
 * [#128](https://github.com/serokell/xrefcheck/pull/128)
   + Make `ignoreRefs` a required parameter.
+* [#129](https://github.com/serokell/xrefcheck/pull/129)
+  + Add support for the `id` attribute in anchors
 
 0.2.1
 ==========

--- a/src/Xrefcheck/Scanners/Markdown.hs
+++ b/src/Xrefcheck/Scanners/Markdown.hs
@@ -154,7 +154,7 @@ nodeExtractInfo input@(Node _ _ nSubs) = do
                 TagOpen a attrs
                   | T.toLower a == "a" -> Just attrs
                 _ -> Nothing
-              (_, name) <- find (\(field, _) -> T.toLower field == "name") attributes
+              (_, name) <- find (\(field, _) -> T.toLower field `elem` ["name", "id"]) attributes
               pure name
 
           case mName of

--- a/tests/Test/Xrefcheck/AnchorsInHeadersSpec.hs
+++ b/tests/Test/Xrefcheck/AnchorsInHeadersSpec.hs
@@ -19,6 +19,10 @@ spec = do
         it "Check if anchors in headers are recognized" $ do
             fi <- getFI "tests/markdowns/without-annotations/anchors_in_headers.md"
             getAnchors fi `shouldBe` ["some-stuff", "stuff-section"]
+
+        it "Check if anchors with id attributes are recognized" $ do
+            fi <- getFI "tests/markdowns/without-annotations/anchors_in_headers_with_id_attribute.md"
+            getAnchors fi `shouldBe` ["some-stuff-with-id-attribute", "stuff-section-with-id-attribute"]
     where
         parse :: FilePath -> IO (Either Text FileInfo)
         parse path =

--- a/tests/markdowns/without-annotations/anchors_in_headers_with_id_attribute.md
+++ b/tests/markdowns/without-annotations/anchors_in_headers_with_id_attribute.md
@@ -1,0 +1,9 @@
+<!--
+ - SPDX-FileCopyrightText: 2018-2019 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -->
+
+## <a id="stuff-section-with-id-attribute"></a> Some stuff with id attribute
+
+[My link](#stuff-section-with-id-attribute)


### PR DESCRIPTION
## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->
Add support for the `id` attribute, while retaining support for the `name` attribute.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #1 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Fixes #94

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](/README.md)
    - Haddock

- Public contracts
  - [ ] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](/CHANGES.md) if my changes are visible to the users
        and
  - [ ] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [ ] My code complies with the [style guide](/docs/code-style.md).
