### PR TITLE
[#223] Use nyan-interpolation for `defConfigText`

### DIFF
--- a/exec/Main.hs
+++ b/exec/Main.hs
@@ -7,7 +7,6 @@ module Main where
 
 import Universum
 
-import Data.ByteString qualified as BS
 import Main.Utf8 (withUtf8)
 
 import Xrefcheck.CLI (Command (..), getCommand)
@@ -21,4 +20,4 @@ main = withUtf8 $ do
     DefaultCommand options ->
       defaultAction options
     DumpConfig repoType path ->
-      BS.writeFile path (defConfigText repoType)
+      writeFile path (defConfigText repoType)

--- a/package.yaml
+++ b/package.yaml
@@ -86,7 +86,6 @@ library:
     - directory
     - dlist
     - filepath
-    - raw-strings-qq
     - fmt
     - ftp-client
     - Glob
@@ -104,7 +103,6 @@ library:
     - tagsoup
     - text
     - text-metrics
-    - th-lift-instances
     - time
     - transformers
     - universum
@@ -127,7 +125,6 @@ executables:
       - -O2
     dependencies:
       - xrefcheck
-      - bytestring
       - universum
       - with-utf8
 
@@ -144,7 +141,6 @@ tests:
       - cmark-gfm
       - firefly
       - xrefcheck
-      - bytestring
       - directory
       - http-types
       - o-clock

--- a/src/Xrefcheck/Core.hs
+++ b/src/Xrefcheck/Core.hs
@@ -15,9 +15,9 @@ import Control.Lens (makeLenses)
 import Data.Aeson (FromJSON (..), withText)
 import Data.Char (isAlphaNum)
 import Data.Char qualified as C
-import Data.Default (Default (..))
 import Data.DList (DList)
 import Data.DList qualified as DList
+import Data.Default (Default (..))
 import Data.List qualified as L
 import Data.Reflection (Given)
 import Data.Text qualified as T

--- a/src/Xrefcheck/Scanners/Markdown.hs
+++ b/src/Xrefcheck/Scanners/Markdown.hs
@@ -25,8 +25,8 @@ import Control.Lens (_Just, makeLenses, makeLensesFor, (.=))
 import Control.Monad.Trans.Writer.CPS (Writer, runWriter, tell)
 import Data.Aeson (FromJSON (..), genericParseJSON)
 import Data.ByteString.Lazy qualified as BSL
-import Data.Default (def)
 import Data.DList qualified as DList
+import Data.Default (def)
 import Data.Text qualified as T
 import Data.Text.Lazy qualified as LT
 import Fmt (Buildable (..), nameF)

--- a/src/Xrefcheck/Verify.hs
+++ b/src/Xrefcheck/Verify.hs
@@ -33,7 +33,7 @@ module Xrefcheck.Verify
 
 import Universum
 
-import Control.Concurrent.Async (async, cancel, wait, withAsync, Async, poll)
+import Control.Concurrent.Async (Async, async, cancel, poll, wait, withAsync)
 import Control.Exception (AsyncException (..), throwIO)
 import Control.Monad.Except (MonadError (..))
 import Data.ByteString qualified as BS
@@ -65,6 +65,7 @@ import Text.URI (Authority (..), ParseExceptionBs, URI (..), mkURIBs)
 import Time (RatioNat, Second, Time (..), ms, sec, threadDelay, timeout, (+:+), (-:-))
 import URI.ByteString qualified as URIBS
 
+import Control.Exception.Safe (handleAsync, handleJust)
 import Data.Bits (toIntegralSized)
 import Xrefcheck.Config
 import Xrefcheck.Core
@@ -73,7 +74,6 @@ import Xrefcheck.Progress
 import Xrefcheck.Scan
 import Xrefcheck.System
 import Xrefcheck.Util
-import Control.Exception.Safe (handleAsync, handleJust)
 
 {-# ANN module ("HLint: ignore Use uncurry" :: Text) #-}
 {-# ANN module ("HLint: ignore Use 'runExceptT' from Universum" :: Text) #-}

--- a/tests/Test/Xrefcheck/ConfigSpec.hs
+++ b/tests/Test/Xrefcheck/ConfigSpec.hs
@@ -10,7 +10,6 @@ import Universum
 import Control.Concurrent (forkIO, killThread)
 import Control.Exception qualified as E
 
-import Data.ByteString qualified as BS
 import Data.List (isInfixOf)
 import Data.Yaml (ParseException (..), decodeEither')
 import Network.HTTP.Types (Status (..))
@@ -38,7 +37,7 @@ test_config =
     -- The config we match against can be regenerated with
     -- stack exec xrefcheck -- dump-config -t GitHub -o tests/configs/github-config.yaml
       [ testCase "Config matches" $ do
-        config <- BS.readFile "tests/configs/github-config.yaml"
+        config <- readFile "tests/configs/github-config.yaml"
         when (config /= defConfigText GitHub) $
           assertFailure $ toString $ unwords
             [ "Config does not match the expected format."
@@ -76,7 +75,7 @@ test_config =
        ]
   , testGroup "Config parser reject input with unknown fields"
       [ testCase "throws error with useful messages" $ do
-          case decodeEither' @Config (defConfigText GitHub <> "strangeField: []") of
+          case decodeEither' @Config $ encodeUtf8 $ defConfigText GitHub <> "strangeField: []" of
             Left (AesonException str) ->
               if "unknown fields: [\"strangeField\"]" `isInfixOf` str
               then pure ()


### PR DESCRIPTION
## Description

Problem:
We have a function `defConfigText :: Flavor -> ByteString` that uses  `fillHoles` to modify `defConfigUnfilled`.
This is a bit error-prone and very complicated way to have a `ByteString` with parametric blocks. Also using `ByteString` instead of `Text` to store text leads to CRLF-related issues when launched on Windows.

Solution:
Remove `fillHoles` and `defConfigUnfilled`,
`defConfigText` creates a `Text` using `nyan-interpolation`.
We have test that proves that config string for `GitHub` flavor wasn't accidently changed.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #1 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Fixes #223

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](https://github.com/serokell/xrefcheck/tree/master/README.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](https://github.com/serokell/xrefcheck/tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](https://github.com/serokell/style/blob/master/haskell.md).
