### PR TITLE
[#150] Change `ignore link` behavior

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,11 @@ Unreleased
 * [#198](https://github.com/serokell/xrefcheck/pull/198)
   + Now we're checking globs in config fields and CLI args (e.g. `ignored`),
     they must be valid globs relative to repository root (`foo/*` instead of `/foo/*`)
+* [#196](https://github.com/serokell/xrefcheck/pull/196)
+  + Now `xrefcheck: ignore link` annotation expects a link to ignore in next markdown node,
+    instead of expecting link in whole rest of file.
+    If you've got `Expected a LINK after "ignore link" annotation` message, see
+    PR's description for examples and details.
 
 0.2.1
 ==========

--- a/tests/Test/Xrefcheck/AnchorsInHeadersSpec.hs
+++ b/tests/Test/Xrefcheck/AnchorsInHeadersSpec.hs
@@ -16,11 +16,13 @@ import Xrefcheck.Core
 test_anchorsInHeaders :: TestTree
 test_anchorsInHeaders = testGroup "Anchors in headers"
   [ testCase "Check if anchors in headers are recognized" $ do
-      fi <- getFI  GitHub "tests/markdowns/without-annotations/anchors_in_headers.md"
+      (fi, errs) <- parse  GitHub "tests/markdowns/without-annotations/anchors_in_headers.md"
       getAnchors fi @?= ["some-stuff", "stuff-section"]
+      errs @?= []
   , testCase "Check if anchors with id attributes are recognized" $ do
-      fi <- getFI GitHub "tests/markdowns/without-annotations/anchors_in_headers_with_id_attribute.md"
+      (fi, errs) <- parse GitHub "tests/markdowns/without-annotations/anchors_in_headers_with_id_attribute.md"
       getAnchors fi @?= ["some-stuff-with-id-attribute", "stuff-section-with-id-attribute"]
+      errs @?= []
   ]
   where
     getAnchors :: FileInfo -> [Text]

--- a/tests/Test/Xrefcheck/AnchorsSpec.hs
+++ b/tests/Test/Xrefcheck/AnchorsSpec.hs
@@ -19,11 +19,12 @@ checkHeaderConversions fl suites =
     [testCase (show a <> " == " <> show b) $ headerToAnchor fl a @?= b | (a,b) <- suites]
     ++
     [ testCase "Non-stripped header name should be stripped" $ do
-        fi <- getFI fl "tests/markdowns/without-annotations/non_stripped_spaces.md"
+        (fi, errs) <- parse fl "tests/markdowns/without-annotations/non_stripped_spaces.md"
         getAnchors fi @?= [ case fl of GitHub -> "header--with-leading-spaces"
                                        GitLab -> "header-with-leading-spaces"
                           , "edge-case"
                           ]
+        errs @?= []
     ]
   where
     getAnchors :: FileInfo -> [Text]

--- a/tests/Test/Xrefcheck/IgnoreAnnotationsSpec.hs
+++ b/tests/Test/Xrefcheck/IgnoreAnnotationsSpec.hs
@@ -38,19 +38,23 @@ test_ignoreAnnotations =
       ]
   , testGroup "\"ignore link\" mode"
       [ testCase "Check \"ignore link\" performance" $ do
-          fi <- getFI GitHub "tests/markdowns/with-annotations/ignore_link.md"
+          let file = "tests/markdowns/with-annotations/ignore_link.md"
+          (fi, errs) <- parse GitHub file
           getRefs fi @?=
-            ["team", "team", "team", "hire-us", "how-we-work", "privacy", "link2", "link2"]
+            ["team", "team", "team", "hire-us", "how-we-work", "privacy", "link2", "link2", "link3"]
+          errs @?= makeError (Just $ PosInfo 42 1 42 31) file LinkErr
       ]
   , testGroup "\"ignore paragraph\" mode"
       [ testCase "Check \"ignore paragraph\" performance" $ do
-         fi <- getFI GitHub "tests/markdowns/with-annotations/ignore_paragraph.md"
+         (fi, errs) <- parse GitHub "tests/markdowns/with-annotations/ignore_paragraph.md"
          getRefs fi @?= ["blog", "contacts"]
+         errs @?= []
       ]
   , testGroup "\"ignore file\" mode"
       [ testCase "Check \"ignore file\" performance" $ do
-        fi <- getFI GitHub "tests/markdowns/with-annotations/ignore_file.md"
+        (fi, errs) <- parse GitHub "tests/markdowns/with-annotations/ignore_file.md"
         getRefs fi @?= []
+        errs @?= []
       ]
   ]
   where

--- a/tests/Test/Xrefcheck/Util.hs
+++ b/tests/Test/Xrefcheck/Util.hs
@@ -17,9 +17,6 @@ import Xrefcheck.Scanners.Markdown (MarkdownConfig (MarkdownConfig, mcFlavor), m
 parse :: Flavor -> FilePath -> IO (FileInfo, [ScanError])
 parse fl path = markdownScanner MarkdownConfig { mcFlavor = fl } path
 
-getFI :: Flavor -> FilePath -> IO FileInfo
-getFI fl path = fst <$> parse fl path
-
 mockServer :: IO ()
 mockServer = run 3000 $ do
   route "/401" $ pure $ toResponse ("" :: Text, unauthorized401)

--- a/tests/markdowns/with-annotations/ignore_link.md
+++ b/tests/markdowns/with-annotations/ignore_link.md
@@ -36,3 +36,14 @@ Ignore link bug _regression test_ [link1](link1) [link2](link2)
 
 <!-- xrefcheck: ignore link -->
 Another ignore link bug _some [link1](link1) emphasis_ [link2](link2)
+
+### Ignore pragma should be followed by
+
+<!-- xrefcheck: ignore link -->
+
+This annotation expects link in paragraph right after it.
+
+So [link3](link3) is not ignored.
+
+Annotation inside paragraph <!-- xrefcheck: ignore link --> allows
+softbreaks and __other *things*__ in paragraph, so [link4](link4) is ignored.


### PR DESCRIPTION
## Description

Problem:
Currently `ignore link` annotation works for a  first link after it (in a whole  file). That can be bad for user,
e.g. he may forgot to delete this annotation, and now it ignores link in some random place

Solution:
Throw scan errors when `ignore link` is not followed by a node with link. To do this, we need to increase amount  of context in `ScannerM`.

Examples:
This is now bad and reported with message `Expected a LINK after "ignore link" annotation`:
```markdown
<!-- xrefcheck: ignore link -->

foo

bar [link](link)
```

Those are still OK:
```markdown
<!-- xrefcheck: ignore link -->

foo [link](link)
```
```markdown
Foo <!-- xrefcheck: ignore link --> bar [link](link)
```


<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #1 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Fixes #150 

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](https://github.com/serokell/xrefcheck/tree/master/README.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](https://github.com/serokell/xrefcheck/tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](https://github.com/serokell/style/blob/master/haskell.md).
