### PR TITLE
[#197] Dependent RepoInfo keys example

### DIFF
--- a/src/Xrefcheck/Command.hs
+++ b/src/Xrefcheck/Command.hs
@@ -25,7 +25,7 @@ import Xrefcheck.Progress (allowRewrite)
 import Xrefcheck.Scan
   (FormatsSupport, ScanError (..), ScanResult (..), reportScanErrs, scanRepo,
   specificFormatsSupport)
-import Xrefcheck.Scanners.Markdown (markdownSupport)
+import Xrefcheck.Scanners.Markdown (MarkdownConfig (mcFlavor), markdownSupport)
 import Xrefcheck.System (askWithinCI)
 import Xrefcheck.Util
 import Xrefcheck.Verify (reportVerifyErrs, verifyErrors, verifyRepo)
@@ -70,7 +70,9 @@ defaultAction Options{..} = do
 
     (ScanResult scanErrs repoInfo) <- allowRewrite showProgressBar $ \rw -> do
       let fullConfig = addExclusionOptions (cExclusions config) oExclusionOptions
-      scanRepo oScanPolicy rw (formats $ cScanners config) fullConfig oRoot
+          formatsSupport = formats $ cScanners config
+          flavor = mcFlavor $ scMarkdown $ cScanners config
+      scanRepo oScanPolicy rw formatsSupport fullConfig flavor oRoot
 
     when oVerbose $
       fmt [int||

--- a/src/Xrefcheck/Core.hs
+++ b/src/Xrefcheck/Core.hs
@@ -21,7 +21,7 @@ import Data.DList qualified as DList
 import Data.List qualified as L
 import Data.Reflection (Given)
 import Data.Text qualified as T
-import Fmt (Buildable (..), Builder)
+import Fmt (Buildable (..))
 import System.FilePath.Posix (isPathSeparator)
 import Text.Interpolation.Nyan
 import Time (Second, Time)
@@ -146,14 +146,6 @@ data DirectoryStatus
   | UntrackedDirectory
   deriving stock (Show)
 
--- | All tracked files and directories.
-data RepoInfo = RepoInfo
- { riFiles       :: Map FilePath FileStatus
-   -- ^ Files from the repo with `FileInfo` attached to files that we've scanned.
- , riDirectories :: Map FilePath DirectoryStatus
-   -- ^ Directories containing those files.
- } deriving stock (Show)
-
 -----------------------------------------------------------
 -- Instances
 -----------------------------------------------------------
@@ -202,19 +194,6 @@ instance Given ColorMode => Buildable FileInfo where
     - anchors:
     #{ interpolateIndentF 4 $ maybe "none" interpolateBlockListF (nonEmpty _fiAnchors) }
     |]
-
-instance Given ColorMode => Buildable RepoInfo where
-  build (RepoInfo m _)
-    | Just scanned <- nonEmpty [(name, info) | (name, Scanned info) <- toPairs m]
-    = interpolateUnlinesF $ buildFileReport <$> scanned
-    where
-      buildFileReport :: ([Char], FileInfo) -> Builder
-      buildFileReport (name, info) =
-        [int||
-        #{ colorIfNeeded Cyan $ name }:
-        #{ interpolateIndentF 2 $ build info }
-        |]
-  build _ = "No scannable files found."
 
 -----------------------------------------------------------
 -- Analysing

--- a/src/Xrefcheck/RepoInfo.hs
+++ b/src/Xrefcheck/RepoInfo.hs
@@ -1,0 +1,113 @@
+{- SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -}
+
+{-# LANGUAGE GADTs #-}
+
+module Xrefcheck.RepoInfo
+  ( RepoInfo
+  , mkRepoInfo
+  , riFiles
+  , lookupFile
+  , lookupDirectory
+  ) where
+
+import Universum
+
+import Data.Char qualified as C
+import Data.Map qualified as M
+import Data.Reflection (Given)
+import Fmt (Buildable (build), Builder)
+import Text.Interpolation.Nyan
+
+import Xrefcheck.Core
+import Xrefcheck.Util
+
+-- | Supose that we already have a type, `CanonicalPath`
+-- that corresponds to a canonicalized `FilePath` (#197).
+-- This is an example with an alias, and that is why
+-- Golden tests are failing.
+type CanonicalPath = FilePath
+
+-- | The repository info: files and directories.
+data RepoInfo = forall a. RepoInfo (RepoInfo' a)
+
+-- | Generate a 'RepoInfo' with efficient path lookup depending
+-- on the case-sensitivity of a given Markdown flavor.
+mkRepoInfo
+  :: Flavor
+  -> [(CanonicalPath, FileStatus)]
+  -> [(CanonicalPath, DirectoryStatus)] -> RepoInfo
+mkRepoInfo flavor files directories =
+    if caseInsensitiveAnchors flavor
+    then RepoInfo $ RICaseInsensitive $ RepoInfoData
+      { ridFiles = M.fromList $ fmap (first CaseInsensitivePath) $ files
+      , ridDirectories = M.fromList $ fmap (first CaseInsensitivePath) $ directories
+      }
+    else RepoInfo $ RICaseSensitive $ RepoInfoData
+      { ridFiles = M.fromList $ fmap (first CaseSensitivePath) $ files
+      , ridDirectories = M.fromList $ fmap (first CaseSensitivePath) $ directories
+      }
+
+-- | All tracked files and directories.
+data RepoInfoData a = RepoInfoData
+  { ridFiles :: Map a FileStatus
+    -- ^ Files from the repo with `FileInfo` attached to files that we've scanned.
+  , ridDirectories :: Map a DirectoryStatus
+    -- ^ Directories containing those files.
+  }
+
+data RepoInfo' a where
+  RICaseInsensitive :: RepoInfoData CaseInsensitivePath -> RepoInfo' CaseInsensitivePath
+  RICaseSensitive :: RepoInfoData CaseSensitivePath -> RepoInfo' CaseSensitivePath
+
+-- Files from the repo with `FileInfo` attached to files that we've scanned.
+riFiles :: RepoInfo -> [(CanonicalPath, FileStatus)]
+riFiles (RepoInfo (RICaseInsensitive (RepoInfoData{..}))) =
+  first unCaseInsensitivePath <$> toPairs ridFiles
+riFiles (RepoInfo (RICaseSensitive (RepoInfoData{..}))) =
+  first unCaseSensitivePath <$> toPairs ridFiles
+
+-- Search for a file in the repository.
+lookupFile :: CanonicalPath -> RepoInfo -> Maybe FileStatus
+lookupFile path (RepoInfo (RICaseInsensitive (RepoInfoData{..}))) =
+  M.lookup (CaseInsensitivePath path) ridFiles
+lookupFile path (RepoInfo (RICaseSensitive (RepoInfoData{..}))) =
+  M.lookup (CaseSensitivePath path) ridFiles
+
+-- Search for a directory in the repository.
+lookupDirectory :: CanonicalPath -> RepoInfo -> Maybe DirectoryStatus
+lookupDirectory path (RepoInfo (RICaseInsensitive (RepoInfoData{..}))) =
+  M.lookup (CaseInsensitivePath path) ridDirectories
+lookupDirectory path (RepoInfo (RICaseSensitive (RepoInfoData{..}))) =
+  M.lookup (CaseSensitivePath path) ridDirectories
+
+data CaseSensitivePath = CaseSensitivePath
+  { unCaseSensitivePath :: CanonicalPath
+  } deriving stock (Show, Eq, Ord)
+
+data CaseInsensitivePath = CaseInsensitivePath
+  { unCaseInsensitivePath :: CanonicalPath
+  } deriving stock (Show)
+
+instance Eq CaseInsensitivePath where
+  (CaseInsensitivePath p1) == (CaseInsensitivePath p2) =
+    on (==) (fmap C.toLower) p1 p2
+
+instance Ord CaseInsensitivePath where
+  compare (CaseInsensitivePath p1) (CaseInsensitivePath p2) =
+    on compare (fmap C.toLower) p1 p2
+
+instance Given ColorMode => Buildable RepoInfo where
+  build repoInfo
+    | Just scanned <- nonEmpty [(name, info) | (name, Scanned info) <- riFiles repoInfo]
+    = interpolateUnlinesF $ buildFileReport <$> scanned
+    where
+      buildFileReport :: (CanonicalPath, FileInfo) -> Builder
+      buildFileReport (name, info) =
+        [int||
+        #{ colorIfNeeded Cyan $ name }:
+        #{ interpolateIndentF 2 $ build info }
+        |]
+  build _ = "No scannable files found."

--- a/tests/Test/Xrefcheck/IgnoreRegexSpec.hs
+++ b/tests/Test/Xrefcheck/IgnoreRegexSpec.hs
@@ -39,7 +39,7 @@ test_ignoreRegex = give WithoutColors $
   in testGroup "Regular expressions performance"
     [ testCase "Check that only not matched links are verified" $ do
       scanResult <- allowRewrite showProgressBar $ \rw ->
-        scanRepo OnlyTracked rw formats (config ^. cExclusionsL) root
+        scanRepo OnlyTracked rw formats (config ^. cExclusionsL) GitHub root
 
       verifyRes <- allowRewrite showProgressBar $ \rw ->
         verifyRepo rw config verifyMode root $ srRepoInfo scanResult

--- a/tests/Test/Xrefcheck/TrailingSlashSpec.hs
+++ b/tests/Test/Xrefcheck/TrailingSlashSpec.hs
@@ -15,6 +15,7 @@ import Text.Interpolation.Nyan
 import Xrefcheck.Config
 import Xrefcheck.Core
 import Xrefcheck.Progress
+import Xrefcheck.RepoInfo
 import Xrefcheck.Scan
 import Xrefcheck.Scanners.Markdown
 import Xrefcheck.Util
@@ -27,9 +28,9 @@ test_slash = testGroup "Trailing forward slash detection" $
     testCase ("All the files within the root \"" <>
       root <>
       "\" should exist") $ do
-        (ScanResult _ (RepoInfo repoInfo _)) <- allowRewrite False $ \rw ->
-          scanRepo OnlyTracked rw format (cExclusions config & ecIgnoreL .~ []) root
-        nonExistentFiles <- lefts <$> forM (keys repoInfo) (\filePath -> do
+        (ScanResult _ repoInfo) <- allowRewrite False $ \rw ->
+          scanRepo OnlyTracked rw format (cExclusions config & ecIgnoreL .~ []) GitHub root
+        nonExistentFiles <- lefts <$> forM (fst <$> riFiles repoInfo) (\filePath -> do
           predicate <- doesFileExist filePath
           return $ if predicate
                     then Right ()

--- a/tests/Test/Xrefcheck/UtilRequests.hs
+++ b/tests/Test/Xrefcheck/UtilRequests.hs
@@ -12,7 +12,6 @@ module Test.Xrefcheck.UtilRequests
 import Universum
 
 import Control.Exception qualified as E
-import Data.Map qualified as M
 import Text.Interpolation.Nyan
 
 import Control.Concurrent (forkIO, killThread)
@@ -20,6 +19,7 @@ import Test.Tasty.HUnit (assertBool)
 import Xrefcheck.Config
 import Xrefcheck.Core
 import Xrefcheck.Progress
+import Xrefcheck.RepoInfo
 import Xrefcheck.Scan
 import Xrefcheck.Util
 import Xrefcheck.Verify
@@ -72,4 +72,4 @@ verifyReferenceWithProgress :: Reference -> IORef VerifyProgress -> IO (VerifyRe
 verifyReferenceWithProgress reference progRef = do
   fmap wrlItem <$> verifyReference
     (defConfig GitHub & cExclusionsL . ecIgnoreExternalRefsToL .~ []) FullMode
-    progRef (RepoInfo M.empty mempty) "." "" reference
+    progRef (mkRepoInfo GitHub mempty mempty) "." "" reference


### PR DESCRIPTION
## Description

Problem: During the implementation of issue #197, we though about how we could customize the way filepaths are searched within the repository data in an efficient way, depending on if filepaths are case-insensitive or not.

Solution: We implemented a GADT with its polymorphic parameter, corresponding to Map keys, hidden under an existentially quantified type. Although we end up not requiring this, we separate the essence of the idea to a commit in a separate branch, so it can be reviewed in the future.

## Related issue(s)

Relates #197 

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](https://github.com/serokell/xrefcheck/tree/master/README.md)
    - Haddock

- Public contracts
  - [ ] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [ ] I added an entry to the [changelog](https://github.com/serokell/xrefcheck/tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [ ] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [ ] My code complies with the [style guide](https://github.com/serokell/style/blob/master/haskell.md).
