### PR TITLE
[#56] Dump all the errors from different files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,9 @@ Unreleased
   + Add a regex matching localhost links to the `ignoreRefs` field of the default config.
 * [#68](https://github.com/serokell/xrefcheck/pull/68)
   + Recognise manual HTML-anchors inside headers.
+* [#141](https://github.com/serokell/xrefcheck/pull/141)
+  + Dump all the errors from different files.
+  + Fix bug where no errors were reported about broken link annotation and unrecognised annotation.
 
 0.2
 ==========

--- a/package.yaml
+++ b/package.yaml
@@ -107,6 +107,7 @@ library:
     - text-metrics
     - th-lift-instances
     - time
+    - transformers
     - universum
     - uri-bytestring
     - yaml
@@ -137,6 +138,7 @@ tests:
     dependencies:
       - case-insensitive
       - containers
+      - cmark-gfm
       - firefly
       - hspec
       - hspec-expectations

--- a/tests/Test/Xrefcheck/AnchorsInHeadersSpec.hs
+++ b/tests/Test/Xrefcheck/AnchorsInHeadersSpec.hs
@@ -7,31 +7,21 @@ module Test.Xrefcheck.AnchorsInHeadersSpec where
 
 import Universum
 
-import Data.ByteString.Lazy qualified as BSL
 import Test.Hspec (Spec, describe, it, shouldBe)
 
 import Xrefcheck.Core
-import Xrefcheck.Scanners.Markdown
+import Test.Xrefcheck.Util
 
 spec :: Spec
 spec = do
     describe "Anchors in headers" $ do
         it "Check if anchors in headers are recognized" $ do
-            fi <- getFI "tests/markdowns/without-annotations/anchors_in_headers.md"
+            fi <- getFI GitHub "tests/markdowns/without-annotations/anchors_in_headers.md"
             getAnchors fi `shouldBe` ["some-stuff", "stuff-section"]
 
         it "Check if anchors with id attributes are recognized" $ do
-            fi <- getFI "tests/markdowns/without-annotations/anchors_in_headers_with_id_attribute.md"
+            fi <- getFI GitHub "tests/markdowns/without-annotations/anchors_in_headers_with_id_attribute.md"
             getAnchors fi `shouldBe` ["some-stuff-with-id-attribute", "stuff-section-with-id-attribute"]
     where
-        parse :: FilePath -> IO (Either Text FileInfo)
-        parse path =
-            parseFileInfo defGithubMdConfig . decodeUtf8 <$> BSL.readFile path
-
-        getFI :: FilePath -> IO FileInfo
-        getFI path =
-            let errOrFI = parse path
-            in either error id <$> errOrFI
-
         getAnchors :: FileInfo -> [Text]
         getAnchors fi = map aName $ fi ^. fiAnchors

--- a/tests/Test/Xrefcheck/IgnoreRegexSpec.hs
+++ b/tests/Test/Xrefcheck/IgnoreRegexSpec.hs
@@ -15,7 +15,7 @@ import Text.Regex.TDFA (Regex)
 import Xrefcheck.Config
 import Xrefcheck.Core
 import Xrefcheck.Progress (allowRewrite)
-import Xrefcheck.Scan (gatherRepoInfo, specificFormatsSupport)
+import Xrefcheck.Scan (scanRepo, specificFormatsSupport, ScanResult (..))
 import Xrefcheck.Scanners.Markdown
 import Xrefcheck.Verify (VerifyError, VerifyResult, WithReferenceLoc (..), verifyErrors, verifyRepo)
 
@@ -35,11 +35,11 @@ spec = do
     let config = setIgnoreRefs regexs (defConfig GitHub)
 
     it "Check that only not matched links are verified" $ do
-      repoInfo <- allowRewrite showProgressBar $ \rw ->
-        gatherRepoInfo rw formats (config ^. cTraversalL) root
+      scanResult <- allowRewrite showProgressBar $ \rw ->
+        scanRepo rw formats (config ^. cTraversalL) root
 
       verifyRes <- allowRewrite showProgressBar $ \rw ->
-        verifyRepo rw (config ^. cVerificationL) verifyMode root repoInfo
+        verifyRepo rw (config ^. cVerificationL) verifyMode root $ srRepoInfo scanResult
 
       let brokenLinks = pickBrokenLinks verifyRes
 

--- a/tests/Test/Xrefcheck/TrailingSlashSpec.hs
+++ b/tests/Test/Xrefcheck/TrailingSlashSpec.hs
@@ -26,8 +26,8 @@ spec = do
       it ("All the files within the root \"" <>
           root <>
           "\" should exist") $ do
-        RepoInfo repoInfo <- allowRewrite False $ \rw ->
-          gatherRepoInfo rw format TraversalConfig{ tcIgnored = [] } root
+        (ScanResult _ (RepoInfo repoInfo)) <- allowRewrite False $ \rw ->
+          scanRepo rw format TraversalConfig{ tcIgnored = [] } root
         nonExistentFiles <- lefts <$> forM (keys repoInfo) (\filePath -> do
           predicate <- doesFileExist filePath
           return $ if predicate

--- a/tests/Test/Xrefcheck/Util.hs
+++ b/tests/Test/Xrefcheck/Util.hs
@@ -7,21 +7,18 @@ module Test.Xrefcheck.Util where
 
 import Universum
 
-import Data.ByteString.Lazy qualified as BSL
 import Network.HTTP.Types (forbidden403, unauthorized401)
 import Web.Firefly (ToResponse (..), route, run)
 
 import Xrefcheck.Core (FileInfo, Flavor)
-import Xrefcheck.Scanners.Markdown (MarkdownConfig (MarkdownConfig, mcFlavor), parseFileInfo)
+import Xrefcheck.Scan (ScanError)
+import Xrefcheck.Scanners.Markdown (MarkdownConfig (MarkdownConfig, mcFlavor), markdownScanner)
 
-parse :: Flavor -> FilePath -> IO (Either Text FileInfo)
-parse fl path =
-  parseFileInfo MarkdownConfig { mcFlavor = fl } . decodeUtf8 <$> BSL.readFile path
+parse :: Flavor -> FilePath -> IO (FileInfo, [ScanError])
+parse fl path = markdownScanner MarkdownConfig { mcFlavor = fl } path
 
-getFI :: HasCallStack => Flavor -> FilePath -> IO FileInfo
-getFI fl path =
-  let errOrFI = parse fl path
-  in either error id <$> errOrFI
+getFI :: Flavor -> FilePath -> IO FileInfo
+getFI fl path = fst <$> parse fl path
 
 mockServer :: IO ()
 mockServer = run 3000 $ do

--- a/tests/golden/check-ignored/check-ignored.bats
+++ b/tests/golden/check-ignored/check-ignored.bats
@@ -34,7 +34,13 @@ load '../helpers'
 }
 
 @test "Ignore file with broken xrefcheck annotation: directory, check filure" {
-  run xrefcheck --ignored ./to-ignore/inner-directory/
+  xrefcheck --ignored ./to-ignore/inner-directory/ \
+  | prepare > /tmp/check-ignored.test || true
 
-  assert_output --partial "Error when scanning ./to-ignore/inner-directory/broken_annotation.md"
+  diff /tmp/check-ignored.test expected.gold \
+    --ignore-space-change \
+    --ignore-blank-lines \
+    --new-file # treat absent files as empty
+
+  rm /tmp/check-ignored.test
 }

--- a/tests/golden/check-ignored/expected.gold
+++ b/tests/golden/check-ignored/expected.gold
@@ -1,0 +1,10 @@
+=== Scan errors found ===
+
+  ➥  In file ./to-ignore/inner-directory/broken_annotation.md
+  scan error at src:9:1-30:
+
+  ⛀  Annotation "ignore file" must be at the top of markdown or right after comments at the top
+
+
+
+Scan errors dumped, 1 in total.

--- a/tests/golden/check-scan-errors/check-scan-errors.bats
+++ b/tests/golden/check-scan-errors/check-scan-errors.bats
@@ -1,0 +1,21 @@
+#!/usr/bin/env bats
+
+# SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+load '../helpers/bats-support/load'
+load '../helpers/bats-assert/load'
+load '../helpers'
+
+
+@test "Dump all errors along with broken links" {
+  xrefcheck | prepare > /tmp/check-scan-errors.test || true
+
+  diff /tmp/check-scan-errors.test expected.gold \
+    --ignore-space-change \
+    --ignore-blank-lines \
+    --new-file # treat absent files as empty
+
+  rm /tmp/check-scan-errors.test
+}

--- a/tests/golden/check-scan-errors/check-scan-errors.md
+++ b/tests/golden/check-scan-errors/check-scan-errors.md
@@ -1,0 +1,23 @@
+<!--
+ - SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -->
+
+one
+
+<!--xrefcheck: ignore file -->
+
+[Bad reference](/no-file.md)
+
+<!-- xrefcheck: ignore paragraph -->
+
+# not a paragraph
+
+<!-- xrefcheck: ignore link -->
+
+# not a link
+
+<!-- xrefcheck: ignore unrecognised-annotation -->
+
+[Bad link](bad.link.com)

--- a/tests/golden/check-scan-errors/check-second-file.md
+++ b/tests/golden/check-scan-errors/check-second-file.md
@@ -1,0 +1,11 @@
+<!--
+ - SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -->
+
+another file with broken annotation
+
+<!--xrefcheck: ignore file -->
+
+[Another bad reference](/a.md)

--- a/tests/golden/check-scan-errors/expected.gold
+++ b/tests/golden/check-scan-errors/expected.gold
@@ -1,0 +1,80 @@
+=== Scan errors found ===
+
+  ➥  In file ./check-scan-errors.md
+     scan error at src:9:1-30:
+
+     ⛀  Annotation "ignore file" must be at the top of markdown or right after comments at the top
+
+
+  ➥  In file ./check-scan-errors.md
+     scan error at src:13:1-36:
+
+     ⛀  Expected a PARAGRAPH after "ignore paragraph" annotation, but found HEADING
+
+
+  ➥  In file ./check-scan-errors.md
+     scan error at src:17:1-31:
+
+     ⛀  Expected a LINK after "ignore link" annotation
+
+
+  ➥  In file ./check-scan-errors.md
+     scan error at src:21:1-50:
+
+     ⛀  Unrecognised option "unrecognised-annotation" perhaps you meant <"ignore link"|"ignore paragraph"|"ignore file">
+
+
+  ➥  In file ./check-second-file.md
+     scan error at src:9:1-30:
+
+     ⛀  Annotation "ignore file" must be at the top of markdown or right after comments at the top
+
+
+  ➥  In file ./no_link_eof.md
+     scan error at src:9:1-31:
+
+     ⛀  Expected a LINK after "ignore link" annotation
+
+
+  ➥  In file ./no_paragraph_eof.md
+     scan error at src:9:1-36:
+
+     ⛀  Expected a PARAGRAPH after "ignore paragraph" annotation, but found EOF
+
+
+Scan errors dumped, 7 in total.
+
+
+=== Invalid references found ===
+
+  ➥  In file check-scan-errors.md
+     bad reference (absolute) at src:11:1-28:
+       - text: "Bad reference"
+       - link: /no-file.md
+       - anchor: -
+
+     ⛀  File does not exist:
+        ./no-file.md
+
+
+  ➥  In file check-scan-errors.md
+     bad reference (relative) at src:23:1-24:
+       - text: "Bad link"
+       - link: bad.link.com
+       - anchor: -
+
+     ⛀  File does not exist:
+        bad.link.com
+
+
+  ➥  In file check-second-file.md
+     bad reference (absolute) at src:11:1-30:
+       - text: "Another bad reference"
+       - link: /a.md
+       - anchor: -
+
+     ⛀  File does not exist:
+        ./a.md
+
+
+Invalid references dumped, 3 in total.

--- a/tests/golden/check-scan-errors/no_link_eof.md
+++ b/tests/golden/check-scan-errors/no_link_eof.md
@@ -1,0 +1,9 @@
+<!--
+ - SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -->
+
+### Ignore link annotation placed at the end of the file
+
+<!-- xrefcheck: ignore link -->

--- a/tests/golden/check-scan-errors/no_paragraph_eof.md
+++ b/tests/golden/check-scan-errors/no_paragraph_eof.md
@@ -1,0 +1,9 @@
+<!--
+ - SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -->
+
+### Ignore paragragh annotation placed at the end of the file
+
+<!-- xrefcheck: ignore paragraph -->

--- a/tests/markdowns/with-annotations/unrecognised_option.md
+++ b/tests/markdowns/with-annotations/unrecognised_option.md
@@ -4,5 +4,5 @@
  - SPDX-License-Identifier: MPL-2.0
  -->
 
-<!-- xrefcheck: ignore link -->
+<!-- xrefcheck: ignore unrecognised-option -->
 Serokell [web-site](https://serokell.io/)


### PR DESCRIPTION
## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->
Problem: Currently, xrefcheck fails immediately after the first observed error because `die` is used right in `markdownScanner` What we want is dumping all the errors from different markdowns and then print them as a final xrefcheck's result together with the broken links. Also, despite the fact that in the `makeError` function we have 4 error messages, 2 of them are not reported, and the test case that should check this only checks that at least one of the four files throws an error.
https://github.com/serokell/xrefcheck/blob/1b0b8d5fdbae53438df051bf3d57f91df9e9c125/tests/Test/Xrefcheck/IgnoreAnnotationsSpec.hs#L18-L20
Solution: Make xrefcheck to report all errors. Add `ScanError` type and propagate errors to report all of them, rather than failing immediately after the first error is detected.
## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #1 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Fixes #56

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](/README.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](/docs/code-style.md).
