### PR TITLE
[#208] Remove exessive newlines from output

### DIFF
--- a/src/Xrefcheck/Command.hs
+++ b/src/Xrefcheck/Command.hs
@@ -75,7 +75,7 @@ defaultAction Options{..} = do
       fmt [int||
       === Repository data ===
 
-      #{indentF 2 (build repoInfo)}
+      #{indentF 2 (build repoInfo)}\
       |]
 
     unless (null scanErrs) . reportScanErrs $ sortBy (compare `on` seFile) scanErrs
@@ -89,7 +89,7 @@ defaultAction Options{..} = do
       Nothing | null scanErrs -> fmtLn "All repository links are valid."
       Nothing -> exitFailure
       Just (toList -> verifyErrs) -> do
-        fmt "\n\n"
+        unless (null scanErrs) $ fmt "\n"
         reportVerifyErrs verifyErrs
         exitFailure
   where

--- a/src/Xrefcheck/Scan.hs
+++ b/src/Xrefcheck/Scan.hs
@@ -100,7 +100,6 @@ instance Given ColorMode => Buildable ScanError where
 
     ⛀  #{seDescription}
 
-
     |]
 
 data ScanErrorDescription

--- a/src/Xrefcheck/Verify.hs
+++ b/src/Xrefcheck/Verify.hs
@@ -118,7 +118,6 @@ instance (Given ColorMode, Buildable a) => Buildable (WithReferenceLoc a) where
     In file #{styleIfNeeded Faint (styleIfNeeded Bold wrlFile)}
     bad #{wrlReference}
     #{wrlItem}
-
     |]
 
 data VerifyError
@@ -160,7 +159,7 @@ instance Given ColorMode => Buildable VerifyError where
       | otherwise ->
         [int||
         ⛀  Anchor '#{anchor}' is not present, did you mean:
-        #{indentF 4 $ blockListF similar}
+        #{indentF 4 $ blockListF similar}\
         |]
 
     AmbiguousAnchorRef file anchor fileAnchors ->
@@ -229,7 +228,6 @@ instance Given ColorMode => Buildable VerifyError where
     ExternalResourceSomeError err ->
       [int||
       ⛂  #{err}
-
       |]
 
 data RetryAfter = Date UTCTime | Seconds (Time Second)

--- a/tests/golden/check-anchors/check-anchors.bats
+++ b/tests/golden/check-anchors/check-anchors.bats
@@ -12,8 +12,6 @@ load '../helpers'
 @test "We report ambiguous anchor references" {
   to_temp xrefcheck -r ambiguous-anchors
 assert_diff - <<EOF
-
-
 === Invalid references found ===
 
   ➥  In file ambiguous-anchors/a.md
@@ -32,7 +30,6 @@ assert_diff - <<EOF
          Use of ambiguous anchors is discouraged because the target
          can change silently while the document containing it evolves.
 
-
   ➥  In file ambiguous-anchors/b.md
      bad reference (relative) at src:7:1-48:
        - text: "ambiguous anchor in other file"
@@ -49,7 +46,6 @@ assert_diff - <<EOF
          Use of ambiguous anchors is discouraged because the target
          can change silently while the document containing it evolves.
 
-
 Invalid references dumped, 2 in total.
 EOF
 }
@@ -57,8 +53,6 @@ EOF
 @test "We report references to non-existing anchors, giving hints about similar ones" {
   to_temp xrefcheck -r non-existing-anchors
 assert_diff - <<EOF
-
-
 === Invalid references found ===
 
   ➥  In file non-existing-anchors/a.md
@@ -71,8 +65,6 @@ assert_diff - <<EOF
          - h1 (header I) at src:6:1-4
          - h2 (header II) at src:8:1-5
 
-
-
   ➥  In file non-existing-anchors/a.md
      bad reference (current file) at src:14:1-18:
        - text: "broken"
@@ -82,8 +74,6 @@ assert_diff - <<EOF
      ⛀  Anchor 'heading' is not present, did you mean:
          - the-heading (header I) at src:10:1-13
 
-
-
   ➥  In file non-existing-anchors/a.md
      bad reference (current file) at src:16:1-31:
        - text: "broken"
@@ -91,7 +81,6 @@ assert_diff - <<EOF
        - anchor: really-unique-anchor
 
      ⛀  Anchor 'really-unique-anchor' is not present
-
 
 Invalid references dumped, 3 in total.
 EOF

--- a/tests/golden/check-autolinks/check-autolinks.bats
+++ b/tests/golden/check-autolinks/check-autolinks.bats
@@ -27,7 +27,6 @@ assert_diff - <<EOF
     - anchors:
         []
 
-
 All repository links are valid.
 EOF
 }

--- a/tests/golden/check-cli/check-cli.bats
+++ b/tests/golden/check-cli/check-cli.bats
@@ -45,8 +45,6 @@ load '../helpers'
   to_temp xrefcheck --root .
 
   assert_diff - <<EOF
-
-
 === Invalid references found ===
 
   ➥  In file to-ignore/broken-link.md
@@ -57,7 +55,6 @@ load '../helpers'
 
      ⛀  File does not exist:
         ./one/two/three
-
 
 Invalid references dumped, 1 in total.
 EOF
@@ -67,8 +64,6 @@ EOF
   to_temp xrefcheck --root ././///././././//./
 
   assert_diff - <<EOF
-
-
 === Invalid references found ===
 
   ➥  In file to-ignore/broken-link.md
@@ -79,7 +74,6 @@ EOF
 
      ⛀  File does not exist:
         ./one/two/three
-
 
 Invalid references dumped, 1 in total.
 EOF
@@ -89,8 +83,6 @@ EOF
   to_temp xrefcheck
 
   assert_diff - <<EOF
-
-
 === Invalid references found ===
 
   ➥  In file to-ignore/broken-link.md
@@ -101,7 +93,6 @@ EOF
 
      ⛀  File does not exist:
         ./one/two/three
-
 
 Invalid references dumped, 1 in total.
 EOF

--- a/tests/golden/check-footnotes/expected.gold
+++ b/tests/golden/check-footnotes/expected.gold
@@ -1,5 +1,3 @@
-
-
 === Invalid references found ===
 
   ➥  In file broken-link-in-footnote/file-with-footnote-with-broken-link.md
@@ -10,6 +8,5 @@
 
      ⛀  File does not exist:
         broken-link-in-footnote/notExists
-
 
 Invalid references dumped, 1 in total.

--- a/tests/golden/check-git/check-git.bats
+++ b/tests/golden/check-git/check-git.bats
@@ -41,8 +41,6 @@ load '../helpers'
   to_temp xrefcheck
 
   assert_diff - <<EOF
-
-
 === Invalid references found ===
 
   ➥  In file git.md
@@ -53,7 +51,6 @@ load '../helpers'
 
      ⛀  File does not exist:
         a.md
-
 
 Invalid references dumped, 1 in total.
 EOF

--- a/tests/golden/check-ignore/check-ignore.bats
+++ b/tests/golden/check-ignore/check-ignore.bats
@@ -45,7 +45,6 @@ load '../helpers'
 
      ⛀  Annotation "ignore all" must be at the top of markdown or right after comments at the top
 
-
 Scan errors dumped, 1 in total.
 EOF
 }
@@ -61,9 +60,7 @@ EOF
 
      ⛀  Annotation "ignore all" must be at the top of markdown or right after comments at the top
 
-
 Scan errors dumped, 1 in total.
-
 
 === Invalid references found ===
 
@@ -75,7 +72,6 @@ Scan errors dumped, 1 in total.
 
      ⛀  File does not exist:
         ./referenced-file.md
-
 
 Invalid references dumped, 1 in total.
 EOF

--- a/tests/golden/check-ignore/expected.gold
+++ b/tests/golden/check-ignore/expected.gold
@@ -1,11 +1,8 @@
-
-
 === Scan errors found ===
 
   ➥  In file ./to-ignore/inner-directory/broken_annotation.md
      scan error at src:9:1-29:
 
      ⛀  Annotation "ignore all" must be at the top of markdown or right after comments at the top
-
 
 Scan errors dumped, 1 in total.

--- a/tests/golden/check-ignoreExternalRefsTo/expected.gold
+++ b/tests/golden/check-ignoreExternalRefsTo/expected.gold
@@ -1,5 +1,3 @@
-
-
 === Invalid references found ===
 
   ➥  In file check-ignoreExternalRefsTo.md
@@ -10,8 +8,6 @@
 
      ⛂  InternalException (HostCannotConnect "localhost" [Network.Socket.connect: <socket: N>: does not exist (Connection refused)])
 
-
-
   ➥  In file check-ignoreExternalRefsTo.md
      bad reference (external) at src:9:10-45:
        - text: "team"
@@ -19,8 +15,6 @@
        - anchor: -
 
      ⛂  InternalException (HostCannotConnect "127.0.0.1" [Network.Socket.connect: <socket: N>: does not exist (Connection refused)])
-
-
 
   ➥  In file check-ignoreExternalRefsTo.md
      bad reference (external) at src:11:10-44:
@@ -30,8 +24,6 @@
 
      ⛂  ConnectionFailure Network.Socket.connect: <socket: N>: does not exist (Connection refused)
 
-
-
   ➥  In file check-ignoreExternalRefsTo.md
      bad reference (external) at src:13:10-44:
        - text: "labs"
@@ -39,7 +31,5 @@
        - anchor: -
 
      ⛂  ConnectionFailure Network.Socket.connect: <socket: N>: does not exist (Connection refused)
-
-
 
 Invalid references dumped, 4 in total.

--- a/tests/golden/check-ignoreLocalRefsTo/expected.gold
+++ b/tests/golden/check-ignoreLocalRefsTo/expected.gold
@@ -1,5 +1,3 @@
-
-
 === Invalid references found ===
 
   ➥  In file check-ignoreLocalRefsTo.md
@@ -11,7 +9,6 @@
      ⛀  File does not exist:
         ./one/a.md
 
-
   ➥  In file check-ignoreLocalRefsTo.md
      bad reference (absolute) at src:9:1-26:
        - text: "glob wildcard"
@@ -20,7 +17,6 @@
 
      ⛀  File does not exist:
         ./two/b.md
-
 
   ➥  In file check-ignoreLocalRefsTo.md
      bad reference (absolute) at src:11:1-39:
@@ -31,7 +27,6 @@
      ⛀  File does not exist:
         ./three/c.md
 
-
   ➥  In file check-ignoreLocalRefsTo.md
      bad reference (absolute) at src:13:1-51:
        - text: "recursive nested directory glob"
@@ -40,7 +35,6 @@
 
      ⛀  File does not exist:
         ./three/four/d.md
-
 
   ➥  In file check-ignoreLocalRefsTo.md
      bad reference (absolute) at src:15:1-59:
@@ -51,7 +45,6 @@
      ⛀  File does not exist:
         ./three/five/e.md
 
-
   ➥  In file one/file.md
      bad reference (relative) at src:7:1-58:
        - text: "check ignoreLocalRefsTo are relative to the root"
@@ -61,7 +54,6 @@
      ⛀  File does not exist:
         one/a.md
 
-
   ➥  In file one/file.md
      bad reference (relative) at src:9:1-23:
        - text: "one more"
@@ -70,6 +62,5 @@
 
      ⛀  File does not exist:
         one/../two/b.md
-
 
 Invalid references dumped, 7 in total.

--- a/tests/golden/check-ignoreRefsFrom/check-ignoreRefsFrom.bats
+++ b/tests/golden/check-ignoreRefsFrom/check-ignoreRefsFrom.bats
@@ -32,8 +32,6 @@ load '../helpers'
   to_temp xrefcheck -c config-directory.yaml
 
   assert_diff - <<EOF
-
-
 === Invalid references found ===
 
   ➥  In file ignoreRefsFrom/inner-directory/bad-reference.md
@@ -44,7 +42,6 @@ load '../helpers'
 
      ⛀  File does not exist:
         ./no-file.md
-
 
 Invalid references dumped, 1 in total.
 EOF

--- a/tests/golden/check-images/expected.gold
+++ b/tests/golden/check-images/expected.gold
@@ -29,9 +29,6 @@
     - anchors:
         []
 
-
-
-
 === Invalid references found ===
 
   ➥  In file check-images.md
@@ -42,7 +39,6 @@
 
      ⛂  Resource unavailable (404 Not Found)
 
-
   ➥  In file check-images.md
      bad reference (external) at src:16:1-33:
        - text: "bad image ref 2"
@@ -50,7 +46,6 @@
        - anchor: -
 
      ⛂  Resource unavailable (404 Not Found)
-
 
   ➥  In file check-images.md
      bad reference (relative) at src:20:1-34:
@@ -61,7 +56,6 @@
      ⛀  File does not exist:
         3.png
 
-
   ➥  In file check-images.md
      bad reference (relative) at src:21:1-33:
        - text: "bad image ref 4"
@@ -70,6 +64,5 @@
 
      ⛀  File does not exist:
         4.png
-
 
 Invalid references dumped, 4 in total.

--- a/tests/golden/check-local-refs/expected1.gold
+++ b/tests/golden/check-local-refs/expected1.gold
@@ -1,5 +1,3 @@
-
-
 === Invalid references found ===
 
   ➥  In file dir1/dir2/d2f1.md
@@ -10,7 +8,6 @@
 
      ⛀  Anchor 'bad' is not present
 
-
   ➥  In file dir1/dir2/d2f1.md
      bad reference (relative) at src:27:1-43:
        - text: "bad-file-rel"
@@ -19,7 +16,6 @@
 
      ⛀  File does not exist:
         dir1/dir2/../a/b/c/unexisting-file.md
-
 
   ➥  In file dir1/dir2/d2f1.md
      bad reference (relative) at src:28:1-31:
@@ -30,7 +26,6 @@
      ⛀  File does not exist:
         dir1/dir2/D2F2.md/
 
-
   ➥  In file dir1/dir2/d2f1.md
      bad reference (relative) at src:29:1-32:
        - text: "bad-casing-folder-rel"
@@ -40,7 +35,6 @@
      ⛀  File does not exist:
         dir1/dir2/../DIR2
 
-
   ➥  In file dir1/dir2/d2f1.md
      bad reference (relative) at src:31:1-38:
        - text: "bad-anchor-rel-1"
@@ -48,7 +42,6 @@
        - anchor: bad-anchor
 
      ⛀  Anchor 'bad-anchor' is not present
-
 
   ➥  In file dir1/dir2/d2f1.md
      bad reference (relative) at src:32:1-49:
@@ -59,7 +52,6 @@
      ⛀  File does not exist:
         dir1/dir2/unexisting-file.md
 
-
   ➥  In file dir1/dir2/d2f1.md
      bad reference (absolute) at src:42:1-22:
        - text: "file-abs-2"
@@ -68,7 +60,6 @@
 
      ⛀  File does not exist:
         ./d1f1.md
-
 
   ➥  In file dir1/dir2/d2f1.md
      bad reference (absolute) at src:43:1-27:
@@ -79,7 +70,6 @@
      ⛀  File does not exist:
         ./dir2/d2f2.md
 
-
   ➥  In file dir1/dir2/d2f1.md
      bad reference (absolute) at src:44:1-32:
        - text: "file-abs-4"
@@ -88,7 +78,6 @@
 
      ⛀  File does not exist:
         ././dir2/../d1f1.md
-
 
   ➥  In file dir1/dir2/d2f1.md
      bad reference (absolute) at src:45:1-37:
@@ -99,7 +88,6 @@
      ⛀  File does not exist:
         ././dir2/../d1f1.md/
 
-
   ➥  In file dir1/dir2/d2f1.md
      bad reference (absolute) at src:46:1-55:
        - text: "anchor-abs-3"
@@ -108,7 +96,6 @@
 
      ⛀  File does not exist:
         ././dir2/../d1f1.md
-
 
   ➥  In file dir1/dir2/d2f1.md
      bad reference (absolute) at src:57:1-16:
@@ -119,7 +106,6 @@
      ⛀  Link targets a local file outside repository:
         ./../../a.md
 
-
   ➥  In file dir1/dir2/d2f1.md
      bad reference (absolute) at src:58:1-18:
        - text: "B"
@@ -128,6 +114,5 @@
 
      ⛀  Link targets a local file outside repository:
         ./b/../../b.md
-
 
 Invalid references dumped, 13 in total.

--- a/tests/golden/check-local-refs/expected2.gold
+++ b/tests/golden/check-local-refs/expected2.gold
@@ -1,5 +1,3 @@
-
-
 === Invalid references found ===
 
   ➥  In file dir1/dir2/d2f1.md
@@ -10,7 +8,6 @@
 
      ⛀  Anchor 'bad' is not present
 
-
   ➥  In file dir1/dir2/d2f1.md
      bad reference (relative) at src:27:1-43:
        - text: "bad-file-rel"
@@ -19,7 +16,6 @@
 
      ⛀  File does not exist:
         dir1/dir2/../a/b/c/unexisting-file.md
-
 
   ➥  In file dir1/dir2/d2f1.md
      bad reference (relative) at src:28:1-31:
@@ -30,7 +26,6 @@
      ⛀  File does not exist:
         dir1/dir2/D2F2.md/
 
-
   ➥  In file dir1/dir2/d2f1.md
      bad reference (relative) at src:29:1-32:
        - text: "bad-casing-folder-rel"
@@ -40,7 +35,6 @@
      ⛀  File does not exist:
         dir1/dir2/../DIR2
 
-
   ➥  In file dir1/dir2/d2f1.md
      bad reference (relative) at src:31:1-38:
        - text: "bad-anchor-rel-1"
@@ -48,7 +42,6 @@
        - anchor: bad-anchor
 
      ⛀  Anchor 'bad-anchor' is not present
-
 
   ➥  In file dir1/dir2/d2f1.md
      bad reference (relative) at src:32:1-49:
@@ -59,7 +52,6 @@
      ⛀  File does not exist:
         dir1/dir2/unexisting-file.md
 
-
   ➥  In file dir1/dir2/d2f1.md
      bad reference (absolute) at src:36:1-29:
        - text: "file-abs-1"
@@ -68,7 +60,6 @@
 
      ⛀  File does not exist:
         dir1/dir1/./d1f1.md
-
 
   ➥  In file dir1/dir2/d2f1.md
      bad reference (absolute) at src:37:1-21:
@@ -79,7 +70,6 @@
      ⛀  File does not exist:
         dir1/dir1
 
-
   ➥  In file dir1/dir2/d2f1.md
      bad reference (absolute) at src:38:1-30:
        - text: "folder-abs-2"
@@ -88,7 +78,6 @@
 
      ⛀  File does not exist:
         dir1/dir1/dir2/../
-
 
   ➥  In file dir1/dir2/d2f1.md
      bad reference (absolute) at src:39:1-58:
@@ -99,7 +88,6 @@
      ⛀  File does not exist:
         dir1/dir1/../dir1/d1f1.md
 
-
   ➥  In file dir1/dir2/d2f1.md
      bad reference (absolute) at src:40:1-73:
        - text: "anchor-abs-2"
@@ -108,7 +96,6 @@
 
      ⛀  File does not exist:
         dir1/dir1/dir2/../../dir1/./dir2/d2f2.md
-
 
   ➥  In file dir1/dir2/d2f1.md
      bad reference (relative) at src:51:1-42:
@@ -119,7 +106,6 @@
      ⛀  Link targets a local file outside repository:
         dir1/dir2/../../dir1/d1f1.md
 
-
   ➥  In file dir1/dir2/d2f1.md
      bad reference (relative) at src:52:1-75:
        - text: "path-through-top-dir-with-anchor"
@@ -128,7 +114,6 @@
 
      ⛀  Link targets a local file outside repository:
         dir1/dir2/../../dir1/d1f1.md
-
 
   ➥  In file dir1/dir2/d2f1.md
      bad reference (relative) at src:53:1-26:
@@ -139,7 +124,6 @@
      ⛀  Link targets a local file outside repository:
         dir1/dir2/../../d0f1.md
 
-
   ➥  In file dir1/dir2/d2f1.md
      bad reference (absolute) at src:57:1-16:
        - text: "A"
@@ -149,7 +133,6 @@
      ⛀  Link targets a local file outside repository:
         dir1/../../a.md
 
-
   ➥  In file dir1/dir2/d2f1.md
      bad reference (absolute) at src:58:1-18:
        - text: "B"
@@ -158,6 +141,5 @@
 
      ⛀  Link targets a local file outside repository:
         dir1/b/../../b.md
-
 
 Invalid references dumped, 16 in total.

--- a/tests/golden/check-local-refs/expected3.gold
+++ b/tests/golden/check-local-refs/expected3.gold
@@ -1,5 +1,3 @@
-
-
 === Invalid references found ===
 
   ➥  In file dir1/dir2/d2f1.md
@@ -10,7 +8,6 @@
 
      ⛀  Anchor 'bad' is not present
 
-
   ➥  In file dir1/dir2/d2f1.md
      bad reference (relative) at src:27:1-43:
        - text: "bad-file-rel"
@@ -19,7 +16,6 @@
 
      ⛀  File does not exist:
         dir1/dir2/../a/b/c/unexisting-file.md
-
 
   ➥  In file dir1/dir2/d2f1.md
      bad reference (relative) at src:28:1-31:
@@ -30,7 +26,6 @@
      ⛀  File does not exist:
         dir1/dir2/D2F2.md/
 
-
   ➥  In file dir1/dir2/d2f1.md
      bad reference (relative) at src:31:1-38:
        - text: "bad-anchor-rel-1"
@@ -38,7 +33,6 @@
        - anchor: bad-anchor
 
      ⛀  Anchor 'bad-anchor' is not present
-
 
   ➥  In file dir1/dir2/d2f1.md
      bad reference (relative) at src:32:1-49:
@@ -49,7 +43,6 @@
      ⛀  File does not exist:
         dir1/dir2/unexisting-file.md
 
-
   ➥  In file dir1/dir2/d2f1.md
      bad reference (absolute) at src:36:1-29:
        - text: "file-abs-1"
@@ -58,7 +51,6 @@
 
      ⛀  File does not exist:
         dir1/dir1/./d1f1.md
-
 
   ➥  In file dir1/dir2/d2f1.md
      bad reference (absolute) at src:37:1-21:
@@ -69,7 +61,6 @@
      ⛀  File does not exist:
         dir1/dir1
 
-
   ➥  In file dir1/dir2/d2f1.md
      bad reference (absolute) at src:38:1-30:
        - text: "folder-abs-2"
@@ -78,7 +69,6 @@
 
      ⛀  File does not exist:
         dir1/dir1/dir2/../
-
 
   ➥  In file dir1/dir2/d2f1.md
      bad reference (absolute) at src:39:1-58:
@@ -89,7 +79,6 @@
      ⛀  File does not exist:
         dir1/dir1/../dir1/d1f1.md
 
-
   ➥  In file dir1/dir2/d2f1.md
      bad reference (absolute) at src:40:1-73:
        - text: "anchor-abs-2"
@@ -98,7 +87,6 @@
 
      ⛀  File does not exist:
         dir1/dir1/dir2/../../dir1/./dir2/d2f2.md
-
 
   ➥  In file dir1/dir2/d2f1.md
      bad reference (relative) at src:51:1-42:
@@ -109,7 +97,6 @@
      ⛀  Link targets a local file outside repository:
         dir1/dir2/../../dir1/d1f1.md
 
-
   ➥  In file dir1/dir2/d2f1.md
      bad reference (relative) at src:52:1-75:
        - text: "path-through-top-dir-with-anchor"
@@ -118,6 +105,5 @@
 
      ⛀  Link targets a local file outside repository:
         dir1/dir2/../../dir1/d1f1.md
-
 
 Invalid references dumped, 12 in total.

--- a/tests/golden/check-scan-errors/expected.gold
+++ b/tests/golden/check-scan-errors/expected.gold
@@ -5,45 +5,37 @@
 
      ⛀  Annotation "ignore all" must be at the top of markdown or right after comments at the top
 
-
   ➥  In file check-scan-errors.md
      scan error at src:13:1-36:
 
      ⛀  Expected a PARAGRAPH after "ignore paragraph" annotation, but found HEADING
-
 
   ➥  In file check-scan-errors.md
      scan error at src:17:1-31:
 
      ⛀  Expected a LINK after "ignore link" annotation
 
-
   ➥  In file check-scan-errors.md
      scan error at src:21:1-50:
 
      ⛀  Unrecognised option "unrecognised-annotation" perhaps you meant <"ignore link"|"ignore paragraph"|"ignore all">
-
 
   ➥  In file check-second-file.md
      scan error at src:9:1-29:
 
      ⛀  Annotation "ignore all" must be at the top of markdown or right after comments at the top
 
-
   ➥  In file no_link_eof.md
      scan error at src:9:1-31:
 
      ⛀  Expected a LINK after "ignore link" annotation
-
 
   ➥  In file no_paragraph_eof.md
      scan error at src:9:1-36:
 
      ⛀  Expected a PARAGRAPH after "ignore paragraph" annotation, but found EOF
 
-
 Scan errors dumped, 7 in total.
-
 
 === Invalid references found ===
 
@@ -56,7 +48,6 @@ Scan errors dumped, 7 in total.
      ⛀  File does not exist:
         ./no-file.md
 
-
   ➥  In file check-scan-errors.md
      bad reference (relative) at src:23:1-24:
        - text: "Bad link"
@@ -66,7 +57,6 @@ Scan errors dumped, 7 in total.
      ⛀  File does not exist:
         bad.link.com
 
-
   ➥  In file check-second-file.md
      bad reference (absolute) at src:11:1-30:
        - text: "Another bad reference"
@@ -75,6 +65,5 @@ Scan errors dumped, 7 in total.
 
      ⛀  File does not exist:
         ./a.md
-
 
 Invalid references dumped, 3 in total.


### PR DESCRIPTION
## Description

Problem: xrefcheck's output contains many redundant newlines, so it takes more display space than it could.
For list of places where such newlines appear, see #208

Solution: don't print redundant newlines, so output is more compact. Since tests are newline-sensetive, I've checked that now there are no extra  (e.g. 2 ajacent) blank lines in `expected` part of tests.


<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #1 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Fixes #208

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](https://github.com/serokell/xrefcheck/tree/master/README.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [ ] I added an entry to the [changelog](https://github.com/serokell/xrefcheck/tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](https://github.com/serokell/style/blob/master/haskell.md).

