### PR TITLE
[#228] Rename local file reference tag

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,7 +32,7 @@ Unreleased
   + Use utf-8 compatible codepage on Windows
 * [#224](https://github.com/serokell/xrefcheck/pull/224)
   + Now the program output does not contain unicode characters that are not widely supported.
-* [#226](https://github.com/serokell/xrefcheck/pull/226)
+* [#229](https://github.com/serokell/xrefcheck/pull/229)
   + Now we call references to anchors in current file (e.g. `[a](#b)`) as
   `file-local` references instead of calling them `current file` (which was ambiguous).
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@ Unreleased
 
 * [#176](https://github.com/serokell/xrefcheck/pull/176)
   + Enabled `autolink` extension for `cmark-gfm`, so now we're finding strings
-  like `www.google.com` or `https://google.com`, threating them as links
+  like `www.google.com` or `https://google.com`, treating them as links
   and checking.
 * [#175](https://github.com/serokell/xrefcheck/pull/175)
   + Reorganize top-level config keys.
@@ -32,6 +32,9 @@ Unreleased
   + Use utf-8 compatible codepage on Windows
 * [#224](https://github.com/serokell/xrefcheck/pull/224)
   + Now the program output does not contain unicode characters that are not widely supported.
+* [#226](https://github.com/serokell/xrefcheck/pull/226)
+  + Now we call references to anchors in current file (e.g. `[a](#b)`) as
+  `file-local` references instead of calling them `current file` (which was ambiguous).
 
 0.2.2
 ==========
@@ -46,7 +49,7 @@ Unreleased
   + Make `flavor` a required parameter.
 * [#182](https://github.com/serokell/xrefcheck/pull/182)
   + Now we call references to anchors in current file (e.g. `[a](#b)`) as
-  `current file` references instead of calling them `local` (which was ambigious).
+  `current file` references instead of calling them `local` (which was ambiguous).
 * [#188](https://github.com/serokell/xrefcheck/pull/188)
   + Added CLI option `--no-colors` that disables ANSI colors in output.
   + Automatically disable coloring if it is not supported

--- a/src/Xrefcheck/Core.hs
+++ b/src/Xrefcheck/Core.hs
@@ -225,7 +225,7 @@ pattern PathSep <- (isPathSeparator -> True)
 
 -- | Type of reference.
 data LocationType
-  = CurrentFileLoc
+  = FileLocalLoc
     -- ^ Reference to this file, e.g. @[a](#header)@
   | RelativeLoc
     -- ^ Reference to a file relative to given one, e.g. @[b](folder/file#header)@
@@ -239,7 +239,7 @@ data LocationType
 
 instance Given ColorMode => Buildable LocationType where
   build = \case
-    CurrentFileLoc -> colorIfNeeded Green "current file"
+    FileLocalLoc   -> colorIfNeeded Green "file-local"
     RelativeLoc    -> colorIfNeeded Yellow "relative"
     AbsoluteLoc    -> colorIfNeeded Blue "absolute"
     ExternalLoc    -> colorIfNeeded Red "external"
@@ -254,7 +254,7 @@ isExternal = \case
 -- | Whether this is a link to repo-local resource.
 isLocal :: LocationType -> Bool
 isLocal = \case
-  CurrentFileLoc -> True
+  FileLocalLoc   -> True
   RelativeLoc    -> True
   AbsoluteLoc    -> True
   ExternalLoc    -> False
@@ -263,7 +263,7 @@ isLocal = \case
 -- | Get type of reference.
 locationType :: Text -> LocationType
 locationType location = case toString location of
-  []                      -> CurrentFileLoc
+  []                      -> FileLocalLoc
   PathSep : _             -> AbsoluteLoc
   '.' : PathSep : _       -> RelativeLoc
   '.' : '.' : PathSep : _ -> RelativeLoc

--- a/src/Xrefcheck/Verify.hs
+++ b/src/Xrefcheck/Verify.hs
@@ -420,7 +420,7 @@ verifyReference
         let locType = locationType rLink
         if shouldCheckLocType mode locType
         then case locType of
-          CurrentFileLoc    -> checkRef rAnchor fileWithReference
+          FileLocalLoc      -> checkRef rAnchor fileWithReference
           RelativeLoc       -> checkRef rAnchor
                                 (normalise $ takeDirectory fileWithReference
                                   </> toString (canonizeLocalRef rLink))

--- a/tests/golden/check-anchors/check-anchors.bats
+++ b/tests/golden/check-anchors/check-anchors.bats
@@ -15,7 +15,7 @@ assert_diff - <<EOF
 === Invalid references found ===
 
   ➥  In file ambiguous-anchors/a.md
-     bad reference (current file) at src:16:1-43:
+     bad reference (file-local) at src:16:1-43:
        - text: "ambiguous anchor in this file"
        - link: -
        - anchor: some-text
@@ -54,7 +54,7 @@ assert_diff - <<EOF
 === Invalid references found ===
 
   ➥  In file non-existing-anchors/a.md
-     bad reference (current file) at src:12:1-13:
+     bad reference (file-local) at src:12:1-13:
        - text: "broken"
        - link: -
        - anchor: h3
@@ -64,7 +64,7 @@ assert_diff - <<EOF
          - h2 (header II) at src:8:1-5
 
   ➥  In file non-existing-anchors/a.md
-     bad reference (current file) at src:14:1-18:
+     bad reference (file-local) at src:14:1-18:
        - text: "broken"
        - link: -
        - anchor: heading
@@ -73,7 +73,7 @@ assert_diff - <<EOF
          - the-heading (header I) at src:10:1-13
 
   ➥  In file non-existing-anchors/a.md
-     bad reference (current file) at src:16:1-31:
+     bad reference (file-local) at src:16:1-31:
        - text: "broken"
        - link: -
        - anchor: really-unique-anchor

--- a/tests/golden/check-local-refs/dir1/dir2/d2f1.md
+++ b/tests/golden/check-local-refs/dir1/dir2/d2f1.md
@@ -4,8 +4,8 @@
  - SPDX-License-Identifier: MPL-2.0
  -->
 
-# Current file links
-[existing-cf-ref](#current-file-links)
+# File-local links
+[existing-cf-ref](#file-local-links)
 [bad-cf-ref](#bad)
 
 # Relative links

--- a/tests/golden/check-local-refs/expected1.gold
+++ b/tests/golden/check-local-refs/expected1.gold
@@ -1,7 +1,7 @@
 === Invalid references found ===
 
   ➥  In file dir1/dir2/d2f1.md
-     bad reference (current file) at src:9:1-18:
+     bad reference (file-local) at src:9:1-18:
        - text: "bad-cf-ref"
        - link: -
        - anchor: bad

--- a/tests/golden/check-local-refs/expected2.gold
+++ b/tests/golden/check-local-refs/expected2.gold
@@ -1,7 +1,7 @@
 === Invalid references found ===
 
   ➥  In file dir1/dir2/d2f1.md
-     bad reference (current file) at src:9:1-18:
+     bad reference (file-local) at src:9:1-18:
        - text: "bad-cf-ref"
        - link: -
        - anchor: bad

--- a/tests/golden/check-local-refs/expected3.gold
+++ b/tests/golden/check-local-refs/expected3.gold
@@ -1,7 +1,7 @@
 === Invalid references found ===
 
   ➥  In file dir1/dir2/d2f1.md
-     bad reference (current file) at src:9:1-18:
+     bad reference (file-local) at src:9:1-18:
        - text: "bad-cf-ref"
        - link: -
        - anchor: bad


### PR DESCRIPTION
## Description

Problem: We have found that the current tag for local file references, "current file", may lead to ambiguities.

Solution: Rename the tag that we use for local file references to be "file-local" instead.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #1 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Fixes #228 

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](https://github.com/serokell/xrefcheck/tree/master/README.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](https://github.com/serokell/xrefcheck/tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](https://github.com/serokell/style/blob/master/haskell.md).