### PR TITLE
[#206] Make bats tests space-sensitive

### DIFF
--- a/tests/golden/check-cli/check-cli.bats
+++ b/tests/golden/check-cli/check-cli.bats
@@ -33,7 +33,7 @@ load '../helpers'
   assert_output --partial "All repository links are valid."
 }
 
-@test "Reduchant slashes in ignore" {
+@test "Redundant slashes in ignore" {
   run xrefcheck \
     --ignore ./././././././//to-ignore/* \
     --root .
@@ -45,6 +45,8 @@ load '../helpers'
   to_temp xrefcheck --root .
 
   assert_diff - <<EOF
+
+
 === Invalid references found ===
 
   ➥  In file to-ignore/broken-link.md
@@ -65,6 +67,8 @@ EOF
   to_temp xrefcheck --root ././///././././//./
 
   assert_diff - <<EOF
+
+
 === Invalid references found ===
 
   ➥  In file to-ignore/broken-link.md
@@ -85,6 +89,8 @@ EOF
   to_temp xrefcheck
 
   assert_diff - <<EOF
+
+
 === Invalid references found ===
 
   ➥  In file to-ignore/broken-link.md

--- a/tests/golden/check-footnotes/expected.gold
+++ b/tests/golden/check-footnotes/expected.gold
@@ -1,3 +1,5 @@
+
+
 === Invalid references found ===
 
   ➥  In file broken-link-in-footnote/file-with-footnote-with-broken-link.md

--- a/tests/golden/check-git/check-git.bats
+++ b/tests/golden/check-git/check-git.bats
@@ -41,16 +41,18 @@ load '../helpers'
   to_temp xrefcheck
 
   assert_diff - <<EOF
+
+
 === Invalid references found ===
 
   ➥  In file git.md
-      bad reference (relative) at src:1:1-11:
-        - text: "a"
-        - link: ./a.md
-        - anchor: -
+     bad reference (relative) at src:1:1-11:
+       - text: "a"
+       - link: ./a.md
+       - anchor: -
 
-      ⛀  File does not exist:
-          a.md
+     ⛀  File does not exist:
+        a.md
 
 
 Invalid references dumped, 1 in total.

--- a/tests/golden/check-ignore/check-ignore.bats
+++ b/tests/golden/check-ignore/check-ignore.bats
@@ -41,10 +41,9 @@ load '../helpers'
 === Scan errors found ===
 
   ➥  In file to-ignore/inner-directory/broken_annotation.md
-  scan error at src:9:1-29:
+     scan error at src:9:1-29:
 
-  ⛀  Annotation "ignore all" must be at the top of markdown or right after comments at the top
-
+     ⛀  Annotation "ignore all" must be at the top of markdown or right after comments at the top
 
 
 Scan errors dumped, 1 in total.

--- a/tests/golden/check-ignore/expected.gold
+++ b/tests/golden/check-ignore/expected.gold
@@ -1,3 +1,5 @@
+
+
 === Scan errors found ===
 
   ➥  In file ./to-ignore/inner-directory/broken_annotation.md

--- a/tests/golden/check-ignoreExternalRefsTo/expected.gold
+++ b/tests/golden/check-ignoreExternalRefsTo/expected.gold
@@ -1,3 +1,5 @@
+
+
 === Invalid references found ===
 
   ➥  In file check-ignoreExternalRefsTo.md

--- a/tests/golden/check-ignoreLocalRefsTo/expected.gold
+++ b/tests/golden/check-ignoreLocalRefsTo/expected.gold
@@ -1,3 +1,5 @@
+
+
 === Invalid references found ===
 
   ➥  In file check-ignoreLocalRefsTo.md

--- a/tests/golden/check-ignoreRefsFrom/check-ignoreRefsFrom.bats
+++ b/tests/golden/check-ignoreRefsFrom/check-ignoreRefsFrom.bats
@@ -32,6 +32,8 @@ load '../helpers'
   to_temp xrefcheck -c config-directory.yaml
 
   assert_diff - <<EOF
+
+
 === Invalid references found ===
 
   ➥  In file ignoreRefsFrom/inner-directory/bad-reference.md

--- a/tests/golden/check-local-refs/expected1.gold
+++ b/tests/golden/check-local-refs/expected1.gold
@@ -1,3 +1,5 @@
+
+
 === Invalid references found ===
 
   ➥  In file dir1/dir2/d2f1.md

--- a/tests/golden/check-local-refs/expected2.gold
+++ b/tests/golden/check-local-refs/expected2.gold
@@ -1,3 +1,5 @@
+
+
 === Invalid references found ===
 
   ➥  In file dir1/dir2/d2f1.md

--- a/tests/golden/check-local-refs/expected3.gold
+++ b/tests/golden/check-local-refs/expected3.gold
@@ -1,3 +1,5 @@
+
+
 === Invalid references found ===
 
   ➥  In file dir1/dir2/d2f1.md

--- a/tests/golden/check-scan-errors/expected.gold
+++ b/tests/golden/check-scan-errors/expected.gold
@@ -1,6 +1,5 @@
 === Scan errors found ===
 
-
   ➥  In file check-scan-errors.md
      scan error at src:9:1-29:
 

--- a/tests/golden/helpers.bash
+++ b/tests/golden/helpers.bash
@@ -67,9 +67,6 @@ assert_diff() {
   : "{output_file?}"
 
   diff $output_file $1 \
-    --ignore-space-change \
     --ignore-tab-expansion \
-    --ignore-trailing-space \
-    --ignore-blank-lines \
-    --new-file # treat absent files as empty
+    --ignore-trailing-space
 }


### PR DESCRIPTION
## Description

Problem: Right now, our bats tests ignore empty lines and
leading/trailing whitespace differences between the expected output and
the actual output.

However, this could lead to accidental bugs in xrefcheck's output.

Trailing whitespace isn't very concerning (except when it's excessive
and it causes the terminal to line-wrap), but additional/missing empty
lines and leading whitespace can lead to significant changes.

Solution: Let's make these tests sensitive to empty lines and leading
whitespace.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #1 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Fixes #206

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](https://github.com/serokell/xrefcheck/tree/master/README.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](https://github.com/serokell/xrefcheck/tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](https://github.com/serokell/style/blob/master/haskell.md).

#### ✓ Release Checklist

- [ ] I updated the version number in `package.yaml`.
- [ ] I updated the [changelog](https://github.com/serokell/xrefcheck/tree/master/CHANGES.md) and moved everything
      under the "Unreleased" section to a new section for this release version.
- [ ] (After merging) I edited the [auto-release](https://github.com/serokell/xrefcheck/releases/tag/auto-release).
    * Change the tag and title using the format `vX.Y.Z`.
    * Write a summary of all user-facing changes.
    * Deselect the "This is a pre-release" checkbox at the bottom.
- [ ] (After merging) I updated [`xrefcheck-action`](https://github.com/serokell/xrefcheck-action#updating-supported-versions).
- [ ] (After merging) I uploaded the package to [hackage](https://hackage.haskell.org/package/xrefcheck).
