### PR TITLE
[#76] Add tests for `virtualFiles` glob patterns 

### DIFF
--- a/tests/golden/check-virtualFiles/check-virtualFiles.bats
+++ b/tests/golden/check-virtualFiles/check-virtualFiles.bats
@@ -1,0 +1,27 @@
+#!/usr/bin/env bats
+
+# SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+load '../helpers/bats-support/load'
+load '../helpers/bats-assert/load'
+load '../helpers'
+
+
+@test "Virtual files: all references should be valid" {
+  run xrefcheck -c ./config-virtualFiles.yaml
+
+  assert_output --partial "All repository links are valid."
+}
+
+@test "Virtual files: check failure" {
+  xrefcheck | prepare > /tmp/check-virtualFiles.test || true
+
+  diff /tmp/check-virtualFiles.test expected.gold \
+    --ignore-space-change \
+    --ignore-blank-lines \
+    --new-file # treat absent files as empty
+
+  rm /tmp/check-virtualFiles.test
+}

--- a/tests/golden/check-virtualFiles/check-virtualFiles.md
+++ b/tests/golden/check-virtualFiles/check-virtualFiles.md
@@ -1,0 +1,15 @@
+<!--
+ - SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -->
+
+[full path](/one/a.md)
+
+[glob wildcard](/two/b.md)
+
+[recursive directory glob](/three/c.md)
+
+[recursive nested directory glob](/three/four/d.md)
+
+[another recursive nested directory glob](/three/five/e.md)

--- a/tests/golden/check-virtualFiles/config-virtualFiles.yaml
+++ b/tests/golden/check-virtualFiles/config-virtualFiles.yaml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: Unlicense
+
+traversal:
+  ignored: []
+
+verification:
+  anchorSimilarityThreshold: 0.5
+  externalRefCheckTimeout: 10s
+  notScanned: []
+  virtualFiles:
+    - ./one/a.md
+    - ./two/*
+    - ./three/**/*
+  ignoreRefs: []
+  checkLocalhost: true
+  ignoreAuthFailures: true
+  defaultRetryAfter: 30s
+  maxRetries: 3
+
+scanners:
+  markdown:
+    flavor: GitHub

--- a/tests/golden/check-virtualFiles/expected.gold
+++ b/tests/golden/check-virtualFiles/expected.gold
@@ -1,0 +1,73 @@
+=== Invalid references found ===
+
+  ➥  In file check-virtualFiles.md
+     bad reference (absolute) at src:7:1-22:
+       - text: "full path"
+       - link: /one/a.md
+       - anchor: -
+
+     ⛀  File does not exist:
+        ./one/a.md
+
+
+  ➥  In file check-virtualFiles.md
+     bad reference (absolute) at src:9:1-26:
+       - text: "glob wildcard"
+       - link: /two/b.md
+       - anchor: -
+
+     ⛀  File does not exist:
+        ./two/b.md
+
+
+  ➥  In file check-virtualFiles.md
+     bad reference (absolute) at src:11:1-39:
+       - text: "recursive directory glob"
+       - link: /three/c.md
+       - anchor: -
+
+     ⛀  File does not exist:
+        ./three/c.md
+
+
+  ➥  In file check-virtualFiles.md
+     bad reference (absolute) at src:13:1-51:
+       - text: "recursive nested directory glob"
+       - link: /three/four/d.md
+       - anchor: -
+
+     ⛀  File does not exist:
+        ./three/four/d.md
+
+
+  ➥  In file check-virtualFiles.md
+     bad reference (absolute) at src:15:1-59:
+       - text: "another recursive nested directory glob"
+       - link: /three/five/e.md
+       - anchor: -
+
+     ⛀  File does not exist:
+        ./three/five/e.md
+
+
+  ➥  In file one/file.md
+     bad reference (relative) at src:7:1-53:
+       - text: "check virtualFiles are relative to the root"
+       - link: ./a.md
+       - anchor: -
+
+     ⛀  File does not exist:
+        one/a.md
+
+
+  ➥  In file one/file.md
+     bad reference (relative) at src:9:1-23:
+       - text: "one more"
+       - link: ../two/b.md
+       - anchor: -
+
+     ⛀  File does not exist:
+        one/../two/b.md
+
+
+Invalid references dumped, 7 in total.

--- a/tests/golden/check-virtualFiles/one/file.md
+++ b/tests/golden/check-virtualFiles/one/file.md
@@ -1,0 +1,9 @@
+<!--
+ - SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -->
+
+[check virtualFiles are relative to the root](./a.md)
+
+[one more](../two/b.md)


### PR DESCRIPTION
## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->
Problem: The `virtualFiles` config allows the user to use glob patterns
to specify files that do not physically exist in the repository but
should be treated as existing nevertheless. However, we do not yet
have any around our usage of glob patterns. We should write some to
1) ensure it behaves in a sensible way even in corner cases and 2)
document  the behaviour.

Solution: Add tests that document how the `virtualFiles` glob paterns work.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #1 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Fixes #76 

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](/README.md)
    - Haddock

- Public contracts
  - [ ] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [ ] I added an entry to the [changelog](/CHANGES.md) if my changes are visible to the users
        and
  - [ ] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [ ] My code complies with the [style guide](/docs/code-style.md).
