### PR TITLE
[#217] Retry on response timeout

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -12,7 +12,6 @@
 - ignore: { name: Redundant do }
 - ignore: { name: Redundant bracket }
 - ignore: { name: Redundant lambda }
-- ignore: { name: Redundant $ }
 - ignore: { name: Redundant flip }
 - ignore: { name: Move brackets to avoid $ }
 - ignore: { name: Avoid lambda using `infix` }

--- a/src/Xrefcheck/CLI.hs
+++ b/src/Xrefcheck/CLI.hs
@@ -126,7 +126,7 @@ filepathOption :: Mod OptionFields FilePath -> Parser FilePath
 filepathOption = strOption
 
 globOption :: Mod OptionFields RelGlobPattern -> Parser RelGlobPattern
-globOption = option $ eitherReader $ mkGlobPattern
+globOption = option $ eitherReader mkGlobPattern
 
 repoTypeReadM :: ReadM RepoType
 repoTypeReadM = eitherReader $ \name ->

--- a/src/Xrefcheck/Command.hs
+++ b/src/Xrefcheck/Command.hs
@@ -79,7 +79,7 @@ defaultAction Options{..} = do
       #{interpolateIndentF 2 (build repoInfo)}
       |]
 
-    whenJust (nonEmpty $ sortBy (compare `on` seFile) scanErrs) $ reportScanErrs
+    whenJust (nonEmpty $ sortBy (compare `on` seFile) scanErrs) reportScanErrs
 
     verifyRes <- allowRewrite showProgressBar $ \rw -> do
       let fullConfig = config

--- a/src/Xrefcheck/Config/Default.hs
+++ b/src/Xrefcheck/Config/Default.hs
@@ -54,7 +54,32 @@ networking:
 
   # How many attempts to retry an external link after getting
   # a "429 Too Many Requests" response.
+  # Timeouts may also be accounted here, see the description
+  # of `maxTimeoutRetries` field.
+
+  # If a site once responded with 429 error code, subsequent
+  # request timeouts will also be treated as hitting the site's
+  # rate limiter and result in retry attempts, unless the
+  # maximum retries number has been reached.
+  #
+  # On other errors xrefcheck fails immediately, without retrying.
   maxRetries: 3
+
+# Querying a given domain that ever returned 429 before,
+# this defines how many timeouts are allowed during retries.
+#
+# For such domains, timeouts likely mean hitting the rate limiter,
+# and so xrefcheck considers timeouts in the same way as 429 errors.
+#
+# For other domains, a timeout results in a respective error, no retry
+# attempts will be performed. Use `externalRefCheckTimeout` option
+# to increase the time after which timeout is declared.
+#
+# This option is similar to `maxRetries`, the difference is that
+# this `maxTimeoutRetries` option limits only the number of retries
+# caused by timeouts, and `maxRetries` limits the number of retries
+# caused both by 429s and timeouts.
+  maxTimeoutRetries: 1
 
 # Parameters of scanners for various file types.
 scanners:

--- a/src/Xrefcheck/Scan.hs
+++ b/src/Xrefcheck/Scan.hs
@@ -239,7 +239,7 @@ scanRepo scanMode rw formatsSupport config root = do
 
   return . ScanResult errs $ RepoInfo
     { riFiles = M.fromList $ processedFiles <> notProcessedFiles
-    , riDirectories = M.fromList $ (fmap (, TrackedDirectory) trackedDirs
+    , riDirectories = M.fromList (fmap (, TrackedDirectory) trackedDirs
         <> fmap (, UntrackedDirectory) untrackedDirs)
     , riRoot = canonicalRoot
     }

--- a/src/Xrefcheck/Scanners/Markdown.hs
+++ b/src/Xrefcheck/Scanners/Markdown.hs
@@ -57,11 +57,11 @@ toPosition :: Maybe PosInfo -> Position
 toPosition = Position . \case
   Nothing -> Nothing
   Just PosInfo{..}
-    | startLine == endLine -> Just $
+    | startLine == endLine -> Just
         [int|s|
         #{startLine}:#{startColumn}-#{endColumn}
         |]
-    | otherwise -> Just $
+    | otherwise -> Just
         [int|s|
         #{startLine}:#{startColumn}-#{endLine}:#{endColumn}
         |]

--- a/src/Xrefcheck/Util.hs
+++ b/src/Xrefcheck/Util.hs
@@ -9,8 +9,11 @@ module Xrefcheck.Util
   , postfixFields
   , (-:)
   , aesonConfigOption
+  , composeFuncList
   , posixTimeToTimeSecond
   , utcTimeToTimeSecond
+  , unlessFunc
+  , whenFunc
   , module Xrefcheck.Util.Colorize
   , module Xrefcheck.Util.Interpolate
   ) where
@@ -59,3 +62,13 @@ posixTimeToTimeSecond posixTime =
 
 utcTimeToTimeSecond :: UTCTime -> Time Second
 utcTimeToTimeSecond = posixTimeToTimeSecond . utcTimeToPOSIXSeconds
+
+composeFuncList :: [a -> a] -> a -> a
+composeFuncList = foldr (.) id
+
+whenFunc :: Bool -> (a -> a) -> (a -> a)
+whenFunc True f = f
+whenFunc False _ = id
+
+unlessFunc :: Bool -> (a -> a) -> (a -> a)
+unlessFunc = whenFunc . not

--- a/tests/Test/Xrefcheck/RedirectRequestsSpec.hs
+++ b/tests/Test/Xrefcheck/RedirectRequestsSpec.hs
@@ -9,6 +9,7 @@ import Universum
 
 import Data.CaseInsensitive qualified as CI
 import Data.Map qualified as M
+import Data.Set qualified as S
 import Network.HTTP.Types (Status, mkStatus)
 import Network.HTTP.Types.Header (hLocation)
 import Test.Tasty (TestName, TestTree, testGroup)
@@ -56,8 +57,10 @@ test_redirectRequests = testGroup "Redirect response tests"
         ]
 
     redirectAssertion :: Status -> Maybe Text -> Maybe VerifyError -> Assertion
-    redirectAssertion expectedStatus expectedLocation expectedError =
-      checkLinkAndProgressWithServer
+    redirectAssertion expectedStatus expectedLocation expectedError = do
+      setRef <- newIORef S.empty
+      checkLinkAndProgressWithServerDefault
+        setRef
         (mockRedirect expectedLocation expectedStatus)
         url
         (Progress

--- a/tests/Test/Xrefcheck/TimeoutSpec.hs
+++ b/tests/Test/Xrefcheck/TimeoutSpec.hs
@@ -1,0 +1,146 @@
+{- SPDX-FileCopyrightText: 2021 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -}
+
+module Test.Xrefcheck.TimeoutSpec where
+
+import Universum
+
+import Data.CaseInsensitive qualified as CI
+import Data.Map qualified as M
+import Data.Set qualified as S
+import Network.HTTP.Types (ok200, tooManyRequests429)
+import Network.HTTP.Types.Header (hRetryAfter)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase)
+import Time (Second, Time, sec, threadDelay)
+import Web.Firefly (ToResponse (toResponse), route, run)
+
+import Test.Xrefcheck.UtilRequests
+import Xrefcheck.Config
+import Xrefcheck.Progress
+import Xrefcheck.Verify
+
+-- Here all the delays are doubled because we call sites
+-- with HEAD first and then GET methods.
+test_timeout :: TestTree
+test_timeout = testGroup "Timeout tests"
+  [ testCase "Succeeds on one timeout if there were no 429 responses and no retries allowed" $
+      timeoutTestCase [Delay] True
+        (cNetworkingL . ncMaxTimeoutRetriesL .~ 0)
+  , testCase "Returns an error on two timeouts if there were no 429 responses" $
+      timeoutTestCase [Delay, Delay] False
+        (cNetworkingL . ncMaxTimeoutRetriesL .~ 2)
+  , testCase "Returns an error if there were 429 but no timeouts allowed" $
+      timeoutTestCase [Respond429, Delay, Delay] False
+        (cNetworkingL . ncMaxTimeoutRetriesL .~ 0)
+  , testCase "Succeeds if there were 429 and one timeout allowed" $
+      timeoutTestCase [Respond429, Delay, Delay] True
+        (cNetworkingL . ncMaxTimeoutRetriesL .~ 1)
+  , testCase "Fails on second timeout if there were 429 and one timeout allowed" $
+      timeoutTestCase [Respond429, Delay, Delay, Delay, Delay] False
+        (cNetworkingL . ncMaxTimeoutRetriesL .~ 1)
+  , testCase "Fails on maximum allowed errors achieved (mixed errors)" $
+      timeoutTestCase [Respond429, Delay, Delay, Respond429, Delay, Delay] False $ \c -> c
+        & cNetworkingL . ncMaxTimeoutRetriesL .~ 3
+        & cNetworkingL . ncMaxRetriesL .~ 3
+  , testCase "Fails on timeout if another domain returned 429" $ do
+      setRef <- newIORef S.empty
+      checkMultipleLinksWithServer
+        (mockTimeout (sec 0.4) [Respond429, Ok, Delay, Delay])
+        setRef
+        [ VerifyLinkTestEntry
+            { vlteConfigModifier = \c -> c
+                & cNetworkingL . ncMaxRetriesL .~ 1
+                & setAllowedTimeout
+            , vlteLink = "http://127.0.0.1:5000/timeout"
+            , vlteExpectedProgress = mkProgressWithOneTask True
+            , vlteExpectationErrors = VerifyResult []
+            }
+        , VerifyLinkTestEntry
+            { vlteConfigModifier = \c -> c
+                & cNetworkingL . ncMaxTimeoutRetriesL .~ 0
+                & setAllowedTimeout
+            , vlteLink = "http://localhost:5000/timeout"
+            , vlteExpectedProgress = mkProgressWithOneTask False
+            , vlteExpectationErrors = VerifyResult
+              [ ExternalHttpTimeout (Just $ DomainName "localhost")
+              ]
+            }
+        ]
+  , testCase "Succeeds on timeout if another path of this domain returned 429" $ do
+      setRef <- newIORef S.empty
+      checkMultipleLinksWithServer
+        (mockTimeout (sec 0.4) [Respond429, Ok, Delay, Delay])
+        setRef
+        [ VerifyLinkTestEntry
+            { vlteConfigModifier = \c -> c
+                & cNetworkingL . ncMaxRetriesL .~ 1
+                & setAllowedTimeout
+            , vlteLink = "http://127.0.0.1:5000/timeout"
+            , vlteExpectedProgress = mkProgressWithOneTask True
+            , vlteExpectationErrors = VerifyResult []
+            }
+        , VerifyLinkTestEntry
+            { vlteConfigModifier = \c -> c
+                & cNetworkingL . ncMaxTimeoutRetriesL .~ 1
+                & setAllowedTimeout
+            , vlteLink = "http://127.0.0.1:5000/timeoutother"
+            , vlteExpectedProgress = mkProgressWithOneTask True
+            , vlteExpectationErrors = VerifyResult []
+            }
+        ]
+  ]
+  where
+    setAllowedTimeout = cNetworkingL . ncExternalRefCheckTimeoutL .~ (sec 0.25)
+
+    mkProgressWithOneTask shouldSucceed =
+      Progress
+        { pTotal = 1
+        , pCurrent = 1
+        , pErrorsUnfixable = if shouldSucceed then 0 else 1
+        , pErrorsFixable = 0
+        , pTaskTimestamp = Nothing
+        }
+
+    timeoutTestCase mockResponses shouldSucceed configModifier = do
+      let prog = mkProgressWithOneTask shouldSucceed
+      setRef <- newIORef S.empty
+      checkLinkAndProgressWithServer
+        (\c -> c
+          & setAllowedTimeout
+          & configModifier)
+        setRef
+        (mockTimeout (sec 0.4) mockResponses)
+        "http://127.0.0.1:5000/timeout" prog $
+          VerifyResult $
+            [ExternalHttpTimeout $ Just (DomainName "127.0.0.1") | not shouldSucceed]
+
+    -- When called for the first (N-1) times, waits for specified
+    -- amount of seconds and returns an arbitrary result.
+    -- When called N time returns the result immediately.
+    mockTimeout :: Time Second -> [MockTimeoutBehaviour] -> IO ()
+    mockTimeout timeout behList = do
+      ref <- newIORef @_ behList
+      run 5000 $ do
+        route "/timeout" $ handler ref
+        route "/timeoutother" $ handler ref
+      where
+        handler ref = do
+          mbCurrentAction <- atomicModifyIORef' ref $ \case
+            b : bs -> (bs, Just b)
+            [] -> ([], Nothing)
+          let success = toResponse ("" :: Text, ok200, M.empty @(CI.CI Text) @[Text])
+          case mbCurrentAction of
+            Nothing -> pure success
+            Just Ok -> pure success
+            Just Delay -> do
+              threadDelay timeout
+              pure $ toResponse ("" :: Text, ok200, M.empty @(CI.CI Text) @[Text])
+            Just Respond429 ->
+              pure $ toResponse
+                ("" :: Text, tooManyRequests429,
+                  M.fromList [(CI.map (decodeUtf8 @Text) hRetryAfter, ["1" :: Text])])
+
+data MockTimeoutBehaviour = Respond429 | Delay | Ok

--- a/tests/Test/Xrefcheck/UtilRequests.hs
+++ b/tests/Test/Xrefcheck/UtilRequests.hs
@@ -7,15 +7,22 @@ module Test.Xrefcheck.UtilRequests
   ( checkLinkAndProgressWithServer
   , verifyLink
   , verifyReferenceWithProgress
+  , checkMultipleLinksWithServer
+  , checkLinkAndProgressWithServerDefault
+  , verifyLinkDefault
+  , verifyReferenceWithProgressDefault
+  , VerifyLinkTestEntry (..)
   ) where
 
 import Universum
 
+import Control.Concurrent (forkIO, killThread)
 import Control.Exception qualified as E
+import Data.Map qualified as M
+import Data.Set qualified as S
+import Test.Tasty.HUnit (assertBool)
 import Text.Interpolation.Nyan
 
-import Control.Concurrent (forkIO, killThread)
-import Test.Tasty.HUnit (assertBool)
 import Xrefcheck.Config
 import Xrefcheck.Core
 import Xrefcheck.Progress
@@ -24,29 +31,57 @@ import Xrefcheck.System (canonicalizePath)
 import Xrefcheck.Util
 import Xrefcheck.Verify
 
-checkLinkAndProgressWithServer
+checkMultipleLinksWithServer
   :: IO ()
+  -> IORef (S.Set DomainName)
+  -> [VerifyLinkTestEntry]
+  -> IO ()
+checkMultipleLinksWithServer mock setRef entries =
+  E.bracket (forkIO mock) killThread $ \_ -> do
+    forM_ entries $ \VerifyLinkTestEntry {..} ->
+      checkLinkAndProgress
+        vlteConfigModifier
+        setRef
+        vlteLink
+        vlteExpectedProgress
+        vlteExpectationErrors
+
+checkLinkAndProgressWithServer
+  :: (Config -> Config)
+  -> IORef (Set DomainName)
+  -> IO ()
   -> Text
   -> Progress Int
   -> VerifyResult VerifyError
   -> IO ()
-checkLinkAndProgressWithServer mock link progress vrExpectation =
-      E.bracket (forkIO mock) killThread $ \_ -> do
-        (result, progRes) <- verifyLink link
-        flip assertBool (result == vrExpectation) $
-          [int||
-          Verification results differ: expected
-          #{interpolateIndentF 2 (show vrExpectation)}
-          but got
-          #{interpolateIndentF 2 (show result)}
-          |]
-        flip assertBool (progRes `progEquiv` progress) $
-          [int||
-          Expected the progress bar state to be
-          #{interpolateIndentF 2 (show progress)}
-          but got
-          #{interpolateIndentF 2 (show progRes)}
-          |]
+checkLinkAndProgressWithServer configModifier setRef mock link progress vrExpectation =
+  E.bracket (forkIO mock) killThread $ \_ -> do
+    checkLinkAndProgress configModifier setRef link progress vrExpectation
+
+checkLinkAndProgress
+  :: (Config -> Config)
+  -> IORef (Set DomainName)
+  -> Text
+  -> Progress Int
+  -> VerifyResult VerifyError
+  -> IO ()
+checkLinkAndProgress configModifier setRef link progress vrExpectation = do
+  (result, progRes) <- verifyLink configModifier setRef link
+  flip assertBool (result == vrExpectation)
+    [int||
+    Verification results differ: expected
+    #{interpolateIndentF 2 (show vrExpectation)}
+    but got
+    #{interpolateIndentF 2 (show result)}
+    |]
+  flip assertBool (progRes `progEquiv` progress)
+    [int||
+    Expected the progress bar state to be
+    #{interpolateIndentF 2 (show progress)}
+    but got
+    #{interpolateIndentF 2 (show progRes)}
+    |]
+
   where
     -- Check whether the two @Progress@ values are equal up to similarity of their essential
     -- components, ignoring the comparison of @pTaskTimestamp@s, which is done to prevent test
@@ -60,18 +95,57 @@ checkLinkAndProgressWithServer mock link progress vrExpectation =
                           , ((==) `on` pErrorsFixable) p1 p2
                           ]
 
-verifyLink :: Text -> IO (VerifyResult VerifyError, Progress Int)
-verifyLink link = do
+checkLinkAndProgressWithServerDefault
+  :: IORef (Set DomainName)
+  -> IO ()
+  -> Text
+  -> Progress Int
+  -> VerifyResult VerifyError
+  -> IO ()
+checkLinkAndProgressWithServerDefault = checkLinkAndProgressWithServer id
+
+verifyLink
+  :: (Config -> Config)
+  -> IORef (S.Set DomainName)
+  -> Text
+  -> IO (VerifyResult VerifyError, Progress Int)
+verifyLink configModifier setRef link = do
   let reference = Reference "" link Nothing (Position Nothing) RIExternal
   progRef <- newIORef $ initVerifyProgress [reference]
-  result <- verifyReferenceWithProgress reference progRef
-  p <- readIORef progRef
-  return (result, vrExternal p)
+  result <- verifyReferenceWithProgress configModifier reference setRef progRef
+  progress <- readIORef progRef
+  return (result, vrExternal progress)
 
-verifyReferenceWithProgress :: Reference -> IORef VerifyProgress -> IO (VerifyResult VerifyError)
-verifyReferenceWithProgress reference progRef = do
+verifyLinkDefault
+  :: IORef (Set DomainName)
+  -> Text
+  -> IO (VerifyResult VerifyError, Progress Int)
+verifyLinkDefault = verifyLink id
+
+verifyReferenceWithProgress
+  :: (Config -> Config)
+  -> Reference
+  -> IORef (S.Set DomainName)
+  -> IORef VerifyProgress
+  -> IO (VerifyResult VerifyError)
+verifyReferenceWithProgress configModifier reference setRef progRef = do
   canonicalRoot <- canonicalizePath "."
   file <- canonicalizePath ""
   fmap wrlItem <$> verifyReference
-    (defConfig GitHub & cExclusionsL . ecIgnoreExternalRefsToL .~ []) FullMode
-    progRef (RepoInfo mempty mempty canonicalRoot) file reference
+    (defConfig GitHub & cExclusionsL . ecIgnoreExternalRefsToL .~ []
+                      & configModifier)
+    FullMode setRef progRef (RepoInfo M.empty mempty canonicalRoot) file reference
+
+verifyReferenceWithProgressDefault
+  :: Reference
+  -> IORef (Set DomainName)
+  -> IORef VerifyProgress
+  -> IO (VerifyResult VerifyError)
+verifyReferenceWithProgressDefault = verifyReferenceWithProgress id
+
+data VerifyLinkTestEntry = VerifyLinkTestEntry
+  { vlteConfigModifier    :: Config -> Config
+  , vlteLink              :: Text
+  , vlteExpectedProgress  :: Progress Int
+  , vlteExpectationErrors :: VerifyResult VerifyError
+  }

--- a/tests/configs/github-config.yaml
+++ b/tests/configs/github-config.yaml
@@ -43,7 +43,32 @@ networking:
 
   # How many attempts to retry an external link after getting
   # a "429 Too Many Requests" response.
+  # Timeouts may also be accounted here, see the description
+  # of `maxTimeoutRetries` field.
+
+  # If a site once responded with 429 error code, subsequent
+  # request timeouts will also be treated as hitting the site's
+  # rate limiter and result in retry attempts, unless the
+  # maximum retries number has been reached.
+  #
+  # On other errors xrefcheck fails immediately, without retrying.
   maxRetries: 3
+
+# Querying a given domain that ever returned 429 before,
+# this defines how many timeouts are allowed during retries.
+#
+# For such domains, timeouts likely mean hitting the rate limiter,
+# and so xrefcheck considers timeouts in the same way as 429 errors.
+#
+# For other domains, a timeout results in a respective error, no retry
+# attempts will be performed. Use `externalRefCheckTimeout` option
+# to increase the time after which timeout is declared.
+#
+# This option is similar to `maxRetries`, the difference is that
+# this `maxTimeoutRetries` option limits only the number of retries
+# caused by timeouts, and `maxRetries` limits the number of retries
+# caused both by 429s and timeouts.
+  maxTimeoutRetries: 1
 
 # Parameters of scanners for various file types.
 scanners:


### PR DESCRIPTION

## Description

Problem: Currently, getting response timeout immediately results in fail, it's desired to have a possibility to configure retries on timeouts.

Solution: The new ExternalHttpTimeout error is added, which is treated in a similar way as the ExternalHttpTooManyRequests error. A new field is added to the config meaning how many timeouts are allowed. Default value equals to 1.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #1 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Fixes #217 

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](https://github.com/serokell/xrefcheck/tree/master/README.md)
    - Haddock

- Public contracts
  - [ ] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [ ] I added an entry to the [changelog](https://github.com/serokell/xrefcheck/tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [ ] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](https://github.com/serokell/style/blob/master/haskell.md).

#### ✓ Release Checklist

- [ ] I updated the version number in `package.yaml`.
- [ ] I updated the [changelog](https://github.com/serokell/xrefcheck/tree/master/CHANGES.md) and moved everything
      under the "Unreleased" section to a new section for this release version.
- [ ] (After merging) I edited the [auto-release](https://github.com/serokell/xrefcheck/releases/tag/auto-release).
    * Change the tag and title using the format `vX.Y.Z`.
    * Write a summary of all user-facing changes.
    * Deselect the "This is a pre-release" checkbox at the bottom.
- [ ] (After merging) I updated [`xrefcheck-action`](https://github.com/serokell/xrefcheck-action#updating-supported-versions).
- [ ] (After merging) I uploaded the package to [hackage](https://hackage.haskell.org/package/xrefcheck).
