### PR TITLE
[#185] Add CLI option to disable output coloring

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -98,3 +98,15 @@
     lhs: '(Fmt.||++|)'
     rhs: '(Fmt.|++|)'
     note: "The use of '(||++|)' may result in outputting raw Haskell into user-facing code"
+- warn:
+    name: "Avoid colorize function that ignore ColorMode"
+    lhs: 'System.Console.Pretty.colorize'
+    rhs: 'Xrefcheck.Util.Colorize.colorizeIfNeeded'
+- warn:
+    name: "Avoid color function that ignore ColorMode"
+    lhs: 'System.Console.Pretty.color'
+    rhs: 'Xrefcheck.Util.Colorize.colorIfNeeded'
+- warn:
+    name: "Avoid style function that ignore ColorMode"
+    lhs: 'System.Console.Pretty.style'
+    rhs: 'Xrefcheck.Util.Colorize.styleIfNeeded'

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@ Unreleased
 * [#182](https://github.com/serokell/xrefcheck/pull/182)
   + Now we call references to anchors in current file (e.g. `[a](#b)`) as
   `current file` references instead of calling them `local` (which was ambigious).
+* [#188](https://github.com/serokell/xrefcheck/pull/188)
+  + Added CLI option `--no-colors` that disables ANSI colors in output.
 
 0.2.1
 ==========

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,7 +19,7 @@ Unreleased
   `current file` references instead of calling them `local` (which was ambigious).
 * [#188](https://github.com/serokell/xrefcheck/pull/188)
   + Added CLI option `--no-colors` that disables ANSI colors in output.
-
+  + Automatically disable coloring if it is not supported
 0.2.1
 ==========
 

--- a/package.yaml
+++ b/package.yaml
@@ -110,6 +110,7 @@ library:
     - universum
     - uri-bytestring
     - yaml
+    - reflection
 
 executables:
   xrefcheck:
@@ -155,6 +156,7 @@ tests:
       - modern-uri
       - uri-bytestring
       - yaml
+      - reflection
 
   ftp-tests:
     main: Main.hs

--- a/src/Xrefcheck/CLI.hs
+++ b/src/Xrefcheck/CLI.hs
@@ -26,9 +26,9 @@ import Data.List qualified as L
 import Data.Text qualified as T
 import Data.Version (showVersion)
 import Options.Applicative
-  (Mod, OptionFields, Parser, ReadM, auto, command, eitherReader, execParser, flag', footerDoc,
-  fullDesc, help, helpDoc, helper, hsubparser, info, infoOption, long, metavar, option, progDesc,
-  short, strOption, switch, value)
+  (Mod, OptionFields, Parser, ReadM, auto, command, eitherReader, execParser, flag, flag',
+  footerDoc, fullDesc, help, helpDoc, helper, hsubparser, info, infoOption, long, metavar, option,
+  progDesc, short, strOption, switch, value)
 import Options.Applicative.Help.Pretty (Doc, displayS, fill, fillSep, indent, renderPretty, text)
 import Options.Applicative.Help.Pretty qualified as Pretty
 
@@ -37,7 +37,7 @@ import Xrefcheck.Config (VerifyConfig, VerifyConfig' (..))
 import Xrefcheck.Core
 import Xrefcheck.Scan
 import Xrefcheck.System (RelGlobPattern (..))
-import Xrefcheck.Util (normaliseWithNoTrailing)
+import Xrefcheck.Util (ColorMode (WithColors, WithoutColors), normaliseWithNoTrailing)
 
 modeReadM :: ReadM VerifyMode
 modeReadM = eitherReader $ \s ->
@@ -74,6 +74,7 @@ data Options = Options
   , oMode             :: VerifyMode
   , oVerbose          :: Bool
   , oShowProgressBar  :: Maybe Bool
+  , oColorMode        :: ColorMode
   , oTraversalOptions :: TraversalOptions
   , oVerifyOptions    :: VerifyOptions
   }
@@ -170,6 +171,9 @@ optionsParser = do
         help "Do not display progress bar during verification."
     , pure Nothing
     ]
+  oColorMode <- flag WithColors WithoutColors $
+    long "no-color" <>
+    help "Disable ANSI coloring of output"
   oTraversalOptions <- traversalOptionsParser
   oVerifyOptions <- verifyOptionsParser
   return Options{..}

--- a/src/Xrefcheck/Command.hs
+++ b/src/Xrefcheck/Command.hs
@@ -9,6 +9,7 @@ module Xrefcheck.Command
 
 import Universum
 
+import Data.Reflection (give)
 import Data.Yaml (decodeFileEither, prettyPrintParseException)
 import Fmt (blockListF', build, fmt, fmtLn, indentF)
 import System.Directory (doesFileExist)
@@ -42,7 +43,7 @@ findFirstExistingFile = \case
     if exists then pure (Just file) else findFirstExistingFile files
 
 defaultAction :: Options -> IO ()
-defaultAction Options{..} = do
+defaultAction Options{..} = give oColorMode $ do
     config <- case oConfigPath of
       Just configPath -> readConfig configPath
       Nothing -> do

--- a/src/Xrefcheck/Command.hs
+++ b/src/Xrefcheck/Command.hs
@@ -12,6 +12,7 @@ import Universum
 import Data.Reflection (give)
 import Data.Yaml (decodeFileEither, prettyPrintParseException)
 import Fmt (blockListF', build, fmt, fmtLn, indentF)
+import System.Console.Pretty (supportsPretty)
 import System.Directory (doesFileExist)
 
 import Xrefcheck.CLI (Options (..), addTraversalOptions, addVerifyOptions, defaultConfigPaths)
@@ -23,6 +24,7 @@ import Xrefcheck.Scan
   (FormatsSupport, ScanError (..), ScanResult (..), scanRepo, specificFormatsSupport)
 import Xrefcheck.Scanners.Markdown (markdownSupport)
 import Xrefcheck.System (askWithinCI)
+import Xrefcheck.Util
 import Xrefcheck.Verify (verifyErrors, verifyRepo)
 
 readConfig :: FilePath -> IO Config
@@ -43,7 +45,9 @@ findFirstExistingFile = \case
     if exists then pure (Just file) else findFirstExistingFile files
 
 defaultAction :: Options -> IO ()
-defaultAction Options{..} = give oColorMode $ do
+defaultAction Options{..} = do
+  coloringSupported <- supportsPretty
+  give (if coloringSupported then oColorMode else WithoutColors) $ do
     config <- case oConfigPath of
       Just configPath -> readConfig configPath
       Nothing -> do

--- a/src/Xrefcheck/Core.hs
+++ b/src/Xrefcheck/Core.hs
@@ -21,7 +21,6 @@ import Data.Map qualified as M
 import Data.Reflection (Given)
 import Data.Text qualified as T
 import Fmt (Buildable (..), blockListF, blockListF', nameF, (+|), (|+))
-import System.Console.Pretty (Color (..), Style (..))
 import System.FilePath (isPathSeparator, pathSeparator)
 import Time (Second, Time)
 

--- a/src/Xrefcheck/Progress.hs
+++ b/src/Xrefcheck/Progress.hs
@@ -31,10 +31,9 @@ import Universum
 
 import Data.Ratio ((%))
 import Data.Reflection (Given)
-import System.Console.Pretty (Color (..), Style (..))
 import Time (Second, Time, sec, unTime, (-:-))
 
-import Xrefcheck.Util (ColorMode, colorIfNeeded, styleIfNeeded)
+import Xrefcheck.Util
 
 -----------------------------------------------------------
 -- Task timestamp

--- a/src/Xrefcheck/Progress.hs
+++ b/src/Xrefcheck/Progress.hs
@@ -30,8 +30,11 @@ module Xrefcheck.Progress
 import Universum
 
 import Data.Ratio ((%))
-import System.Console.Pretty (Color (..), Style (..), color, style)
+import Data.Reflection (Given)
+import System.Console.Pretty (Color (..), Style (..))
 import Time (Second, Time, sec, unTime, (-:-))
+
+import Xrefcheck.Util (ColorMode, colorIfNeeded, styleIfNeeded)
 
 -----------------------------------------------------------
 -- Task timestamp
@@ -126,12 +129,12 @@ checkTaskTimestamp posixTime p@Progress{..} =
       else removeTaskTimestamp p
 
 -- | Visualise progress bar.
-showProgress :: Text -> Int -> Color -> Time Second -> Progress Int -> Text
+showProgress :: Given ColorMode => Text -> Int -> Color -> Time Second -> Progress Int -> Text
 showProgress name width col posixTime Progress{..} = mconcat
-  [ color col (name <> ": [")
+  [ colorIfNeeded col (name <> ": [")
   , toText bar
   , timer
-  , color col "]"
+  , colorIfNeeded col "]"
   , status
   ]
   where
@@ -170,25 +173,25 @@ showProgress name width col posixTime Progress{..} = mconcat
     bar
       | pTotal == 0 = replicate width '-'
       | otherwise = mconcat
-          [ color Blue $ replicate errsF '■'
-          , color Red $ replicate errsU '■'
-          , color col $ replicate successful '■'
-          , color col $ replicate remaining ' '
+          [ colorIfNeeded Blue $ replicate errsF '■'
+          , colorIfNeeded Red $ replicate errsU '■'
+          , colorIfNeeded col $ replicate successful '■'
+          , colorIfNeeded col $ replicate remaining ' '
           , " "
           ]
     timer = case pTaskTimestamp of
       Nothing -> ""
       Just TaskTimestamp{..} -> mconcat
-        [ color col "|"
-        , color Blue . show . timeSecondCeiling
+        [ colorIfNeeded col "|"
+        , colorIfNeeded Blue . show . timeSecondCeiling
         $ ttTimeToCompletion -:- (posixTime -:- ttStart)
         ]
     status = mconcat
       [ if pCurrent == pTotal && pErrorsFixable == 0 && pErrorsUnfixable == 0
-        then style Faint $ color White "✓"
+        then styleIfNeeded Faint $ colorIfNeeded White "✓"
         else ""
-      , if pErrorsFixable /= 0 then color Blue "!" else ""
-      , if pErrorsUnfixable /= 0 then color Red "!" else ""
+      , if pErrorsFixable /= 0 then colorIfNeeded Blue "!" else ""
+      , if pErrorsUnfixable /= 0 then colorIfNeeded Red "!" else ""
       ]
 
     timeSecondCeiling :: Time Second -> Time Second

--- a/src/Xrefcheck/Scan.hs
+++ b/src/Xrefcheck/Scan.hs
@@ -25,8 +25,9 @@ import Universum
 import Data.Aeson (FromJSON (..), genericParseJSON)
 import Data.Foldable qualified as F
 import Data.Map qualified as M
+import Data.Reflection (Given)
 import Fmt (Buildable (..), nameF, (+|), (|+))
-import System.Console.Pretty (Pretty (..), Style (..))
+import System.Console.Pretty (Style (..))
 import System.Directory (doesDirectoryExist)
 import System.Directory.Tree qualified as Tree
 import System.FilePath (dropTrailingPathSeparator, equalFilePath, takeDirectory, takeExtension)
@@ -34,7 +35,7 @@ import System.FilePath (dropTrailingPathSeparator, equalFilePath, takeDirectory,
 import Xrefcheck.Core
 import Xrefcheck.Progress
 import Xrefcheck.System (RelGlobPattern, matchesGlobPatterns, normaliseGlobPattern, readingSystem)
-import Xrefcheck.Util (Field, aesonConfigOption, normaliseWithNoTrailing)
+import Xrefcheck.Util (ColorMode, Field, aesonConfigOption, normaliseWithNoTrailing, styleIfNeeded)
 
 -- | Type alias for TraversalConfig' with all required fields.
 type TraversalConfig = TraversalConfig' Identity
@@ -74,9 +75,9 @@ data ScanError = ScanError
   , seDescription :: Text
   } deriving stock (Show, Eq)
 
-instance Buildable ScanError where
+instance Given ColorMode => Buildable ScanError where
   build ScanError{..} =
-    "In file " +| style Faint (style Bold seFile) |+ "\n"
+    "In file " +| styleIfNeeded Faint (styleIfNeeded Bold seFile) |+ "\n"
     +| nameF ("scan error " +| sePosition |+ "") mempty |+ "\n⛀  "
     +| seDescription |+ "\n\n\n"
 

--- a/src/Xrefcheck/Scan.hs
+++ b/src/Xrefcheck/Scan.hs
@@ -27,7 +27,6 @@ import Data.Foldable qualified as F
 import Data.Map qualified as M
 import Data.Reflection (Given)
 import Fmt (Buildable (..), nameF, (+|), (|+))
-import System.Console.Pretty (Style (..))
 import System.Directory (doesDirectoryExist)
 import System.Directory.Tree qualified as Tree
 import System.FilePath (dropTrailingPathSeparator, equalFilePath, takeDirectory, takeExtension)
@@ -35,7 +34,7 @@ import System.FilePath (dropTrailingPathSeparator, equalFilePath, takeDirectory,
 import Xrefcheck.Core
 import Xrefcheck.Progress
 import Xrefcheck.System (RelGlobPattern, matchesGlobPatterns, normaliseGlobPattern, readingSystem)
-import Xrefcheck.Util (ColorMode, Field, aesonConfigOption, normaliseWithNoTrailing, styleIfNeeded)
+import Xrefcheck.Util
 
 -- | Type alias for TraversalConfig' with all required fields.
 type TraversalConfig = TraversalConfig' Identity

--- a/src/Xrefcheck/Util.hs
+++ b/src/Xrefcheck/Util.hs
@@ -7,7 +7,6 @@
 
 module Xrefcheck.Util
   ( Field
-  , nameF'
   , paren
   , postfixFields
   , (-:)
@@ -15,6 +14,9 @@ module Xrefcheck.Util
   , normaliseWithNoTrailing
   , posixTimeToTimeSecond
   , utcTimeToTimeSecond
+  , ColorMode(..)
+  , colorIfNeeded
+  , styleIfNeeded
   ) where
 
 import Universum
@@ -24,20 +26,18 @@ import Data.Aeson qualified as Aeson
 import Data.Aeson.Casing (aesonPrefix, camelCase)
 import Data.Fixed (Fixed (MkFixed), HasResolution (resolution))
 import Data.Ratio ((%))
+import Data.Reflection (Given (..))
 import Data.Time (UTCTime)
 import Data.Time.Clock (nominalDiffTimeToSeconds)
 import Data.Time.Clock.POSIX (POSIXTime, utcTimeToPOSIXSeconds)
-import Fmt (Builder, build, fmt, nameF)
-import System.Console.Pretty (Pretty (..), Style (Faint))
+import Fmt (Builder, build, fmt)
+import System.Console.Pretty (Color, Pretty (..), Style)
 import System.FilePath (dropTrailingPathSeparator, normalise)
 import Time (Second, Time (..), sec)
 
 instance Pretty Builder where
     colorize s c = build @Text . colorize s c . fmt
     style s = build @Text . style s . fmt
-
-nameF' :: Builder -> Builder -> Builder
-nameF' a = nameF (style Faint a)
 
 paren :: Builder -> Builder
 paren a
@@ -70,3 +70,15 @@ posixTimeToTimeSecond posixTime =
 
 utcTimeToTimeSecond :: UTCTime -> Time Second
 utcTimeToTimeSecond = posixTimeToTimeSecond . utcTimeToPOSIXSeconds
+
+data ColorMode = WithColors | WithoutColors
+
+colorIfNeeded :: (Pretty a, Given ColorMode) => Color -> a -> a
+colorIfNeeded = case given of
+  WithColors -> color
+  WithoutColors -> const id
+
+styleIfNeeded :: (Pretty a, Given ColorMode) => Style -> a -> a
+styleIfNeeded = case given of
+  WithColors -> style
+  WithoutColors -> const id

--- a/src/Xrefcheck/Util.hs
+++ b/src/Xrefcheck/Util.hs
@@ -3,8 +3,6 @@
  - SPDX-License-Identifier: MPL-2.0
  -}
 
-{-# OPTIONS_GHC -fno-warn-orphans #-}
-
 module Xrefcheck.Util
   ( Field
   , paren
@@ -14,9 +12,7 @@ module Xrefcheck.Util
   , normaliseWithNoTrailing
   , posixTimeToTimeSecond
   , utcTimeToTimeSecond
-  , ColorMode(..)
-  , colorIfNeeded
-  , styleIfNeeded
+  , module Xrefcheck.Util.Colorize
   ) where
 
 import Universum
@@ -26,18 +22,14 @@ import Data.Aeson qualified as Aeson
 import Data.Aeson.Casing (aesonPrefix, camelCase)
 import Data.Fixed (Fixed (MkFixed), HasResolution (resolution))
 import Data.Ratio ((%))
-import Data.Reflection (Given (..))
 import Data.Time (UTCTime)
 import Data.Time.Clock (nominalDiffTimeToSeconds)
 import Data.Time.Clock.POSIX (POSIXTime, utcTimeToPOSIXSeconds)
-import Fmt (Builder, build, fmt)
-import System.Console.Pretty (Color, Pretty (..), Style)
+import Fmt (Builder)
 import System.FilePath (dropTrailingPathSeparator, normalise)
 import Time (Second, Time (..), sec)
 
-instance Pretty Builder where
-    colorize s c = build @Text . colorize s c . fmt
-    style s = build @Text . style s . fmt
+import Xrefcheck.Util.Colorize
 
 paren :: Builder -> Builder
 paren a
@@ -70,15 +62,3 @@ posixTimeToTimeSecond posixTime =
 
 utcTimeToTimeSecond :: UTCTime -> Time Second
 utcTimeToTimeSecond = posixTimeToTimeSecond . utcTimeToPOSIXSeconds
-
-data ColorMode = WithColors | WithoutColors
-
-colorIfNeeded :: (Pretty a, Given ColorMode) => Color -> a -> a
-colorIfNeeded = case given of
-  WithColors -> color
-  WithoutColors -> const id
-
-styleIfNeeded :: (Pretty a, Given ColorMode) => Style -> a -> a
-styleIfNeeded = case given of
-  WithColors -> style
-  WithoutColors -> const id

--- a/src/Xrefcheck/Util/Colorize.hs
+++ b/src/Xrefcheck/Util/Colorize.hs
@@ -1,0 +1,46 @@
+{- SPDX-FileCopyrightText: 2018-2019 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -}
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
+module Xrefcheck.Util.Colorize
+  ( ColorMode(..)
+  , Color(..)
+  , Style(..)
+  , colorizeIfNeeded
+  , colorIfNeeded
+  , styleIfNeeded
+  ) where
+
+import Universum
+
+import Data.Reflection (Given (..))
+import Fmt (Buildable (build), Builder, fmt)
+import System.Console.Pretty (Color (..), Pretty (..), Section, Style (..))
+
+{-# HLINT ignore  "Avoid style function that ignore ColorMode" #-}
+{-# HLINT ignore  "Avoid color function that ignore ColorMode"#-}
+{-# HLINT ignore  "Avoid colorize function that ignore ColorMode"#-}
+
+data ColorMode = WithColors | WithoutColors
+
+instance Pretty Builder where
+    colorize s c = build @Text . colorize s c . fmt
+    style s = build @Text . style s . fmt
+
+colorIfNeeded :: (Pretty a, Given ColorMode) => Color -> a -> a
+colorIfNeeded = case given of
+  WithColors -> color
+  WithoutColors -> const id
+
+styleIfNeeded :: (Pretty a, Given ColorMode) => Style -> a -> a
+styleIfNeeded = case given of
+  WithColors -> style
+  WithoutColors -> const id
+
+colorizeIfNeeded :: (Pretty a, Given ColorMode) => Section -> Color -> a -> a
+colorizeIfNeeded section = case given of
+  WithColors -> colorize section
+  WithoutColors -> const id

--- a/src/Xrefcheck/Verify.hs
+++ b/src/Xrefcheck/Verify.hs
@@ -57,7 +57,6 @@ import Network.HTTP.Req
   HttpMethod, NoReqBody (..), defaultHttpConfig, ignoreResponse, req, runReq, useURI)
 import Network.HTTP.Types.Header (hRetryAfter)
 import Network.HTTP.Types.Status (Status, statusCode, statusMessage)
-import System.Console.Pretty (Style (..))
 import System.Directory (doesDirectoryExist, doesFileExist)
 import System.FilePath (normalise, takeDirectory, (</>))
 import Text.ParserCombinators.ReadPrec qualified as ReadPrec (lift)

--- a/src/Xrefcheck/Verify.hs
+++ b/src/Xrefcheck/Verify.hs
@@ -40,6 +40,7 @@ import Control.Monad.Except (MonadError (..))
 import Data.ByteString qualified as BS
 import Data.List qualified as L
 import Data.Map qualified as M
+import Data.Reflection (Given)
 import Data.Text.Metrics (damerauLevenshteinNorm)
 import Data.Time (UTCTime, defaultTimeLocale, formatTime, readPTime, rfc822DateFormat)
 import Data.Time.Clock.POSIX (getPOSIXTime)
@@ -56,7 +57,7 @@ import Network.HTTP.Req
   HttpMethod, NoReqBody (..), defaultHttpConfig, ignoreResponse, req, runReq, useURI)
 import Network.HTTP.Types.Header (hRetryAfter)
 import Network.HTTP.Types.Status (Status, statusCode, statusMessage)
-import System.Console.Pretty (Style (..), style)
+import System.Console.Pretty (Style (..))
 import System.Directory (doesDirectoryExist, doesFileExist)
 import System.FilePath (normalise, takeDirectory, (</>))
 import Text.ParserCombinators.ReadPrec qualified as ReadPrec (lift)
@@ -111,9 +112,9 @@ data WithReferenceLoc a = WithReferenceLoc
   , wrlItem      :: a
   }
 
-instance Buildable a => Buildable (WithReferenceLoc a) where
+instance (Given ColorMode, Buildable a) => Buildable (WithReferenceLoc a) where
   build WithReferenceLoc{..} =
-    "In file " +| style Faint (style Bold wrlFile) |+ "\nbad "
+    "In file " +| styleIfNeeded Faint (styleIfNeeded Bold wrlFile) |+ "\nbad "
     +| wrlReference |+ "\n"
     +| wrlItem |+ "\n\n"
 
@@ -133,7 +134,7 @@ data VerifyError
   | ExternalResourceSomeError Text
   deriving stock (Show, Eq)
 
-instance Buildable VerifyError where
+instance Given ColorMode => Buildable VerifyError where
   build = \case
     LocalFileDoesNotExist file ->
       "⛀  File does not exist:\n   " +| file |+ "\n"
@@ -244,7 +245,8 @@ forConcurrentlyCaching list needsCaching action = go [] M.empty list
     go acc _ [] = for acc wait <&> reverse
 
 verifyRepo
-  :: Rewrite
+  :: Given ColorMode
+  => Rewrite
   -> VerifyConfig
   -> VerifyMode
   -> FilePath

--- a/tests/Test/Xrefcheck/IgnoreRegexSpec.hs
+++ b/tests/Test/Xrefcheck/IgnoreRegexSpec.hs
@@ -7,6 +7,7 @@ module Test.Xrefcheck.IgnoreRegexSpec where
 
 import Universum
 
+import Data.Reflection (give)
 import Data.Yaml (decodeEither')
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (assertFailure, testCase)
@@ -17,10 +18,11 @@ import Xrefcheck.Core
 import Xrefcheck.Progress (allowRewrite)
 import Xrefcheck.Scan (ScanResult (..), scanRepo, specificFormatsSupport)
 import Xrefcheck.Scanners.Markdown
+import Xrefcheck.Util (ColorMode (WithoutColors))
 import Xrefcheck.Verify (VerifyError, VerifyResult, WithReferenceLoc (..), verifyErrors, verifyRepo)
 
 test_ignoreRegex :: TestTree
-test_ignoreRegex =
+test_ignoreRegex = give WithoutColors $
   let root = "tests/markdowns/without-annotations"
       showProgressBar = False
       formats = specificFormatsSupport [markdownSupport defGithubMdConfig]


### PR DESCRIPTION
## Description
Problem: output of xrefcheck contains ANSI-colored text,
which is bad when we redirect output to file
or when our terminal is not supporting colors.
Colorising is performed in `Buildable` instances of various types,
so we can't just pass some extra flag here

Solution: add CLI  option `--no-color`
Create `colorIfNeeded` and `styleIfNeeded` functions that have
`Data.Reflection.Given ColorMode` constraint, and replace all usages of
 `color` nd `style` by them, adding new
constraint to instances.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #1 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Fixes #185 

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](https://github.com/serokell/xrefcheck/tree/master/README.md)
    - Haddock

- Public contracts
  - [ ] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [ ] I added an entry to the [changelog](https://github.com/serokell/xrefcheck/tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [ ] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [ ] My code complies with the [style guide](https://github.com/serokell/style/blob/master/haskell.md).
