### PR TITLE
[#157] Add support for autolinks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,11 @@
 Unreleased
 ==========
 
+* [#176](https://github.com/serokell/xrefcheck/pull/176)
+  + Enabled `autolink` extension for `cmark-gfm`, so now we're finding strings
+  like `www.google.com` or `https://google.com`, threating them as links
+  and checking.
+
 0.2.2
 ==========
 

--- a/src/Xrefcheck/Scanners/Markdown.hs
+++ b/src/Xrefcheck/Scanners/Markdown.hs
@@ -19,7 +19,8 @@ module Xrefcheck.Scanners.Markdown
 
 import Universum
 
-import CMarkGFM (Node (..), NodeType (..), PosInfo (..), commonmarkToNode, optFootnotes)
+import CMarkGFM
+  (Node (..), NodeType (..), PosInfo (..), commonmarkToNode, extAutolink, optFootnotes)
 import Control.Lens (_Just, makeLenses, makeLensesFor, (.=))
 import Control.Monad.Trans.Writer.CPS (Writer, runWriter, tell)
 import Data.Aeson (FromJSON (..), genericParseJSON)
@@ -398,7 +399,7 @@ parseFileInfo config fp input
   = runWriter
   $ flip runReaderT config
   $ nodeExtractInfo fp
-  $ commonmarkToNode [optFootnotes] []
+  $ commonmarkToNode [optFootnotes] [extAutolink]
   $ toStrict input
 
 markdownScanner :: MarkdownConfig -> ScanAction

--- a/tests/golden/check-autolinks/check-autolinks.bats
+++ b/tests/golden/check-autolinks/check-autolinks.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+
+# SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+load '../helpers/bats-support/load'
+load '../helpers/bats-assert/load'
+load '../helpers/bats-file/load'
+load '../helpers'
+
+@test "We're finding and checking autolinks" {
+  to_temp xrefcheck -v
+assert_diff - <<EOF
+=== Repository data ===
+
+  ⮚ file-with-autolinks.md:
+    - references:
+        - reference (external) :
+            - text: "https://www.google.com/doodles"
+            - link: https://www.google.com/doodles
+            - anchor: -
+        - reference (external) at src:8:0-18:
+            - text: "www.commonmark.org"
+            - link: http://www.commonmark.org
+            - anchor: -
+    - anchors: []
+
+
+All repository links are valid.
+EOF
+}

--- a/tests/golden/check-autolinks/file-with-autolinks.md
+++ b/tests/golden/check-autolinks/file-with-autolinks.md
@@ -1,0 +1,10 @@
+<!--
+ - SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -->
+So, first one is here https://www.google.com/doodles.
+
+www.commonmark.org
+
+Without www it is not a link - github.com/serokell/


### PR DESCRIPTION
## Description

Problem: GitHub renders "implicit" links like `visit www.google.com` as links, but we don't check them, since cmark-gfm renders them as text

Solution: add `autolink` extension to `cmark-gfm`, so both `www.google.com`  and `https://google.com`
will be parsed as link and successfuly verified

Also now we use newest cmark-gfm form hackage (not from GitHub)


<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #1 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Fixes #157

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](https://github.com/serokell/xrefcheck/tree/master/README.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](https://github.com/serokell/xrefcheck/tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](https://github.com/serokell/style/blob/master/haskell.md).

#### ✓ Release Checklist

- [ ] I updated the version number in `package.yaml`.
- [ ] I updated the [changelog](https://github.com/serokell/xrefcheck/tree/master/CHANGES.md) and moved everything
      under the "Unreleased" section to a new section for this release version.
- [ ] (After merging) I edited the [auto-release](https://github.com/serokell/xrefcheck/releases/tag/auto-release).
    * Change the tag and title using the format `vX.Y.Z`.
    * Write a summary of all user-facing changes.
    * Deselect the "This is a pre-release" checkbox at the bottom.
- [ ] (After merging) I updated [`xrefcheck-action`](https://github.com/serokell/xrefcheck-action#updating-supported-versions).
