### PR TITLE
[#170] [#119] Reorganize top-level config keys

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@ Unreleased
   + Enabled `autolink` extension for `cmark-gfm`, so now we're finding strings
   like `www.google.com` or `https://google.com`, threating them as links
   and checking.
+* [#175](https://github.com/serokell/xrefcheck/pull/175)
+  + Reorganize top-level config keys.
 
 0.2.2
 ==========
@@ -18,7 +20,7 @@ Unreleased
 * [#145](https://github.com/serokell/xrefcheck/pull/145)
   + Add check that there is no unknown fields in config.
 * [#158](https://github.com/serokell/xrefcheck/pull/158)
-  + Fixed bug when we reported footnotes as broken links
+  + Fixed bug when we reported footnotes as broken links.
 * [#163](https://github.com/serokell/xrefcheck/pull/163)
   + Fixed an issue where the progress bar thread might be unexpectedly cancelled and jumble up the output.
 * [#184](https://github.com/serokell/xrefcheck/pull/184)

--- a/ftp-tests/Test/Xrefcheck/FtpLinks.hs
+++ b/ftp-tests/Test/Xrefcheck/FtpLinks.hs
@@ -15,9 +15,9 @@ import Test.Tasty (TestTree, askOption, testGroup)
 import Test.Tasty.HUnit (assertBool, assertFailure, testCase, (@?=))
 import Test.Tasty.Options as Tasty (IsOption (..), OptionDescription (Option), safeRead)
 
-import Xrefcheck.Config
-  (Config' (cVerification), VerifyConfig, VerifyConfig' (vcIgnoreRefs), defConfig)
+import Xrefcheck.Config (Config, cExclusionsL, defConfig)
 import Xrefcheck.Core (Flavor (GitHub))
+import Xrefcheck.Scan (ecIgnoreRefsL)
 import Xrefcheck.Verify
   (VerifyError (..), VerifyResult (VerifyResult), checkExternalResource, verifyErrors)
 
@@ -42,8 +42,8 @@ instance IsOption FtpHostOpt where
     )
 
 
-config :: VerifyConfig
-config = (cVerification $ defConfig GitHub) { vcIgnoreRefs = [] }
+config :: Config
+config = defConfig GitHub & cExclusionsL . ecIgnoreRefsL .~ []
 
 test_FtpLinks :: TestTree
 test_FtpLinks = askOption $ \(FtpHostOpt host) -> do

--- a/src/Xrefcheck/Config/Default.hs
+++ b/src/Xrefcheck/Config/Default.hs
@@ -13,21 +13,11 @@ import Text.RawString.QQ
 
 defConfigUnfilled :: ByteString
 defConfigUnfilled =
-  [r|# Parameters of repository traversal.
-traversal:
+  [r|# Exclusion parameters.
+exclusions:
   # Glob patterns describing files which we pretend do not exist
   # (so they are neither analyzed nor can be referenced).
   ignored: []
-
-# Verification parameters.
-verification:
-  # On 'anchor not found' error, how much similar anchors should be displayed as
-  # hint. Number should be between 0 and 1, larger value means stricter filter.
-  anchorSimilarityThreshold: 0.5
-
-  # When checking external references, how long to wait on request before
-  # declaring "Response timeout".
-  externalRefCheckTimeout: 10s
 
   # Glob patterns describing the files, references in which should not be analyzed.
   notScanned:
@@ -44,6 +34,12 @@ verification:
     # Ignore localhost links by default
     - ^(https?|ftps?)://(localhost|127\.0\.0\.1).*
 
+# Networking parameters.
+networking:
+  # When checking external references, how long to wait on request before
+  # declaring "Response timeout".
+  externalRefCheckTimeout: 10s
+
   # Skip links which return 403 or 401 code.
   ignoreAuthFailures: true
 
@@ -58,6 +54,10 @@ verification:
 
 # Parameters of scanners for various file types.
 scanners:
+  # On 'anchor not found' error, how much similar anchors should be displayed as
+  # hint. Number should be between 0 and 1, larger value means stricter filter.
+  anchorSimilarityThreshold: 0.5
+
   markdown:
     # Flavor of markdown, e.g. GitHub-flavor.
     #

--- a/tests/Test/Xrefcheck/ConfigSpec.hs
+++ b/tests/Test/Xrefcheck/ConfigSpec.hs
@@ -19,8 +19,10 @@ import Test.Tasty.HUnit (assertFailure, testCase, (@?=))
 import Test.Tasty.QuickCheck (ioProperty, testProperty)
 
 
-import Xrefcheck.Config (Config, Config' (..), VerifyConfig' (..), defConfig, defConfigText)
+import Xrefcheck.Config
+  (Config, cExclusionsL, cNetworkingL, defConfig, defConfigText, ncIgnoreAuthFailuresL)
 import Xrefcheck.Core (Flavor (GitHub), allFlavors)
+import Xrefcheck.Scan (ecIgnoreRefsL)
 import Xrefcheck.Verify (VerifyError (..), VerifyResult (..), checkExternalResource)
 
 import Test.Xrefcheck.Util (mockServer)
@@ -46,24 +48,27 @@ test_config =
             ]
       ]
   , testGroup "`ignoreAuthFailures` working as expected" $
-    let config = (cVerification $ defConfig GitHub) { vcIgnoreRefs = [] }
+    let config = defConfig GitHub & cExclusionsL . ecIgnoreRefsL .~ []
+
+        setIgnoreAuthFailures value =
+          config & cNetworkingL . ncIgnoreAuthFailuresL .~ value
     in [ testCase "when True - assume 401 status is valid" $
-          checkLinkWithServer (config { vcIgnoreAuthFailures = True })
+          checkLinkWithServer (setIgnoreAuthFailures True)
             "http://127.0.0.1:3000/401" $ VerifyResult []
 
        , testCase "when False - assume 401 status is invalid" $
-          checkLinkWithServer (config { vcIgnoreAuthFailures = False })
+          checkLinkWithServer (setIgnoreAuthFailures False)
             "http://127.0.0.1:3000/401" $ VerifyResult
               [ ExternalHttpResourceUnavailable $
                   Status { statusCode = 401, statusMessage = "Unauthorized" }
               ]
 
        , testCase "when True - assume 403 status is valid" $
-          checkLinkWithServer (config { vcIgnoreAuthFailures = True })
+          checkLinkWithServer (setIgnoreAuthFailures True)
             "http://127.0.0.1:3000/403" $ VerifyResult []
 
        , testCase "when False - assume 403 status is invalid" $
-          checkLinkWithServer (config { vcIgnoreAuthFailures = False })
+          checkLinkWithServer (setIgnoreAuthFailures False)
             "http://127.0.0.1:3000/403" $ VerifyResult
               [ ExternalHttpResourceUnavailable $
                   Status { statusCode = 403, statusMessage = "Forbidden" }

--- a/tests/Test/Xrefcheck/IgnoreRegexSpec.hs
+++ b/tests/Test/Xrefcheck/IgnoreRegexSpec.hs
@@ -16,7 +16,7 @@ import Text.Regex.TDFA (Regex)
 import Xrefcheck.Config
 import Xrefcheck.Core
 import Xrefcheck.Progress (allowRewrite)
-import Xrefcheck.Scan (ScanResult (..), scanRepo, specificFormatsSupport)
+import Xrefcheck.Scan (ScanResult (..), ecIgnoreRefsL, scanRepo, specificFormatsSupport)
 import Xrefcheck.Scanners.Markdown
 import Xrefcheck.Util (ColorMode (WithoutColors))
 import Xrefcheck.Verify (VerifyError, VerifyResult, WithReferenceLoc (..), verifyErrors, verifyRepo)
@@ -39,10 +39,10 @@ test_ignoreRegex = give WithoutColors $
   in testGroup "Regular expressions performance"
     [ testCase "Check that only not matched links are verified" $ do
       scanResult <- allowRewrite showProgressBar $ \rw ->
-        scanRepo rw formats (config ^. cTraversalL) root
+        scanRepo rw formats (config ^. cExclusionsL) root
 
       verifyRes <- allowRewrite showProgressBar $ \rw ->
-        verifyRepo rw (config ^. cVerificationL) verifyMode root $ srRepoInfo scanResult
+        verifyRepo rw config verifyMode root $ srRepoInfo scanResult
 
       let brokenLinks = pickBrokenLinks verifyRes
 
@@ -87,4 +87,4 @@ test_ignoreRegex = give WithoutColors $
         in map (either (error . show) id) errOrRegexs
 
       setIgnoreRefs :: [Regex] -> Config -> Config
-      setIgnoreRefs regexs = (cVerificationL . vcIgnoreRefsL) .~ regexs
+      setIgnoreRefs regexs = (cExclusionsL . ecIgnoreRefsL) .~ regexs

--- a/tests/Test/Xrefcheck/TooManyRequestsSpec.hs
+++ b/tests/Test/Xrefcheck/TooManyRequestsSpec.hs
@@ -24,6 +24,7 @@ import Web.Firefly (ToResponse (toResponse), getMethod, route, run)
 import Xrefcheck.Config
 import Xrefcheck.Core
 import Xrefcheck.Progress
+import Xrefcheck.Scan
 import Xrefcheck.Util
 import Xrefcheck.Verify
 
@@ -197,7 +198,7 @@ test_tooManyRequests = testGroup "429 response tests"
     verifyReferenceWithProgress :: Reference -> IORef VerifyProgress -> IO (VerifyResult VerifyError)
     verifyReferenceWithProgress reference progRef = do
       fmap wrlItem <$> verifyReference
-        ((cVerification $ defConfig GitHub) { vcIgnoreRefs = [] }) FullMode
+        (defConfig GitHub & cExclusionsL . ecIgnoreRefsL .~ []) FullMode
         progRef (RepoInfo M.empty mempty) "." "" reference
 
     -- | When called for the first time, returns with a 429 and `Retry-After: @retryAfter@`.

--- a/tests/Test/Xrefcheck/TrailingSlashSpec.hs
+++ b/tests/Test/Xrefcheck/TrailingSlashSpec.hs
@@ -27,7 +27,7 @@ test_slash = testGroup "Trailing forward slash detection" $
       root <>
       "\" should exist") $ do
         (ScanResult _ (RepoInfo repoInfo _)) <- allowRewrite False $ \rw ->
-          scanRepo rw format TraversalConfig{ tcIgnored = [] } root
+          scanRepo rw format (cExclusions config & ecIgnoredL .~ []) root
         nonExistentFiles <- lefts <$> forM (keys repoInfo) (\filePath -> do
           predicate <- doesFileExist filePath
           return $ if predicate

--- a/tests/configs/github-config.yaml
+++ b/tests/configs/github-config.yaml
@@ -1,18 +1,8 @@
-# Parameters of repository traversal.
-traversal:
+# Exclusion parameters.
+exclusions:
   # Glob patterns describing files which we pretend do not exist
   # (so they are neither analyzed nor can be referenced).
   ignored: []
-
-# Verification parameters.
-verification:
-  # On 'anchor not found' error, how much similar anchors should be displayed as
-  # hint. Number should be between 0 and 1, larger value means stricter filter.
-  anchorSimilarityThreshold: 0.5
-
-  # When checking external references, how long to wait on request before
-  # declaring "Response timeout".
-  externalRefCheckTimeout: 10s
 
   # Glob patterns describing the files, references in which should not be analyzed.
   notScanned:
@@ -35,6 +25,12 @@ verification:
     # Ignore localhost links by default
     - ^(https?|ftps?)://(localhost|127\.0\.0\.1).*
 
+# Networking parameters.
+networking:
+  # When checking external references, how long to wait on request before
+  # declaring "Response timeout".
+  externalRefCheckTimeout: 10s
+
   # Skip links which return 403 or 401 code.
   ignoreAuthFailures: true
 
@@ -49,6 +45,10 @@ verification:
 
 # Parameters of scanners for various file types.
 scanners:
+  # On 'anchor not found' error, how much similar anchors should be displayed as
+  # hint. Number should be between 0 and 1, larger value means stricter filter.
+  anchorSimilarityThreshold: 0.5
+
   markdown:
     # Flavor of markdown, e.g. GitHub-flavor.
     #

--- a/tests/golden/check-cli/config-no-scan-ignored.yaml
+++ b/tests/golden/check-cli/config-no-scan-ignored.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-verification:
+exclusions:
   notScanned: [ "to-ignore/broken-link.md" ]
 
 scanners:

--- a/tests/golden/check-ignoreRefs/config-check-disabled.yaml
+++ b/tests/golden/check-ignoreRefs/config-check-disabled.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-verification:
+exclusions:
   ignoreRefs:
     - ^(https?|ftps?)://(localhost|127\.0\.0\.1).*
 

--- a/tests/golden/check-ignoreRefs/config-check-enabled.yaml
+++ b/tests/golden/check-ignoreRefs/config-check-enabled.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-verification:
+exclusions:
   ignoreRefs: []
 
 scanners:

--- a/tests/golden/check-ignored/config-ignored-bad-path-absolute.yaml
+++ b/tests/golden/check-ignored/config-ignored-bad-path-absolute.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-traversal:
+exclusions:
   ignored:
     - /to-ignore/inner-directory/broken_annotation.md
 

--- a/tests/golden/check-ignored/config-ignored-malformed-glob.yaml
+++ b/tests/golden/check-ignored/config-ignored-malformed-glob.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-traversal:
+exclusions:
   ignored:
     - </to-ignore/inner-directory/broken_annotation.md>
 

--- a/tests/golden/check-ignored/config-ignored.yaml
+++ b/tests/golden/check-ignored/config-ignored.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-traversal:
+exclusions:
   ignored:
     - ./to-ignore/inner-directory/broken_annotation.md
 

--- a/tests/golden/check-local-refs/config-with-virtual-files.yaml
+++ b/tests/golden/check-local-refs/config-with-virtual-files.yaml
@@ -1,7 +1,8 @@
 # SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
 #
 # SPDX-License-Identifier: Unlicense
-verification:
+
+exclusions:
   virtualFiles:
     - ../d0f1.md
     - ../../a.md

--- a/tests/golden/check-notScanned/config-directory.yaml
+++ b/tests/golden/check-notScanned/config-directory.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-verification:
+exclusions:
   notScanned:
     - notScanned/inner-directory
 

--- a/tests/golden/check-notScanned/config-full-path.yaml
+++ b/tests/golden/check-notScanned/config-full-path.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-verification:
+exclusions:
   notScanned:
     - ./notScanned/inner-directory/bad-reference.md
 

--- a/tests/golden/check-notScanned/config-nested-directories.yaml
+++ b/tests/golden/check-notScanned/config-nested-directories.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-verification:
+exclusions:
   notScanned:
     - ./**/*
 

--- a/tests/golden/check-notScanned/config-wildcard.yaml
+++ b/tests/golden/check-notScanned/config-wildcard.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-verification:
+exclusions:
   notScanned:
     - ./notScanned/inner-directory/*
 

--- a/tests/golden/check-virtualFiles/config-virtualFiles.yaml
+++ b/tests/golden/check-virtualFiles/config-virtualFiles.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-verification:
+exclusions:
   virtualFiles:
     - ./one/a.md
     - ./two/*


### PR DESCRIPTION
## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->
Problem: At the moment, the config yaml is organized in 3 top-level keys: `traversal`, `verification` and `scanners`. However, the distinction between the "traversal" and the "verification" stages is not relevant to the user. This is entirely an internal concern.

Solution: Reorganize yaml config options under `exclusions`, `networking` and `scanners`.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #1 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Fixes #170 
Fixes #119 

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](https://github.com/serokell/xrefcheck/tree/master/README.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](https://github.com/serokell/xrefcheck/tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](https://github.com/serokell/style/blob/master/haskell.md).

#### ✓ Release Checklist

- [ ] I updated the version number in `package.yaml`.
- [ ] I updated the [changelog](https://github.com/serokell/xrefcheck/tree/master/CHANGES.md) and moved everything
      under the "Unreleased" section to a new section for this release version.
- [ ] (After merging) I edited the [auto-release](https://github.com/serokell/xrefcheck/releases/tag/auto-release).
    * Change the tag and title using the format `vX.Y.Z`.
    * Write a summary of all user-facing changes.
    * Deselect the "This is a pre-release" checkbox at the bottom.
- [ ] (After merging) I updated [`xrefcheck-action`](https://github.com/serokell/xrefcheck-action#updating-supported-versions).
