### PR TITLE
[#200] Warnings about files that weren't added to git yet

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,10 @@ Unreleased
   `<!-- xrefcheck: ignore all -->` instead of `<!-- xrefcheck: ignore file -->`
   should be used to disable checking for links in file, so it's clearer that
   file itself is not ignored (and links can target it).
+* [#215](https://github.com/serokell/xrefcheck/pull/215)
+  + Now we notify user when there are scannable files that were not added to Git
+  yet. Also added CLI option `--include-untracked` to scan such files and treat
+  as existing.
 
 0.2.2
 ==========

--- a/src/Xrefcheck/CLI.hs
+++ b/src/Xrefcheck/CLI.hs
@@ -81,6 +81,7 @@ data Options = Options
   , oColorMode         :: ColorMode
   , oExclusionOptions  :: ExclusionOptions
   , oNetworkingOptions :: NetworkingOptions
+  , oScanPolicy        :: ScanPolicy
   }
 
 data ExclusionOptions = ExclusionOptions
@@ -181,9 +182,13 @@ optionsParser = do
     ]
   oColorMode <- flag WithColors WithoutColors $
     long "no-color" <>
-    help "Disable ANSI coloring of output"
+    help "Disable ANSI coloring of output."
   oExclusionOptions <- exclusionOptionsParser
   oNetworkingOptions <- networkingOptionsParser
+  oScanPolicy <- flag OnlyTracked IncludeUntracked $
+    long "include-untracked" <>
+    help "Scan and treat as existing files that were not added to Git.\
+         \ Files explicitly ignored by Git are always ignored by xrefcheck."
   return Options{..}
 
 exclusionOptionsParser :: Parser ExclusionOptions

--- a/src/Xrefcheck/Command.hs
+++ b/src/Xrefcheck/Command.hs
@@ -70,7 +70,7 @@ defaultAction Options{..} = do
 
     (ScanResult scanErrs repoInfo) <- allowRewrite showProgressBar $ \rw -> do
       let fullConfig = addExclusionOptions (cExclusions config) oExclusionOptions
-      scanRepo rw (formats $ cScanners config) fullConfig oRoot
+      scanRepo oScanPolicy rw (formats $ cScanners config) fullConfig oRoot
 
     when oVerbose $
       fmt [int||

--- a/tests/Test/Xrefcheck/IgnoreRegexSpec.hs
+++ b/tests/Test/Xrefcheck/IgnoreRegexSpec.hs
@@ -39,7 +39,7 @@ test_ignoreRegex = give WithoutColors $
   in testGroup "Regular expressions performance"
     [ testCase "Check that only not matched links are verified" $ do
       scanResult <- allowRewrite showProgressBar $ \rw ->
-        scanRepo rw formats (config ^. cExclusionsL) root
+        scanRepo OnlyTracked rw formats (config ^. cExclusionsL) root
 
       verifyRes <- allowRewrite showProgressBar $ \rw ->
         verifyRepo rw config verifyMode root $ srRepoInfo scanResult

--- a/tests/Test/Xrefcheck/TrailingSlashSpec.hs
+++ b/tests/Test/Xrefcheck/TrailingSlashSpec.hs
@@ -28,7 +28,7 @@ test_slash = testGroup "Trailing forward slash detection" $
       root <>
       "\" should exist") $ do
         (ScanResult _ (RepoInfo repoInfo _)) <- allowRewrite False $ \rw ->
-          scanRepo rw format (cExclusions config & ecIgnoreL .~ []) root
+          scanRepo OnlyTracked rw format (cExclusions config & ecIgnoreL .~ []) root
         nonExistentFiles <- lefts <$> forM (keys repoInfo) (\filePath -> do
           predicate <- doesFileExist filePath
           return $ if predicate

--- a/tests/golden/check-git/check-git.bats
+++ b/tests/golden/check-git/check-git.bats
@@ -38,6 +38,31 @@ Please run "git add" before running xrefcheck or enable --include-untracked CLI 
 EOF
 }
 
+@test "Git: bad file not tracked, --include-untracked enabled, check failure" {
+  cd $TEST_TEMP_DIR
+
+  git init
+
+  echo "[a](./a.md)" >> "git.md"
+
+  to_temp xrefcheck --include-untracked
+
+  assert_diff - <<EOF
+=== Invalid references found ===
+
+  ➥  In file git.md
+     bad reference (relative) at src:1:1-11:
+       - text: "a"
+       - link: ./a.md
+       - anchor: -
+
+     ⛀  File does not exist:
+        a.md
+
+Invalid references dumped, 1 in total.
+EOF
+}
+
 @test "Git: bad file tracked, check failure" {
   cd $TEST_TEMP_DIR
 
@@ -96,3 +121,20 @@ Invalid references dumped, 1 in total.
 EOF
 }
 
+@test "Git: link to untracked file, --include-untracked enabled" {
+  cd $TEST_TEMP_DIR
+
+  git init
+
+  echo "[a](./a.md)" >> "git.md"
+
+  touch ./a.md
+
+  git add git.md
+
+  run xrefcheck --include-untracked
+
+  assert_success
+
+  assert_output --partial "All repository links are valid."
+}


### PR DESCRIPTION
## Description
Problem: after 0.2.2 release, xrefcheck cares only about files that were added to Git. That can be confusing for users (see #200)

Solution:
If a scannable (currently it means markdown) file is not ignored (by git or via config) and not tracked by git, print a warning to stderr while scanning repo.

If a link target such file, change error message from "file not exists" to `Link target is not tracked by Git`

Suggest user to run "git add" before running xrefcheck in both cases.

To do this, I've changed the `RepoInfo` type, so it also contains information about untracked files now.

Also add CLI option 1--include-untracked` to treat such files as existing.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #1 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Fixes #200

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](https://github.com/serokell/xrefcheck/tree/master/README.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](https://github.com/serokell/xrefcheck/tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](https://github.com/serokell/style/blob/master/haskell.md).
