### PR TITLE
[#140] Unknown field errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ cabal.sandbox.config
 .ghc.environment.*
 result
 result-*
+hie.yaml

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 
 Unreleased
 ==========
+* [#145](https://github.com/serokell/xrefcheck/pull/145)
+  + Add check that there is no unknown fields in config.
 
 0.2.1
 ==========

--- a/src/Xrefcheck/Util.hs
+++ b/src/Xrefcheck/Util.hs
@@ -53,7 +53,7 @@ infixr 0 -:
 
 -- | Options that we use to derive JSON instances for config types.
 aesonConfigOption :: Aeson.Options
-aesonConfigOption = aesonPrefix camelCase
+aesonConfigOption = (aesonPrefix camelCase){Aeson.rejectUnknownFields = True}
 
 -- | Config fields that may be abscent.
 type family Field f a where

--- a/tests/golden/check-virtualFiles/config-virtualFiles.yaml
+++ b/tests/golden/check-virtualFiles/config-virtualFiles.yaml
@@ -14,7 +14,6 @@ verification:
     - ./two/*
     - ./three/**/*
   ignoreRefs: []
-  checkLocalhost: true
   ignoreAuthFailures: true
   defaultRetryAfter: 30s
   maxRetries: 3


### PR DESCRIPTION
## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->
Problem: As in #140, unrecognised fields of config are ignored. We want to raise an error instead

Solution: change aeson options for config and it's subtypes, now it throws errors like
```
xrefcheck: Aeson exception:
Error in $: Unknown fields: ["traversajhl"]
```

## Related issue(s)
<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #1 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Fixes #140

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](/README.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [ ] I added an entry to the [changelog](/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](/docs/code-style.md).
