### PR TITLE
[#89] Handle user interrupts

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -30,6 +30,9 @@ steps:
 
   - command: nix run -f ci.nix xrefcheck-static -c xrefcheck --ignore 'tests/markdowns/**/*' --ignore 'tests/golden/**/*'
     label: Xrefcheck itself
+    retry:
+      automatic:
+        limit: 2
 
   - label: lint
     command: nix run -f ci.nix pkgs.haskellPackages.hlint -c hlint .

--- a/package.yaml
+++ b/package.yaml
@@ -85,7 +85,6 @@ library:
     - data-default
     - directory
     - dlist
-    - exceptions
     - filepath
     - raw-strings-qq
     - fmt
@@ -113,6 +112,7 @@ library:
     - yaml
     - reflection
     - nyan-interpolation
+    - safe-exceptions
 
 executables:
   xrefcheck:

--- a/src/Xrefcheck/Command.hs
+++ b/src/Xrefcheck/Command.hs
@@ -23,11 +23,12 @@ import Xrefcheck.Config
 import Xrefcheck.Core (Flavor (..))
 import Xrefcheck.Progress (allowRewrite)
 import Xrefcheck.Scan
-  (FormatsSupport, ScanError (..), ScanResult (..), scanRepo, specificFormatsSupport)
+  (FormatsSupport, ScanError (..), ScanResult (..), reportScanErrs, scanRepo,
+  specificFormatsSupport)
 import Xrefcheck.Scanners.Markdown (markdownSupport)
 import Xrefcheck.System (askWithinCI)
 import Xrefcheck.Util
-import Xrefcheck.Verify (verifyErrors, verifyRepo)
+import Xrefcheck.Verify (reportVerifyErrs, verifyErrors, verifyRepo)
 
 readConfig :: FilePath -> IO Config
 readConfig path = fmap (normaliseConfigFilePaths . overrideConfig) do
@@ -92,19 +93,3 @@ defaultAction Options{..} = do
         unless (null scanErrs) $ fmt "\n"
         reportVerifyErrs verifyErrs
         exitFailure
-  where
-    reportScanErrs errs = fmt
-      [int||
-      === Scan errors found ===
-
-      #{interpolateIndentF 2 (interpolateBlockListF' "➥ " build errs)}
-      Scan errors dumped, #{length errs} in total.
-      |]
-
-    reportVerifyErrs errs = fmt
-      [int||
-      === Invalid references found ===
-
-      #{interpolateIndentF 2 (interpolateBlockListF' "➥ " build errs)}
-      Invalid references dumped, #{length errs} in total.
-      |]

--- a/src/Xrefcheck/Core.hs
+++ b/src/Xrefcheck/Core.hs
@@ -328,7 +328,7 @@ data VerifyProgress = VerifyProgress
 initVerifyProgress :: [Reference] -> VerifyProgress
 initVerifyProgress references = VerifyProgress
   { vrLocal = initProgress (length localRefs)
-  , vrExternal = initProgress (length (L.nubBy ((==) `on` rLink) extRefs))
+  , vrExternal = initProgress (length (ordNub $ map rLink extRefs))
   }
   where
     (extRefs, localRefs) = L.partition (isExternal . locationType . rLink) references

--- a/src/Xrefcheck/Scan.hs
+++ b/src/Xrefcheck/Scan.hs
@@ -25,6 +25,7 @@ module Xrefcheck.Scan
   , ecIgnoreLocalRefsToL
   , ecIgnoreRefsFromL
   , ecIgnoreExternalRefsToL
+  , reportScanErrs
   ) where
 
 import Universum
@@ -34,7 +35,7 @@ import Data.Aeson (FromJSON (..), genericParseJSON, withText)
 import Data.List qualified as L
 import Data.Map qualified as M
 import Data.Reflection (Given)
-import Fmt (Buildable (..))
+import Fmt (Buildable (..), fmt)
 import System.Directory (doesDirectoryExist)
 import System.FilePath
   (dropTrailingPathSeparator, equalFilePath, splitDirectories, takeDirectory, takeExtension, (</>))
@@ -101,6 +102,15 @@ instance Given ColorMode => Buildable ScanError where
     ⛀  #{seDescription}
 
     |]
+
+reportScanErrs :: Given ColorMode => NonEmpty ScanError -> IO ()
+reportScanErrs errs = fmt
+  [int||
+  === Scan errors found ===
+
+  #{interpolateIndentF 2 (interpolateBlockListF' "➥ " build errs)}
+  Scan errors dumped, #{length errs} in total.
+  |]
 
 data ScanErrorDescription
   = LinkErr


### PR DESCRIPTION
## Description

Currently, if xrefcheck is interrupted, it's not displaying any `VerifyError`s, even if it has already found some. When we found error, we are notifying user via progress bar, but he must wait checking of all references to see it
(and it can be long enough).

Solution: when xrefcheck is interrupted, display all errors we have already found and a number of
checked references.
To do this, we need to modify `forConcurrentlyCaching` behaviour on exceptions.


<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #1 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Fixes #89

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](https://github.com/serokell/xrefcheck/tree/master/README.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [ ] I added an entry to the [changelog](https://github.com/serokell/xrefcheck/tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](https://github.com/serokell/style/blob/master/haskell.md).
