### PR TITLE
[#156] Trim redundant config fields from test configs

### DIFF
--- a/src/Xrefcheck/Config.hs
+++ b/src/Xrefcheck/Config.hs
@@ -225,23 +225,18 @@ overrideConfig config
 
     overrideVerify verifyConfig
       = VerifyConfig
-        { vcAnchorSimilarityThreshold = fromMaybe (vcAnchorSimilarityThreshold defVerification)
-            $ vcAnchorSimilarityThreshold verifyConfig
-        , vcExternalRefCheckTimeout   = fromMaybe (vcExternalRefCheckTimeout defVerification)
-            $ vcExternalRefCheckTimeout verifyConfig
-        , vcVirtualFiles              = fromMaybe (vcVirtualFiles defVerification)
-            $ vcVirtualFiles verifyConfig
-        , vcNotScanned                = fromMaybe (vcNotScanned defVerification)
-            $ vcNotScanned verifyConfig
-        , vcIgnoreRefs                = fromMaybe (vcIgnoreRefs defVerification)
-            $ vcIgnoreRefs verifyConfig
-        , vcIgnoreAuthFailures        = fromMaybe (vcIgnoreAuthFailures defVerification)
-            $ vcIgnoreAuthFailures verifyConfig
-        , vcDefaultRetryAfter         = fromMaybe (vcDefaultRetryAfter defVerification)
-            $ vcDefaultRetryAfter verifyConfig
-        , vcMaxRetries                = fromMaybe (vcMaxRetries defVerification)
-            $ vcMaxRetries verifyConfig
+        { vcAnchorSimilarityThreshold = overrideField vcAnchorSimilarityThreshold
+        , vcExternalRefCheckTimeout   = overrideField vcExternalRefCheckTimeout
+        , vcVirtualFiles              = overrideField vcVirtualFiles
+        , vcNotScanned                = overrideField vcNotScanned
+        , vcIgnoreRefs                = overrideField vcIgnoreRefs
+        , vcIgnoreAuthFailures        = overrideField vcIgnoreAuthFailures
+        , vcDefaultRetryAfter         = overrideField vcDefaultRetryAfter
+        , vcMaxRetries                = overrideField vcMaxRetries
         }
+      where
+        overrideField :: (forall f. VerifyConfig' f -> Field f a) -> a
+        overrideField field = fromMaybe (field defVerification) $ field verifyConfig
 
 -----------------------------------------------------------
 -- Yaml instances

--- a/tests/golden/check-cli/config-no-scan-ignored.yaml
+++ b/tests/golden/check-cli/config-no-scan-ignored.yaml
@@ -2,19 +2,5 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-traversal:
-  ignored: []
-
 verification:
-  anchorSimilarityThreshold: 0.5
-  externalRefCheckTimeout: 10s
   notScanned: [ "to-ignore/broken-link.md" ]
-  virtualFiles: []
-  ignoreRefs: []
-  ignoreAuthFailures: true
-  defaultRetryAfter: 30s
-  maxRetries: 3
-
-scanners:
-  markdown:
-    flavor: GitHub

--- a/tests/golden/check-ignoreRefs/config-check-disabled.yaml
+++ b/tests/golden/check-ignoreRefs/config-check-disabled.yaml
@@ -2,20 +2,6 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-traversal:
-  ignored: []
-
 verification:
-  anchorSimilarityThreshold: 0.5
-  externalRefCheckTimeout: 10s
-  notScanned: []
-  virtualFiles: []
   ignoreRefs:
     - ^(https?|ftps?)://(localhost|127\.0\.0\.1).*
-  ignoreAuthFailures: true
-  defaultRetryAfter: 30s
-  maxRetries: 3
-
-scanners:
-  markdown:
-    flavor: GitHub

--- a/tests/golden/check-ignoreRefs/config-check-enabled.yaml
+++ b/tests/golden/check-ignoreRefs/config-check-enabled.yaml
@@ -2,19 +2,5 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-traversal:
-  ignored: []
-
 verification:
-  anchorSimilarityThreshold: 0.5
-  externalRefCheckTimeout: 10s
-  notScanned: []
-  virtualFiles: []
   ignoreRefs: []
-  ignoreAuthFailures: true
-  defaultRetryAfter: 30s
-  maxRetries: 3
-
-scanners:
-  markdown:
-    flavor: GitHub

--- a/tests/golden/check-ignored/config-ignored.yaml
+++ b/tests/golden/check-ignored/config-ignored.yaml
@@ -5,17 +5,3 @@
 traversal:
   ignored:
     - ./to-ignore/inner-directory/broken_annotation.md
-
-verification:
-  anchorSimilarityThreshold: 0.5
-  externalRefCheckTimeout: 10s
-  notScanned: []
-  virtualFiles: []
-  ignoreRefs: []
-  ignoreAuthFailures: true
-  defaultRetryAfter: 30s
-  maxRetries: 3
-
-scanners:
-  markdown:
-    flavor: GitHub

--- a/tests/golden/check-notScanned/config-directory.yaml
+++ b/tests/golden/check-notScanned/config-directory.yaml
@@ -2,20 +2,6 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-traversal:
-  ignored: []
-
 verification:
-  anchorSimilarityThreshold: 0.5
-  externalRefCheckTimeout: 10s
   notScanned:
     - notScanned/inner-directory
-  virtualFiles: []
-  ignoreRefs: []
-  ignoreAuthFailures: true
-  defaultRetryAfter: 30s
-  maxRetries: 3
-
-scanners:
-  markdown:
-    flavor: GitHub

--- a/tests/golden/check-notScanned/config-full-path.yaml
+++ b/tests/golden/check-notScanned/config-full-path.yaml
@@ -2,20 +2,6 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-traversal:
-  ignored: []
-
 verification:
-  anchorSimilarityThreshold: 0.5
-  externalRefCheckTimeout: 10s
   notScanned:
     - ./notScanned/inner-directory/bad-reference.md
-  virtualFiles: []
-  ignoreRefs: []
-  ignoreAuthFailures: true
-  defaultRetryAfter: 30s
-  maxRetries: 3
-
-scanners:
-  markdown:
-    flavor: GitHub

--- a/tests/golden/check-notScanned/config-nested-directories.yaml
+++ b/tests/golden/check-notScanned/config-nested-directories.yaml
@@ -2,20 +2,6 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-traversal:
-  ignored: []
-
 verification:
-  anchorSimilarityThreshold: 0.5
-  externalRefCheckTimeout: 10s
   notScanned:
     - ./**/*
-  virtualFiles: []
-  ignoreRefs: []
-  ignoreAuthFailures: true
-  defaultRetryAfter: 30s
-  maxRetries: 3
-
-scanners:
-  markdown:
-    flavor: GitHub

--- a/tests/golden/check-notScanned/config-wildcard.yaml
+++ b/tests/golden/check-notScanned/config-wildcard.yaml
@@ -2,20 +2,6 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-traversal:
-  ignored: []
-
 verification:
-  anchorSimilarityThreshold: 0.5
-  externalRefCheckTimeout: 10s
   notScanned:
     - ./notScanned/inner-directory/*
-  virtualFiles: []
-  ignoreRefs: []
-  ignoreAuthFailures: true
-  defaultRetryAfter: 30s
-  maxRetries: 3
-
-scanners:
-  markdown:
-    flavor: GitHub

--- a/tests/golden/check-virtualFiles/config-virtualFiles.yaml
+++ b/tests/golden/check-virtualFiles/config-virtualFiles.yaml
@@ -2,22 +2,8 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-traversal:
-  ignored: []
-
 verification:
-  anchorSimilarityThreshold: 0.5
-  externalRefCheckTimeout: 10s
-  notScanned: []
   virtualFiles:
     - ./one/a.md
     - ./two/*
     - ./three/**/*
-  ignoreRefs: []
-  ignoreAuthFailures: true
-  defaultRetryAfter: 30s
-  maxRetries: 3
-
-scanners:
-  markdown:
-    flavor: GitHub


### PR DESCRIPTION

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->
Problem: In #159 we made all config fields optional. Now we can trim redundant fields from test configs.

Solution: Trim redundant config fields. Also slightly refactor `overrideVerify` function to make it more readable.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #1 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Fixes #156 

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](https://github.com/serokell/xrefcheck/tree/master/README.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](https://github.com/serokell/xrefcheck/tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](https://github.com/serokell/style/blob/master/haskell.md).

#### ✓ Release Checklist

- [ ] I updated the version number in `package.yaml`.
- [ ] I updated the [changelog](https://github.com/serokell/xrefcheck/tree/master/CHANGES.md) and moved everything
      under the "Unreleased" section to a new section for this release version.
- [ ] (After merging) I edited the [auto-release](https://github.com/serokell/xrefcheck/releases/tag/auto-release).
    * Change the tag and title using the format `vX.Y.Z`.
    * Write a summary of all user-facing changes.
    * Deselect the "This is a pre-release" checkbox at the bottom.
- [ ] (After merging) I updated [`xrefcheck-action`](https://github.com/serokell/xrefcheck-action#updating-supported-versions).
