### PR TITLE
[#213] Do not print trailing whitespaces

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -110,3 +110,15 @@
     name: "Avoid style function that ignore ColorMode"
     lhs: 'System.Console.Pretty.style'
     rhs: 'Xrefcheck.Util.Colorize.styleIfNeeded'
+- warn:
+    name: "Avoid functions that generate extra trailing newlines/whitespaces"
+    lhs: 'Fmt.indentF'
+    rhs: 'Xrefcheck.Util.Interpolate.interpolateIndentF'
+- warn:
+    name: "Avoid functions that generate extra trailing newlines/whitespaces"
+    lhs: 'Fmt.blockListF'
+    rhs: 'Xrefcheck.Util.Interpolate.interpolateBlockListF'
+- warn:
+    name: "Avoid functions that generate extra trailing newlines/whitespaces"
+    lhs: "Fmt.blockListF'"
+    rhs: "Xrefcheck.Util.Interpolate.interpolateBlockListF'"

--- a/package.yaml
+++ b/package.yaml
@@ -146,7 +146,6 @@ tests:
       - xrefcheck
       - bytestring
       - directory
-      - fmt
       - http-types
       - o-clock
       - regex-tdfa
@@ -159,6 +158,7 @@ tests:
       - uri-bytestring
       - yaml
       - reflection
+      - nyan-interpolation
 
   ftp-tests:
     main: Main.hs

--- a/src/Xrefcheck/Command.hs
+++ b/src/Xrefcheck/Command.hs
@@ -11,7 +11,7 @@ import Universum
 
 import Data.Reflection (give)
 import Data.Yaml (decodeFileEither, prettyPrintParseException)
-import Fmt (blockListF', build, fmt, fmtLn, indentF)
+import Fmt (build, fmt, fmtLn)
 import System.Console.Pretty (supportsPretty)
 import System.Directory (doesFileExist)
 import Text.Interpolation.Nyan
@@ -75,10 +75,10 @@ defaultAction Options{..} = do
       fmt [int||
       === Repository data ===
 
-      #{indentF 2 (build repoInfo)}\
+      #{interpolateIndentF 2 (build repoInfo)}
       |]
 
-    unless (null scanErrs) . reportScanErrs $ sortBy (compare `on` seFile) scanErrs
+    whenJust (nonEmpty $ sortBy (compare `on` seFile) scanErrs) $ reportScanErrs
 
     verifyRes <- allowRewrite showProgressBar $ \rw -> do
       let fullConfig = config
@@ -88,7 +88,7 @@ defaultAction Options{..} = do
     case verifyErrors verifyRes of
       Nothing | null scanErrs -> fmtLn "All repository links are valid."
       Nothing -> exitFailure
-      Just (toList -> verifyErrs) -> do
+      Just verifyErrs -> do
         unless (null scanErrs) $ fmt "\n"
         reportVerifyErrs verifyErrs
         exitFailure
@@ -97,7 +97,7 @@ defaultAction Options{..} = do
       [int||
       === Scan errors found ===
 
-      #{indentF 2 (blockListF' "➥ " build errs)}\
+      #{interpolateIndentF 2 (interpolateBlockListF' "➥ " build errs)}
       Scan errors dumped, #{length errs} in total.
       |]
 
@@ -105,6 +105,6 @@ defaultAction Options{..} = do
       [int||
       === Invalid references found ===
 
-      #{indentF 2 (blockListF' "➥ " build errs)}\
+      #{interpolateIndentF 2 (interpolateBlockListF' "➥ " build errs)}
       Invalid references dumped, #{length errs} in total.
       |]

--- a/src/Xrefcheck/Config.hs
+++ b/src/Xrefcheck/Config.hs
@@ -18,9 +18,9 @@ import Data.ByteString qualified as BS
 import Data.Map qualified as Map
 import Data.Yaml (FromJSON (..), decodeEither', prettyPrintParseException, withText)
 import Instances.TH.Lift ()
+import Text.Interpolation.Nyan
 import Text.Regex.TDFA qualified as R
 import Text.Regex.TDFA.ByteString ()
-import Text.Interpolation.Nyan
 
 import Time (KnownRatName, Second, Time (..), unitsP)
 

--- a/src/Xrefcheck/Scanners/Markdown.hs
+++ b/src/Xrefcheck/Scanners/Markdown.hs
@@ -25,13 +25,13 @@ import Control.Lens (_Just, makeLenses, makeLensesFor, (.=))
 import Control.Monad.Trans.Writer.CPS (Writer, runWriter, tell)
 import Data.Aeson (FromJSON (..), genericParseJSON)
 import Data.ByteString.Lazy qualified as BSL
-import Data.DList qualified as DList
 import Data.Default (def)
+import Data.DList qualified as DList
 import Data.Text qualified as T
 import Data.Text.Lazy qualified as LT
-import Fmt (Buildable (..), blockListF, nameF)
-import Text.Interpolation.Nyan
+import Fmt (Buildable (..), nameF)
 import Text.HTML.TagSoup
+import Text.Interpolation.Nyan
 
 import Xrefcheck.Core
 import Xrefcheck.Scan
@@ -50,7 +50,8 @@ defGithubMdConfig = MarkdownConfig
   }
 
 instance Buildable Node where
-  build (Node _mpos ty subs) = nameF (show ty) $ blockListF subs
+  build (Node _mpos ty mSubs) = nameF (show ty) $
+    maybe "[]" interpolateBlockListF (nonEmpty mSubs)
 
 toPosition :: Maybe PosInfo -> Position
 toPosition = Position . \case

--- a/src/Xrefcheck/Util.hs
+++ b/src/Xrefcheck/Util.hs
@@ -13,6 +13,7 @@ module Xrefcheck.Util
   , posixTimeToTimeSecond
   , utcTimeToTimeSecond
   , module Xrefcheck.Util.Colorize
+  , module Xrefcheck.Util.Interpolate
   ) where
 
 import Universum
@@ -30,6 +31,7 @@ import System.FilePath (dropTrailingPathSeparator, normalise)
 import Time (Second, Time (..), sec)
 
 import Xrefcheck.Util.Colorize
+import Xrefcheck.Util.Interpolate
 
 paren :: Builder -> Builder
 paren a

--- a/src/Xrefcheck/Util/Interpolate.hs
+++ b/src/Xrefcheck/Util/Interpolate.hs
@@ -1,0 +1,81 @@
+{- SPDX-FileCopyrightText: 2018-2019 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
+module Xrefcheck.Util.Interpolate
+  ( -- $notes
+    interpolateIndentF
+  , interpolateBlockListF
+  , interpolateBlockListF'
+  )
+  where
+
+import Universum
+
+import Data.Text.Lazy qualified as TL
+import Data.Text.Lazy.Builder (fromLazyText, toLazyText)
+import Fmt (Buildable, Builder, blockListF, blockListF', indentF)
+
+{- $notes
+The `blockListF` and `indentF` frunctions from @fmt@ add a trailing newline, which makes them unsuitable for string interpolation.
+Consider this case:
+> [int||
+> aaa
+> #{indentF 2 "bbb"}
+> ccc
+> |]
+One would reasonably expect this to produce:
+> aaa
+>   bbb
+> ccc
+But, in reality, it produces:
+> aaa
+>   bbb
+>
+> ccc
+This module introduces versions of these functions that do not produce a trailing newline
+and can therefore be safely used in string interpolation.
+-}
+
+{-# HLINT ignore "Avoid functions that generate extra trailing newlines/whitespaces" #-}
+
+-- | Like @Fmt.indentF@, but strips trailing spaces and does not add a trailing newline.
+--
+-- >>> import Fmt
+-- >>> indentF 2 "a\n\nb"
+-- "  a\n  \n  b\n"
+--
+-- >>> interpolateIndentF 2 "a\n\nb"
+-- "  a\n\n  b"
+interpolateIndentF :: HasCallStack => Int -> Builder -> Builder
+interpolateIndentF n b = (case TL.last (toLazyText b) of
+  '\n' -> id
+  _ ->  stripLastNewline) $ stripTrailingSpaces $ indentF n b
+  -- strips newline added by indentF
+
+-- | Like @Fmt.blockListF'@, but strips trailing spaces and does not add a trailing newline.
+interpolateBlockListF' :: HasCallStack => Text -> (a -> Builder) -> NonEmpty a -> Builder
+interpolateBlockListF' =  stripLastNewline . stripTrailingSpaces ... blockListF'
+
+-- | Like @Fmt.blockListF@, but strips trailing spaces and does not add a trailing newline.
+interpolateBlockListF :: HasCallStack => Buildable a => NonEmpty a -> Builder
+interpolateBlockListF = stripLastNewline . stripTrailingSpaces . blockListF
+
+-- remove trailing whitespace from all lines.
+-- Note: output always ends with newline (adds trailing newline if there wasn't one).
+stripTrailingSpaces :: Builder -> Builder
+stripTrailingSpaces
+  = fromLazyText
+  . TL.unlines
+  . map (TL.stripEnd)
+  . TL.lines
+  . toLazyText
+
+stripLastNewline :: HasCallStack => Builder -> Builder
+stripLastNewline
+  = fromLazyText
+  . fromMaybe (error "stripLastNewline: expected newline to strip")
+  . TL.stripSuffix "\n"
+  . toLazyText

--- a/tests/Test/Xrefcheck/TrailingSlashSpec.hs
+++ b/tests/Test/Xrefcheck/TrailingSlashSpec.hs
@@ -7,16 +7,17 @@ module Test.Xrefcheck.TrailingSlashSpec where
 
 import Universum
 
-import Fmt (blockListF, pretty, unlinesF)
 import System.Directory (doesFileExist)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (assertFailure, testCase)
+import Text.Interpolation.Nyan
 
 import Xrefcheck.Config
 import Xrefcheck.Core
 import Xrefcheck.Progress
 import Xrefcheck.Scan
 import Xrefcheck.Scanners.Markdown
+import Xrefcheck.Util
 
 test_slash :: TestTree
 test_slash = testGroup "Trailing forward slash detection" $
@@ -33,12 +34,12 @@ test_slash = testGroup "Trailing forward slash detection" $
           return $ if predicate
                     then Right ()
                     else Left filePath)
-        if null nonExistentFiles
-        then pass
-        else assertFailure $ pretty $ unlinesF
-          [ "Expected all filepaths to be valid, but these filepaths do not exist:"
-          , blockListF nonExistentFiles
-          ]
+        whenJust (nonEmpty nonExistentFiles) $ \files ->
+          assertFailure
+            [int||
+            Expected all filepaths to be valid, but these filepaths do not exist:
+            #{interpolateBlockListF files}
+            |]
   where
     roots :: [FilePath]
     roots =

--- a/tests/golden/check-anchors/check-anchors.bats
+++ b/tests/golden/check-anchors/check-anchors.bats
@@ -17,18 +17,17 @@ assert_diff - <<EOF
   ➥  In file ambiguous-anchors/a.md
      bad reference (current file) at src:16:1-43:
        - text: "ambiguous anchor in this file"
-       - link:
+       - link: -
        - anchor: some-text
 
      ⛀  Ambiguous reference to anchor 'some-text'
-        In file ambiguous-anchors/a.md
-        It could refer to either:
+       In file ambiguous-anchors/a.md
+       It could refer to either:
          - some-text (header I) at src:6:1-11
          - some-text (header I) at src:8:1-15
          - some-text (header II) at src:12:1-12
-
-         Use of ambiguous anchors is discouraged because the target
-         can change silently while the document containing it evolves.
+       Use of ambiguous anchors is discouraged because the target
+       can change silently while the document containing it evolves.
 
   ➥  In file ambiguous-anchors/b.md
      bad reference (relative) at src:7:1-48:
@@ -37,14 +36,13 @@ assert_diff - <<EOF
        - anchor: some-text
 
      ⛀  Ambiguous reference to anchor 'some-text'
-        In file ambiguous-anchors/a.md
-        It could refer to either:
+       In file ambiguous-anchors/a.md
+       It could refer to either:
          - some-text (header I) at src:6:1-11
          - some-text (header I) at src:8:1-15
          - some-text (header II) at src:12:1-12
-
-         Use of ambiguous anchors is discouraged because the target
-         can change silently while the document containing it evolves.
+       Use of ambiguous anchors is discouraged because the target
+       can change silently while the document containing it evolves.
 
 Invalid references dumped, 2 in total.
 EOF
@@ -58,7 +56,7 @@ assert_diff - <<EOF
   ➥  In file non-existing-anchors/a.md
      bad reference (current file) at src:12:1-13:
        - text: "broken"
-       - link:
+       - link: -
        - anchor: h3
 
      ⛀  Anchor 'h3' is not present, did you mean:
@@ -68,7 +66,7 @@ assert_diff - <<EOF
   ➥  In file non-existing-anchors/a.md
      bad reference (current file) at src:14:1-18:
        - text: "broken"
-       - link:
+       - link: -
        - anchor: heading
 
      ⛀  Anchor 'heading' is not present, did you mean:
@@ -77,7 +75,7 @@ assert_diff - <<EOF
   ➥  In file non-existing-anchors/a.md
      bad reference (current file) at src:16:1-31:
        - text: "broken"
-       - link:
+       - link: -
        - anchor: really-unique-anchor
 
      ⛀  Anchor 'really-unique-anchor' is not present

--- a/tests/golden/check-autolinks/check-autolinks.bats
+++ b/tests/golden/check-autolinks/check-autolinks.bats
@@ -25,7 +25,7 @@ assert_diff - <<EOF
             - link: http://www.commonmark.org
             - anchor: -
     - anchors:
-        []
+        none
 
 All repository links are valid.
 EOF

--- a/tests/golden/check-images/expected.gold
+++ b/tests/golden/check-images/expected.gold
@@ -27,7 +27,7 @@
             - link: ./4.png
             - anchor: -
     - anchors:
-        []
+        none
 
 === Invalid references found ===
 

--- a/tests/golden/check-local-refs/expected1.gold
+++ b/tests/golden/check-local-refs/expected1.gold
@@ -3,7 +3,7 @@
   ➥  In file dir1/dir2/d2f1.md
      bad reference (current file) at src:9:1-18:
        - text: "bad-cf-ref"
-       - link:
+       - link: -
        - anchor: bad
 
      ⛀  Anchor 'bad' is not present

--- a/tests/golden/check-local-refs/expected2.gold
+++ b/tests/golden/check-local-refs/expected2.gold
@@ -3,7 +3,7 @@
   ➥  In file dir1/dir2/d2f1.md
      bad reference (current file) at src:9:1-18:
        - text: "bad-cf-ref"
-       - link:
+       - link: -
        - anchor: bad
 
      ⛀  Anchor 'bad' is not present

--- a/tests/golden/check-local-refs/expected3.gold
+++ b/tests/golden/check-local-refs/expected3.gold
@@ -3,7 +3,7 @@
   ➥  In file dir1/dir2/d2f1.md
      bad reference (current file) at src:9:1-18:
        - text: "bad-cf-ref"
-       - link:
+       - link: -
        - anchor: bad
 
      ⛀  Anchor 'bad' is not present

--- a/tests/golden/helpers.bash
+++ b/tests/golden/helpers.bash
@@ -67,6 +67,5 @@ assert_diff() {
   : "{output_file?}"
 
   diff $output_file $1 \
-    --ignore-tab-expansion \
-    --ignore-trailing-space
+    --ignore-tab-expansion
 }


### PR DESCRIPTION
## Description

Problem: bats tests are not space sensetive
Solution: remove trailing spaces from xrefcheck output (see next problems), remove `--ignore-trailing-space` from `assert_diff`

Problem: there are lines containing only spaces in xrefcheck's output, because `Fmt.indentF` "indents" empty lines too.
Solution: add `Xrefcheck.Util.indentF_` function that is not indenting empty lines. Same for `Fmt.blockListF`

Problem: when there is a current file link `[a](#b)`, it is printed like
```
- text: "a"
- link: (trailing space here)
- anchor: b
```
Solution: as in case when there is no anchor, print `link: -` instead

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #1 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Fixes #213 

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](https://github.com/serokell/xrefcheck/tree/master/README.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [ ] I added an entry to the [changelog](https://github.com/serokell/xrefcheck/tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](https://github.com/serokell/style/blob/master/haskell.md).
