### PR TITLE
v0.2.2 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@
 
 Unreleased
 ==========
+
+0.2.2
+==========
+
 * [#145](https://github.com/serokell/xrefcheck/pull/145)
   + Add check that there is no unknown fields in config.
 * [#158](https://github.com/serokell/xrefcheck/pull/158)

--- a/package.yaml
+++ b/package.yaml
@@ -5,7 +5,7 @@
 spec-version: 0.31.0
 
 name:                xrefcheck
-version:             0.2.1
+version:             0.2.2
 github:              serokell/xrefcheck
 license:             MPL-2.0
 license-file:        LICENSE


### PR DESCRIPTION
## Description
## New features

* Added support for footnotes.
* Tighter git integration. Xrefcheck now ignores all files not being tracked by git.
  References _from_ these files will not be checked; references _to_ these files will fail verification.
* Added the `--no-color` option to disable ANSI-colored text.

## Bug fixes and improvements

* Xrefcheck will no longer fail when it encountes a local link to a file with a trailing slash.
* Xrefcheck was accidentally verifying links to files matching the `--ignored` CLI option or the `ignored` config option.
  This has been fixed; such links will now be reported as invalid.
* Do not print ANSI-colored text when the terminal doesn't support coloring.
* Fail if the config file contains unknown fields / field names with typos.
* Fixed async bug where the output would sometimes [look like a mess](https://github.com/serokell/xrefcheck/issues/162)
* The `--ignored` CLI option and the `ignored`/`notScanned`/`virtualFiles` config fields now only accept relative paths/glob patterns. Absolute paths/patterns will be rejected.
* Glob patterns are now compiled [in "strict" mode](https://hackage.haskell.org/package/Glob-0.10.2/docs/System-FilePath-Glob.html#v:errorRecovery). See migration guide below.
* Verification will now fail for local links that "escape" the root directory, e.g. `[invalid-link](./../xrefcheck/README.md)`.
* The `scanners.markdown.flavor` config option is now required.

## Migration guide

### git integration

Xrefcheck now uses git to determine which files it should analyze and which it should ignore.
Please make sure you have `git` 2.18.0 or later in your PATH.

### Config file

If you have a `.xrefcheck.yaml` / `xrefcheck.yaml` config file in your repo:
* you can now remove `.git/**/*` and `.stack-work/**/*` from the `ignored` list.
* make sure the `scanners.markdown.flavor` field is set.

### Glob patterns

If you were using glob patterns in any CLI option / config field, beware these are now compiled
[in "strict" mode](https://hackage.haskell.org/package/Glob-0.10.2/docs/System-FilePath-Glob.html#v:errorRecovery).

For example, `xrefcheck --ignored '[abc'` would previously ignore a file literally named `[abc`,
but this will now be interpreted as an invalid glob pattern (unclosed character range) and rejected.
To fix it, escape any reserved characters by wrapping them in square brackets: `xrefcheck --ignored '[[]abc'`.

### `ignore link` annotations
If you had an `ignore link` annotation that didn't immediately preceed the paragraph with the link to ignore, xrefcheck 0.2.2 will now fail.

```md
<!-- xrefcheck: ignore link -->

foo

bar [link](link)
```

```
Expected a LINK after "ignore link" annotation
```

To fix this, move the annotation closer to the paragraph with the link:

```md
foo

<!-- xrefcheck: ignore link -->
bar [link](link)
```




#### ✓ Release Checklist

- [x] I updated the version number in `package.yaml`.
- [x] I updated the [changelog](https://github.com/serokell/xrefcheck/tree/master/CHANGES.md) and moved everything
      under the "Unreleased" section to a new section for this release version.
- [ ] (After merging) I edited the [auto-release](https://github.com/serokell/xrefcheck/releases/tag/auto-release).
    * Change the tag and title using the format `vX.Y.Z`.
    * Write a summary of all user-facing changes.
    * Deselect the "This is a pre-release" checkbox at the bottom.
- [ ] (After merging) I updated [`xrefcheck-action`](https://github.com/serokell/xrefcheck-action#updating-supported-versions).
- [ ] (After merging) I uploaded the package to [hackage](https://hackage.haskell.org/package/xrefcheck).
