### PR TITLE
[#218] Change redirects default behaviour

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,9 @@ Unreleased
 * [#229](https://github.com/serokell/xrefcheck/pull/229)
   + Now we call references to anchors in current file (e.g. `[a](#b)`) as
   `file-local` references instead of calling them `current file` (which was ambiguous).
+* [#233](https://github.com/serokell/xrefcheck/pull/233)
+  + Now xrefxcheck does not follow redirect links by default. It fails for permanent
+    redirect responses (i.e. 301 and 308) and passes for temporary ones (i.e. 302, 303, 307).
 
 0.2.2
 ==========

--- a/README.md
+++ b/README.md
@@ -140,7 +140,8 @@ There are several ways to fix this:
     * This behavior can be disabled by setting `ignoreAuthFailures: false` in the config file.
 
 1. How does `xrefcheck` handle redirects?
-    * `xrefcheck` follows up to 10 HTTP redirects.
+    * Permanent redirects (i.e. 301 and 308) are reported as errors.
+    * Temporary redirects (i.e. 302, 303 and 307) are assumed to be valid.
 
 1. How does `xrefcheck` handle localhost links?
     * By default, `xrefcheck` will ignore links to localhost.

--- a/tests/Test/Xrefcheck/RedirectRequestsSpec.hs
+++ b/tests/Test/Xrefcheck/RedirectRequestsSpec.hs
@@ -1,0 +1,79 @@
+{- SPDX-FileCopyrightText: 2021 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -}
+
+module Test.Xrefcheck.RedirectRequestsSpec where
+
+import Universum
+
+import Data.CaseInsensitive qualified as CI
+import Data.Map qualified as M
+import Network.HTTP.Types (Status, mkStatus)
+import Network.HTTP.Types.Header (hLocation)
+import Test.Tasty (TestName, TestTree, testGroup)
+import Test.Tasty.HUnit (Assertion, testCase)
+import Web.Firefly (ToResponse (toResponse), route, run)
+
+import Test.Xrefcheck.UtilRequests
+import Xrefcheck.Progress
+import Xrefcheck.Verify
+
+test_redirectRequests :: TestTree
+test_redirectRequests = testGroup "Redirect response tests"
+  [ testGroup "Temporary" $ temporaryRedirectTests <$> [302, 303, 307]
+  , testGroup "Permanent" $ permanentRedirectTests <$> [301, 308]
+  ]
+  where
+    url :: Text
+    url = "http://127.0.0.1:5000/redirect"
+
+    location :: Maybe Text
+    location = Just "http://127.0.0.1:5000/other"
+
+    temporaryRedirectTests :: Int -> TestTree
+    temporaryRedirectTests statusCode =
+      redirectTests
+        (show statusCode <> " passes by default")
+        (mkStatus statusCode "Temporary redirect")
+        (const Nothing)
+
+    permanentRedirectTests :: Int -> TestTree
+    permanentRedirectTests statusCode =
+      redirectTests
+        (show statusCode <> " fails by default")
+        (mkStatus statusCode "Permanent redirect")
+        (Just . PermanentRedirectError url)
+
+    redirectTests :: TestName -> Status -> (Maybe Text -> Maybe VerifyError) -> TestTree
+    redirectTests name expectedStatus expectedError =
+      testGroup name
+        [
+          testCase "With no location" $
+            redirectAssertion expectedStatus Nothing (expectedError Nothing),
+          testCase "With location" $
+            redirectAssertion expectedStatus location (expectedError location)
+        ]
+
+    redirectAssertion :: Status -> Maybe Text -> Maybe VerifyError -> Assertion
+    redirectAssertion expectedStatus expectedLocation expectedError =
+      checkLinkAndProgressWithServer
+        (mockRedirect expectedLocation expectedStatus)
+        url
+        (Progress
+          { pTotal = 1
+          , pCurrent = 1
+          , pErrorsUnfixable = length $ maybeToList expectedError
+          , pErrorsFixable = 0
+          , pTaskTimestamp = Nothing
+          }
+        )
+        (VerifyResult $ maybeToList expectedError)
+
+    mockRedirect :: Maybe Text -> Status -> IO ()
+    mockRedirect expectedLocation expectedSocation =
+      run 5000 $ route "/redirect" $ pure $ toResponse
+        ( "" :: Text
+        , expectedSocation
+        , M.fromList [(CI.map (decodeUtf8 @Text) hLocation, maybeToList expectedLocation)]
+        )

--- a/tests/Test/Xrefcheck/TooManyRequestsSpec.hs
+++ b/tests/Test/Xrefcheck/TooManyRequestsSpec.hs
@@ -17,14 +17,12 @@ import Network.HTTP.Types (Status (..), ok200, serviceUnavailable503, tooManyReq
 import Network.HTTP.Types.Header (hRetryAfter)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (assertBool, testCase, (@?=))
-import Text.Interpolation.Nyan
 import Time (sec, (-:-))
 import Web.Firefly (ToResponse (toResponse), getMethod, route, run)
 
-import Xrefcheck.Config
+import Test.Xrefcheck.UtilRequests
 import Xrefcheck.Core
 import Xrefcheck.Progress
-import Xrefcheck.Scan
 import Xrefcheck.Util
 import Xrefcheck.Verify
 
@@ -159,51 +157,7 @@ test_tooManyRequests = testGroup "429 response tests"
           ]
   ]
   where
-    checkLinkAndProgressWithServer mock link progress vrExpectation =
-      E.bracket (forkIO mock) killThread $ \_ -> do
-        (result, progRes) <- verifyLink link
-        flip assertBool (result == vrExpectation) $
-          [int||
-          Verification results differ: expected
-          #{interpolateIndentF 2 (show vrExpectation)}
-          but got
-          #{interpolateIndentF 2 (show result)}
-          |]
-        flip assertBool (progRes `progEquiv` progress) $
-          [int||
-          Expected the progress bar state to be
-          #{interpolateIndentF 2 (show progress)}
-          but got
-          #{interpolateIndentF 2 (show progRes)}
-          |]
-      where
-        -- | Check whether the two @Progress@ values are equal up to similarity of their essential
-        -- components, ignoring the comparison of @pTaskTimestamp@s, which is done to prevent test
-        -- failures when comparing the resulting progress, gotten from running the link
-        -- verification algorithm, with the expected one, where @pTaskTimestamp@ is hardcoded
-        -- as @Nothing@.
-        progEquiv :: Eq a => Progress a -> Progress a -> Bool
-        progEquiv p1 p2 = and [ ((==) `on` pCurrent) p1 p2
-                              , ((==) `on` pTotal) p1 p2
-                              , ((==) `on` pErrorsUnfixable) p1 p2
-                              , ((==) `on` pErrorsFixable) p1 p2
-                              ]
-
-    verifyLink :: Text -> IO (VerifyResult VerifyError, Progress Int)
-    verifyLink link = do
-      let reference = Reference "" link Nothing (Position Nothing)
-      progRef <- newIORef $ initVerifyProgress [reference]
-      result <- verifyReferenceWithProgress reference progRef
-      progress <- readIORef progRef
-      return (result, vrExternal progress)
-
-    verifyReferenceWithProgress :: Reference -> IORef VerifyProgress -> IO (VerifyResult VerifyError)
-    verifyReferenceWithProgress reference progRef = do
-      fmap wrlItem <$> verifyReference
-        (defConfig GitHub & cExclusionsL . ecIgnoreExternalRefsToL .~ []) FullMode
-        progRef (RepoInfo M.empty mempty) "." "" reference
-
-    -- | When called for the first time, returns with a 429 and `Retry-After: @retryAfter@`.
+    -- When called for the first time, returns with a 429 and `Retry-After: @retryAfter@`.
     -- Subsequent calls will respond with @status@.
     mock429 :: Text -> Status -> IO ()
     mock429 retryAfter status = do

--- a/tests/Test/Xrefcheck/UtilRequests.hs
+++ b/tests/Test/Xrefcheck/UtilRequests.hs
@@ -1,0 +1,75 @@
+{- SPDX-FileCopyrightText: 2019 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -}
+
+module Test.Xrefcheck.UtilRequests
+  ( checkLinkAndProgressWithServer
+  , verifyLink
+  , verifyReferenceWithProgress
+  ) where
+
+import Universum
+
+import Control.Exception qualified as E
+import Data.Map qualified as M
+import Text.Interpolation.Nyan
+
+import Control.Concurrent (forkIO, killThread)
+import Test.Tasty.HUnit (assertBool)
+import Xrefcheck.Config
+import Xrefcheck.Core
+import Xrefcheck.Progress
+import Xrefcheck.Scan
+import Xrefcheck.Util
+import Xrefcheck.Verify
+
+checkLinkAndProgressWithServer
+  :: IO ()
+  -> Text
+  -> Progress Int
+  -> VerifyResult VerifyError
+  -> IO ()
+checkLinkAndProgressWithServer mock link progress vrExpectation =
+      E.bracket (forkIO mock) killThread $ \_ -> do
+        (result, progRes) <- verifyLink link
+        flip assertBool (result == vrExpectation) $
+          [int||
+          Verification results differ: expected
+          #{interpolateIndentF 2 (show vrExpectation)}
+          but got
+          #{interpolateIndentF 2 (show result)}
+          |]
+        flip assertBool (progRes `progEquiv` progress) $
+          [int||
+          Expected the progress bar state to be
+          #{interpolateIndentF 2 (show progress)}
+          but got
+          #{interpolateIndentF 2 (show progRes)}
+          |]
+  where
+    -- Check whether the two @Progress@ values are equal up to similarity of their essential
+    -- components, ignoring the comparison of @pTaskTimestamp@s, which is done to prevent test
+    -- failures when comparing the resulting progress, gotten from running the link
+    -- verification algorithm, with the expected one, where @pTaskTimestamp@ is hardcoded
+    -- as @Nothing@.
+    progEquiv :: Eq a => Progress a -> Progress a -> Bool
+    progEquiv p1 p2 = and [ ((==) `on` pCurrent) p1 p2
+                          , ((==) `on` pTotal) p1 p2
+                          , ((==) `on` pErrorsUnfixable) p1 p2
+                          , ((==) `on` pErrorsFixable) p1 p2
+                          ]
+
+verifyLink :: Text -> IO (VerifyResult VerifyError, Progress Int)
+verifyLink link = do
+  let reference = Reference "" link Nothing (Position Nothing)
+  progRef <- newIORef $ initVerifyProgress [reference]
+  result <- verifyReferenceWithProgress reference progRef
+  p <- readIORef progRef
+  return (result, vrExternal p)
+
+verifyReferenceWithProgress :: Reference -> IORef VerifyProgress -> IO (VerifyResult VerifyError)
+verifyReferenceWithProgress reference progRef = do
+  fmap wrlItem <$> verifyReference
+    (defConfig GitHub & cExclusionsL . ecIgnoreExternalRefsToL .~ []) FullMode
+    progRef (RepoInfo M.empty mempty) "." "" reference

--- a/tests/golden/check-autolinks/check-autolinks.bats
+++ b/tests/golden/check-autolinks/check-autolinks.bats
@@ -27,6 +27,19 @@ assert_diff - <<EOF
     - anchors:
         none
 
-All repository links are valid.
+=== Invalid references found ===
+
+  ➥  In file file-with-autolinks.md
+     bad reference (external) at src:8:0-18:
+       - text: "www.commonmark.org"
+       - link: http://www.commonmark.org
+       - anchor: -
+
+     Permanent redirect found. Perhaps you want to replace the link:
+       http://www.commonmark.org
+     by:
+       https://commonmark.org/
+
+Invalid references dumped, 1 in total.
 EOF
 }


### PR DESCRIPTION
## Description

Problem: Xrefcheck currently always follows redirect links.

Solution: We are changing its default behaviour regarding redirect links to fail and report permanent redirects, and to pass for temporary redirects. Further PRs will allow the user to configure other policies.


## Related issue(s)

Fixes #218
Relates #25

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](https://github.com/serokell/xrefcheck/tree/master/README.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](https://github.com/serokell/xrefcheck/tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](https://github.com/serokell/style/blob/master/haskell.md).
