### PR TITLE
Yuri romanowski/#220 avoid resource leaking in scanners

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -111,6 +111,7 @@ library:
     - reflection
     - nyan-interpolation
     - safe-exceptions
+    - parallel
 
 executables:
   xrefcheck:

--- a/src/Xrefcheck/Scan.hs
+++ b/src/Xrefcheck/Scan.hs
@@ -2,7 +2,7 @@
  -
  - SPDX-License-Identifier: MPL-2.0
  -}
-
+{-# LANGUAGE DeriveAnyClass #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 -- | Generalised repo scanner and analyser.
@@ -93,7 +93,8 @@ data ScanError = ScanError
   { sePosition    :: Position
   , seFile        :: FilePath
   , seDescription :: ScanErrorDescription
-  } deriving stock (Show, Eq)
+  } deriving stock (Show, Eq, Generic)
+    deriving anyclass NFData
 
 instance Given ColorMode => Buildable ScanError where
   build ScanError{..} = [int||
@@ -118,7 +119,8 @@ data ScanErrorDescription
   | FileErr
   | ParagraphErr Text
   | UnrecognisedErr Text
-  deriving stock (Show, Eq)
+  deriving stock (Show, Eq, Generic)
+  deriving anyclass (NFData)
 
 instance Buildable ScanErrorDescription where
   build = \case

--- a/src/Xrefcheck/Scanners/Markdown.hs
+++ b/src/Xrefcheck/Scanners/Markdown.hs
@@ -24,11 +24,10 @@ import CMarkGFM
 import Control.Lens (_Just, makeLenses, makeLensesFor, (.=))
 import Control.Monad.Trans.Writer.CPS (Writer, runWriter, tell)
 import Data.Aeson (FromJSON (..), genericParseJSON)
-import Data.ByteString.Lazy qualified as BSL
+import Data.ByteString qualified as BS
 import Data.DList qualified as DList
 import Data.Default (def)
 import Data.Text qualified as T
-import Data.Text.Lazy qualified as LT
 import Fmt (Buildable (..), nameF)
 import Text.HTML.TagSoup
 import Text.Interpolation.Nyan
@@ -406,16 +405,15 @@ textToMode ("ignore" : [x])
   | otherwise        = InvalidMode x
 textToMode _         = NotAnAnnotation
 
-parseFileInfo :: MarkdownConfig -> FilePath -> LT.Text -> (FileInfo, [ScanError])
+parseFileInfo :: MarkdownConfig -> FilePath -> T.Text -> (FileInfo, [ScanError])
 parseFileInfo config fp input
   = runWriter
   $ flip runReaderT config
   $ nodeExtractInfo fp
-  $ commonmarkToNode [optFootnotes] [extAutolink]
-  $ toStrict input
+  $ commonmarkToNode [optFootnotes] [extAutolink] input
 
 markdownScanner :: MarkdownConfig -> ScanAction
-markdownScanner config path = parseFileInfo config path . decodeUtf8 <$> BSL.readFile path
+markdownScanner config path = parseFileInfo config path . decodeUtf8 <$> BS.readFile path
 
 markdownSupport :: MarkdownConfig -> ([Extension], ScanAction)
 markdownSupport config = ([".md"], markdownScanner config)


### PR DESCRIPTION
## Description

[#220] Avoid resource leaking in scanners
    
Problem: Currently we use lazy `readFile`, and xrefcheck opens all
the files immediately for reading, while file descriptors are
resource that can be finite.
    
Solution: Replaced lazy `readFile` with strict version.

To be done: Understand issues with parallelism

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #1 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Fixes #220 

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](https://github.com/serokell/xrefcheck/tree/master/README.md)
    - Haddock

- Public contracts
  - [ ] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [ ] I added an entry to the [changelog](https://github.com/serokell/xrefcheck/tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [ ] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [ ] My code complies with the [style guide](https://github.com/serokell/style/blob/master/haskell.md).

#### ✓ Release Checklist

- [ ] I updated the version number in `package.yaml`.
- [ ] I updated the [changelog](https://github.com/serokell/xrefcheck/tree/master/CHANGES.md) and moved everything
      under the "Unreleased" section to a new section for this release version.
- [ ] (After merging) I edited the [auto-release](https://github.com/serokell/xrefcheck/releases/tag/auto-release).
    * Change the tag and title using the format `vX.Y.Z`.
    * Write a summary of all user-facing changes.
    * Deselect the "This is a pre-release" checkbox at the bottom.
- [ ] (After merging) I updated [`xrefcheck-action`](https://github.com/serokell/xrefcheck-action#updating-supported-versions).
- [ ] (After merging) I uploaded the package to [hackage](https://hackage.haskell.org/package/xrefcheck).
