### PR TITLE
[#77] Add support for glob patterns to `ignored` and `notScanned`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -22,7 +22,7 @@ steps:
     artifact_paths:
       - "result/bin/*"
 
-  - command: nix run -f ci.nix xrefcheck-static -c xrefcheck --ignored tests/markdowns --ignored tests/golden/
+  - command: nix run -f ci.nix xrefcheck-static -c xrefcheck --ignored 'tests/**/*'
     label: Xrefcheck itself
 
   - label: lint

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,10 @@ Unreleased
   + Fixed bug with ignoring checks for relative anchors.
 * [#132](https://github.com/serokell/xrefcheck/pull/132)
   + Display URL parsing errors.
+* [#131](https://github.com/serokell/xrefcheck/pull/131)
+  + Add support for glob patterns to `ignored` and `notScanned`.
+  + Remove support for directory names from `ignored` and `notScanned`.
+  + Fix bug with `ignored` not ignoring files with broken xrefcheck annotations.
 
 0.2.1
 ==========

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ xrefcheck dump-config -t GitHub
 
 Currently supported options include:
 * Timeout for checking external references;
-* List of ignored folders.
+* List of ignored files.
 
 ## Build instructions [↑](#xrefcheck)
 

--- a/src/Xrefcheck/CLI.hs
+++ b/src/Xrefcheck/CLI.hs
@@ -37,6 +37,7 @@ import Xrefcheck.Config (VerifyConfig (..))
 import Xrefcheck.Core
 import Xrefcheck.Scan
 import Xrefcheck.Util (normaliseWithNoTrailing)
+import Xrefcheck.System (RelGlobPattern (..))
 
 modeReadM :: ReadM VerifyMode
 modeReadM = eitherReader $ \s ->
@@ -78,7 +79,7 @@ data Options = Options
   }
 
 data TraversalOptions = TraversalOptions
-  { toIgnored :: [FilePath]
+  { toIgnored :: [RelGlobPattern]
   }
 
 addTraversalOptions :: TraversalConfig -> TraversalOptions -> TraversalConfig
@@ -114,6 +115,9 @@ type RepoType = Flavor
 
 filepathOption :: Mod OptionFields FilePath -> Parser FilePath
 filepathOption = fmap normaliseWithNoTrailing <$> strOption
+
+globOption :: Mod OptionFields FilePath -> Parser RelGlobPattern
+globOption = fmap RelGlobPattern <$> filepathOption
 
 repoTypeReadM :: ReadM RepoType
 repoTypeReadM = eitherReader $ \name ->
@@ -174,10 +178,12 @@ optionsParser = do
 
 traversalOptionsParser :: Parser TraversalOptions
 traversalOptionsParser = do
-  toIgnored <- many . filepathOption $
+  toIgnored <- many . globOption $
     long "ignored" <>
-    metavar "FILEPATH" <>
-    help "Files and folders which we pretend do not exist."
+    metavar "GLOB PATTERN" <>
+    help "Files which we pretend do not exist.\
+         \ Glob patterns that contain wildcards MUST be enclosed\
+         \ in quotes to avoid being expanded by shell."
   return TraversalOptions{..}
 
 verifyOptionsParser :: Parser VerifyOptions

--- a/src/Xrefcheck/Config.hs
+++ b/src/Xrefcheck/Config.hs
@@ -28,7 +28,7 @@ import Xrefcheck.Core
 import Xrefcheck.Scan
 import Xrefcheck.Scanners.Markdown
 import Xrefcheck.System (RelGlobPattern, normaliseGlobPattern)
-import Xrefcheck.Util (aesonConfigOption, postfixFields, (-:), normaliseWithNoTrailing)
+import Xrefcheck.Util (aesonConfigOption, postfixFields, (-:))
 import Xrefcheck.Config.Default
 import Text.Regex.TDFA.Common
 
@@ -53,8 +53,8 @@ data VerifyConfig = VerifyConfig
   , vcExternalRefCheckTimeout   :: Time Second
   , vcVirtualFiles              :: [RelGlobPattern]
     -- ^ Files which we pretend do exist.
-  , vcNotScanned                :: [FilePath]
-    -- ^ Prefixes of files, references in which we should not analyze.
+  , vcNotScanned                :: [RelGlobPattern]
+    -- ^ Files, references in which we should not analyze.
   , vcIgnoreRefs                :: [Regex]
     -- ^ Regular expressions that match external references we should not verify.
   , vcCheckLocalhost            :: Bool
@@ -72,7 +72,7 @@ normaliseVerifyConfigFilePaths :: VerifyConfig -> VerifyConfig
 normaliseVerifyConfigFilePaths vc@VerifyConfig{ vcVirtualFiles, vcNotScanned}
   = vc
     { vcVirtualFiles = map normaliseGlobPattern vcVirtualFiles
-    , vcNotScanned = map normaliseWithNoTrailing vcNotScanned
+    , vcNotScanned = map normaliseGlobPattern vcNotScanned
     }
 
 -- | Configs for all the supported scanners.
@@ -167,12 +167,12 @@ defConfigText flavor =
         GitHub ->
           [ ".github/pull_request_template.md"
           , ".github/issue_template.md"
-          , ".github/PULL_REQUEST_TEMPLATE"
-          , ".github/ISSUE_TEMPLATE"
+          , ".github/PULL_REQUEST_TEMPLATE/**/*"
+          , ".github/ISSUE_TEMPLATE/**/*"
           ]
         GitLab ->
-          [ ".gitlab/merge_request_templates/"
-          , ".gitlab/issue_templates/"
+          [ ".gitlab/merge_request_templates/**/*"
+          , ".gitlab/issue_templates/**/*"
           ]
 
     , "virtualFiles" -: Right $ case flavor of

--- a/src/Xrefcheck/Config/Default.hs
+++ b/src/Xrefcheck/Config/Default.hs
@@ -15,14 +15,14 @@ defConfigUnfilled :: ByteString
 defConfigUnfilled =
   [r|# Parameters of repository traversal.
 traversal:
-  # Files and folders which we pretend do not exist
+  # Glob patterns describing files which we pretend do not exist
   # (so they are neither analyzed nor can be referenced).
   ignored:
     # Git files
-    - .git
+    - .git/**/*
 
     # Stack files
-    - .stack-work
+    - .stack-work/**/*
 
 # Verification parameters.
 verification:
@@ -34,7 +34,7 @@ verification:
   # declaring "Response timeout".
   externalRefCheckTimeout: 10s
 
-  # Prefixes of files, references in which should not be analyzed.
+  # Glob patterns describing the files, references in which should not be analyzed.
   notScanned:
     - :PLACEHOLDER:notScanned:
 

--- a/src/Xrefcheck/System.hs
+++ b/src/Xrefcheck/System.hs
@@ -9,6 +9,7 @@ module Xrefcheck.System
   , RelGlobPattern (..)
   , normaliseGlobPattern
   , bindGlobPattern
+  , matchesGlobPatterns
   ) where
 
 import Universum
@@ -51,6 +52,14 @@ bindGlobPattern root (RelGlobPattern relPat) = readingSystem $ do
       "Glob pattern compilation failed after canonicalization: " <> toText err
     Right pat ->
       return pat
+
+matchesGlobPatterns :: FilePath -> [RelGlobPattern] -> FilePath -> Bool
+matchesGlobPatterns root globPatterns file = or
+  [ Glob.match pat cFile
+  | globPattern <- globPatterns
+  , let pat = bindGlobPattern root globPattern
+  , let cFile = readingSystem $ canonicalizePath file
+  ]
 
 instance FromJSON RelGlobPattern where
   parseJSON = withText "Repo-relative glob pattern" $ \path -> do

--- a/tests/configs/github-config.yaml
+++ b/tests/configs/github-config.yaml
@@ -1,13 +1,13 @@
 # Parameters of repository traversal.
 traversal:
-  # Files and folders which we pretend do not exist
+  # Glob patterns describing files which we pretend do not exist
   # (so they are neither analyzed nor can be referenced).
   ignored:
     # Git files
-    - .git
+    - .git/**/*
 
     # Stack files
-    - .stack-work
+    - .stack-work/**/*
 
 # Verification parameters.
 verification:
@@ -19,12 +19,12 @@ verification:
   # declaring "Response timeout".
   externalRefCheckTimeout: 10s
 
-  # Prefixes of files, references in which should not be analyzed.
+  # Glob patterns describing the files, references in which should not be analyzed.
   notScanned:
     - .github/pull_request_template.md
     - .github/issue_template.md
-    - .github/PULL_REQUEST_TEMPLATE
-    - .github/ISSUE_TEMPLATE
+    - .github/PULL_REQUEST_TEMPLATE/**/*
+    - .github/ISSUE_TEMPLATE/**/*
 
   # Glob patterns describing the files which do not physically exist in the
   # repository but should be treated as existing nevertheless.

--- a/tests/golden/check-cli/check-cli.bats
+++ b/tests/golden/check-cli/check-cli.bats
@@ -10,7 +10,7 @@ load '../helpers'
 
 @test "No redundant slashes" {
   run xrefcheck \
-    --ignored to-ignore \
+    --ignored to-ignore/* \
     --root .
 
   assert_output --partial "All repository links are valid."
@@ -18,7 +18,7 @@ load '../helpers'
 
 @test "Redundant slashes in root and ignored" {
   run xrefcheck \
-    --ignored ./././././././//to-ignore \
+    --ignored ./././././././//to-ignore/* \
     --root ./
 
   assert_output --partial "All repository links are valid."
@@ -34,7 +34,7 @@ load '../helpers'
 
 @test "Reduchant slashes in ignored" {
   run xrefcheck \
-    --ignored ./././././././//to-ignore \
+    --ignored ./././././././//to-ignore/* \
     --root .
 
   assert_output --partial "All repository links are valid."

--- a/tests/golden/check-ignored/check-ignored.bats
+++ b/tests/golden/check-ignored/check-ignored.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+
+# SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+load '../helpers/bats-support/load'
+load '../helpers/bats-assert/load'
+load '../helpers'
+
+
+@test "Ignore file with broken xrefcheck annotation: full path" {
+  run xrefcheck --ignored ./to-ignore/inner-directory/broken_annotation.md
+
+  assert_output --partial "All repository links are valid."
+}
+
+@test "Ignore file with broken xrefcheck annotation: glob wildcard" {
+  run xrefcheck --ignored 'to-ignore/inner-directory/*'
+
+  assert_output --partial "All repository links are valid."
+}
+
+@test "Ignore file with broken xrefcheck annotation: nested directories with glob wildcard" {
+  run xrefcheck --ignored './**/*'
+
+  assert_output --partial "All repository links are valid."
+}
+
+@test "Ignore file with broken xrefcheck annotation: config file" {
+  run xrefcheck --config ./config-ignored.yaml
+
+  assert_output --partial "All repository links are valid."
+}
+
+@test "Ignore file with broken xrefcheck annotation: directory, check filure" {
+  run xrefcheck --ignored ./to-ignore/inner-directory/
+
+  assert_output --partial "Error when scanning ./to-ignore/inner-directory/broken_annotation.md"
+}

--- a/tests/golden/check-ignored/config-ignored.yaml
+++ b/tests/golden/check-ignored/config-ignored.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: Unlicense
+
+traversal:
+  ignored:
+    - ./to-ignore/inner-directory/broken_annotation.md
+
+verification:
+  anchorSimilarityThreshold: 0.5
+  externalRefCheckTimeout: 10s
+  notScanned: []
+  virtualFiles: []
+  ignoreRefs: []
+  checkLocalhost: true
+  ignoreAuthFailures: true
+  defaultRetryAfter: 30s
+  maxRetries: 3
+
+scanners:
+  markdown:
+    flavor: GitHub

--- a/tests/golden/check-ignored/to-ignore/inner-directory/broken_annotation.md
+++ b/tests/golden/check-ignored/to-ignore/inner-directory/broken_annotation.md
@@ -1,0 +1,11 @@
+<!--
+ - SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -->
+
+One
+
+<!--xrefcheck: ignore file -->
+
+Two

--- a/tests/golden/check-notScanned/check-notScanned.bats
+++ b/tests/golden/check-notScanned/check-notScanned.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+
+# SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+load '../helpers/bats-support/load'
+load '../helpers/bats-assert/load'
+load '../helpers'
+
+
+@test "Not scanned: full path" {
+  run xrefcheck -c config-full-path.yaml
+
+  assert_output --partial "All repository links are valid."
+}
+
+@test "Not scanned: glob wildcard" {
+  run xrefcheck -c config-wildcard.yaml
+
+  assert_output --partial "All repository links are valid."
+}
+
+@test "Not scanned: nested directories with glob wildcard" {
+  run xrefcheck -c config-nested-directories.yaml
+
+  assert_output --partial "All repository links are valid."
+}
+
+@test "Not scanned: directory, check failure" {
+  xrefcheck -c config-directory.yaml \
+  | prepare > /tmp/check-notScanned.test || true
+
+  diff /tmp/check-notScanned.test expected.gold \
+    --ignore-space-change \
+    --ignore-blank-lines \
+    --new-file # treat absent files as empty
+
+  rm /tmp/check-notScanned.test
+}

--- a/tests/golden/check-notScanned/config-directory.yaml
+++ b/tests/golden/check-notScanned/config-directory.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: Unlicense
+
+traversal:
+  ignored: []
+
+verification:
+  anchorSimilarityThreshold: 0.5
+  externalRefCheckTimeout: 10s
+  notScanned:
+    - notScanned/inner-directory
+  virtualFiles: []
+  ignoreRefs: []
+  checkLocalhost: true
+  ignoreAuthFailures: true
+  defaultRetryAfter: 30s
+  maxRetries: 3
+
+scanners:
+  markdown:
+    flavor: GitHub

--- a/tests/golden/check-notScanned/config-full-path.yaml
+++ b/tests/golden/check-notScanned/config-full-path.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: Unlicense
+
+traversal:
+  ignored: []
+
+verification:
+  anchorSimilarityThreshold: 0.5
+  externalRefCheckTimeout: 10s
+  notScanned:
+    - ./notScanned/inner-directory/bad-reference.md
+  virtualFiles: []
+  ignoreRefs: []
+  checkLocalhost: true
+  ignoreAuthFailures: true
+  defaultRetryAfter: 30s
+  maxRetries: 3
+
+scanners:
+  markdown:
+    flavor: GitHub

--- a/tests/golden/check-notScanned/config-nested-directories.yaml
+++ b/tests/golden/check-notScanned/config-nested-directories.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: Unlicense
+
+traversal:
+  ignored: []
+
+verification:
+  anchorSimilarityThreshold: 0.5
+  externalRefCheckTimeout: 10s
+  notScanned:
+    - ./**/*
+  virtualFiles: []
+  ignoreRefs: []
+  checkLocalhost: true
+  ignoreAuthFailures: true
+  defaultRetryAfter: 30s
+  maxRetries: 3
+
+scanners:
+  markdown:
+    flavor: GitHub

--- a/tests/golden/check-notScanned/config-wildcard.yaml
+++ b/tests/golden/check-notScanned/config-wildcard.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: Unlicense
+
+traversal:
+  ignored: []
+
+verification:
+  anchorSimilarityThreshold: 0.5
+  externalRefCheckTimeout: 10s
+  notScanned:
+    - ./notScanned/inner-directory/*
+  virtualFiles: []
+  ignoreRefs: []
+  checkLocalhost: true
+  ignoreAuthFailures: true
+  defaultRetryAfter: 30s
+  maxRetries: 3
+
+scanners:
+  markdown:
+    flavor: GitHub

--- a/tests/golden/check-notScanned/expected.gold
+++ b/tests/golden/check-notScanned/expected.gold
@@ -1,0 +1,13 @@
+=== Invalid references found ===
+
+  ➥  In file notScanned/inner-directory/bad-reference.md
+     bad reference (absolute) at src:7:1-28:
+       - text: "Bad reference"
+       - link: /no-file.md
+       - anchor: -
+
+     ⛀  File does not exist:
+        ./no-file.md
+
+
+Invalid references dumped, 1 in total.

--- a/tests/golden/check-notScanned/notScanned/inner-directory/bad-reference.md
+++ b/tests/golden/check-notScanned/notScanned/inner-directory/bad-reference.md
@@ -1,0 +1,7 @@
+<!--
+ - SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -->
+
+[Bad reference](/no-file.md)


### PR DESCRIPTION
## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->
Problem: The `virtualFiles` config option supports glob patterns. On the
other hand, `ignored` only supports exact matches and `notScanned`
mathches on prefixes. There is also a bug where `ignored` does not
ignore files if they contain broken xrefcheck annotations.

Solution: Add support for glob patterns to `ignored` and
`notScanned`. Filter ignored files before parsing their contents.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #1 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Fixes #77

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](/README.md)
    - Haddock

- Public contracts
  - [ ] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](/CHANGES.md) if my changes are visible to the users
        and
  - [ ] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [ ] My code complies with the [style guide](/docs/code-style.md).
