### PR TITLE
[#64] Implement copy paste protection

### DIFF
--- a/src/Xrefcheck/Command.hs
+++ b/src/Xrefcheck/Command.hs
@@ -28,7 +28,7 @@ import Xrefcheck.Scan
 import Xrefcheck.Scanners.Markdown (markdownSupport)
 import Xrefcheck.System (askWithinCI)
 import Xrefcheck.Util
-import Xrefcheck.Verify (reportVerifyErrs, verifyErrors, verifyRepo)
+import Xrefcheck.Verify (reportCopyPasteErrors, reportVerifyErrs, verifyErrors, verifyRepo)
 
 readConfig :: FilePath -> IO Config
 readConfig path = fmap (normaliseConfigFilePaths . overrideConfig) do
@@ -81,11 +81,12 @@ defaultAction Options{..} = do
 
     whenJust (nonEmpty $ sortBy (compare `on` seFile) scanErrs) $ reportScanErrs
 
-    verifyRes <- allowRewrite showProgressBar $ \rw -> do
+    (verifyRes, copyPasteErrors) <- allowRewrite showProgressBar $ \rw -> do
       let fullConfig = config
             { cNetworking = addNetworkingOptions (cNetworking config) oNetworkingOptions }
       verifyRepo rw fullConfig oMode oRoot repoInfo
 
+    whenJust (nonEmpty copyPasteErrors) reportCopyPasteErrors
     case verifyErrors verifyRes of
       Nothing | null scanErrs -> fmtLn "All repository links are valid."
       Nothing -> exitFailure

--- a/src/Xrefcheck/Config.hs
+++ b/src/Xrefcheck/Config.hs
@@ -73,6 +73,8 @@ data ScannersConfig' f = ScannersConfig
   , scAnchorSimilarityThreshold :: Field f Double
     -- ^ On 'anchor not found' error, how much similar anchors should be displayed as
     -- hint. Number should be between 0 and 1, larger value means stricter filter.
+  , scCopyPasteCheckEnabled :: Field f Bool
+    -- ^ Whether copy-paste check is enabled globally.
   } deriving stock (Generic)
 
 makeLensesWith postfixFields ''Config'
@@ -94,6 +96,9 @@ overrideConfig config
                   , scAnchorSimilarityThreshold =
                     fromMaybe (scAnchorSimilarityThreshold defScanners)
                     $ scAnchorSimilarityThreshold (cScanners config)
+                  , scCopyPasteCheckEnabled =
+                    fromMaybe (scCopyPasteCheckEnabled defScanners)
+                    $ scCopyPasteCheckEnabled (cScanners config)
                   }
     }
   where

--- a/src/Xrefcheck/Config/Default.hs
+++ b/src/Xrefcheck/Config/Default.hs
@@ -67,6 +67,9 @@ scanners:
     #
     # This affects which anchors are generated for headers.
     flavor: #s{flavor}
+
+  # Whether copy-paste check is enabled globally.
+  copyPasteCheckEnabled: True
 |]
   where
     ignoreLocalRefsFrom :: NonEmpty Text

--- a/src/Xrefcheck/Core.hs
+++ b/src/Xrefcheck/Core.hs
@@ -15,9 +15,9 @@ import Control.Lens (makeLenses)
 import Data.Aeson (FromJSON (..), withText)
 import Data.Char (isAlphaNum)
 import Data.Char qualified as C
-import Data.Default (Default (..))
 import Data.DList (DList)
 import Data.DList qualified as DList
+import Data.Default (Default (..))
 import Data.List qualified as L
 import Data.Reflection (Given)
 import Data.Text qualified as T

--- a/src/Xrefcheck/Core.hs
+++ b/src/Xrefcheck/Core.hs
@@ -61,7 +61,7 @@ instance FromJSON Flavor where
 -- We keep this in text because scanners for different formats use different
 -- representation of this thing, and it actually appears in reports only.
 newtype Position = Position (Maybe Text)
-  deriving stock (Show, Eq, Generic)
+  deriving stock (Show, Eq, Generic, Ord)
 
 instance Given ColorMode => Buildable Position where
   build (Position pos) = case pos of
@@ -77,7 +77,7 @@ data Reference = Reference
   , rAnchor :: Maybe Text
     -- ^ Section or custom anchor tag.
   , rPos    :: Position
-  } deriving stock (Show, Generic)
+  } deriving stock (Show, Generic, Eq, Ord)
 
 -- | Context of anchor.
 data AnchorType

--- a/tests/Test/Xrefcheck/CopyPasteCheckSpec.hs
+++ b/tests/Test/Xrefcheck/CopyPasteCheckSpec.hs
@@ -1,0 +1,65 @@
+{- SPDX-FileCopyrightText: 2019 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -}
+
+module Test.Xrefcheck.CopyPasteCheckSpec where
+
+import Universum
+
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (Assertion, testCase, (@?=))
+
+import Xrefcheck.Core
+import Xrefcheck.Verify
+
+assertUnordered :: (Show a, Ord a) => [a] -> [a] -> Assertion
+assertUnordered = (@?=) `on` sort
+
+testPath :: FilePath
+testPath = "test-path"
+
+test_copyPasteCheck :: TestTree
+test_copyPasteCheck = testGroup "Copypaste check"
+  [ testCase "Detect copypaste error if there is a link with a matching name" $ do
+      let link = "./first-file"
+          anchor = Just "heading"
+          differentAnchor = Nothing
+          defPos = Position Nothing
+          original1 = Reference "_-  First -  - File" link anchor defPos
+          original2 = Reference "_-  First - fi - le" link anchor defPos
+          notCopied = Reference " Link 2 " link differentAnchor defPos
+          copied1 = Reference " foo bar" link anchor defPos
+          copied2 = Reference " Baz quux" link anchor defPos
+          input = [original1, original2, notCopied, copied1, copied2]
+          res = checkCopyPaste testPath input
+          expectedRes =
+          -- only first matching link is shown in the output
+            [ CopyPasteCheckResult testPath original1 copied1
+            , CopyPasteCheckResult testPath original1 copied2
+            ]
+      res `assertUnordered` expectedRes
+  , testCase "Succeed if there is not link with a matching name" $ do
+      let link = "./first-file"
+          anchor = Just "heading"
+          defPos = Position Nothing
+          original1 = Reference "_Foo bar" link anchor defPos
+          original2 = Reference " Baz quux" link anchor defPos
+          original3 = Reference " Foo qubarx" link anchor defPos
+          input = [original1, original2, original3]
+          res = checkCopyPaste testPath input
+          expectedRes = []
+      res @?= expectedRes
+  , testCase "Check external links" $ do
+      let link = "https://github.com"
+          anchor = Nothing
+          defPos = Position Nothing
+          original = Reference "github" link anchor defPos
+          copied = Reference "gitlab" link anchor defPos
+          input = [original, copied]
+          res = checkCopyPaste testPath input
+          expectedRes =
+            [ CopyPasteCheckResult testPath original copied
+            ]
+      res @?= expectedRes
+  ]

--- a/tests/Test/Xrefcheck/IgnoreAnnotationsSpec.hs
+++ b/tests/Test/Xrefcheck/IgnoreAnnotationsSpec.hs
@@ -34,7 +34,7 @@ test_ignoreAnnotations =
       , testCase "Check if broken unrecognised annotation produce error" do
           let file = "tests/markdowns/with-annotations/unrecognised_option.md"
           errs <- getErrs file
-          errs @?= makeError (Just $ PosInfo 7 1 7 46) file (UnrecognisedErr "unrecognised-option")
+          errs @?= makeError (Just $ PosInfo 7 1 7 46) file (UnrecognisedErr "ignore unrecognised-option")
       ]
   , testGroup "\"ignore link\" mode"
       [ testCase "Check \"ignore link\" performance" $ do

--- a/tests/Test/Xrefcheck/IgnoreRegexSpec.hs
+++ b/tests/Test/Xrefcheck/IgnoreRegexSpec.hs
@@ -44,7 +44,7 @@ test_ignoreRegex = give WithoutColors $
       verifyRes <- allowRewrite showProgressBar $ \rw ->
         verifyRepo rw config verifyMode root $ srRepoInfo scanResult
 
-      let brokenLinks = pickBrokenLinks verifyRes
+      let brokenLinks = pickBrokenLinks $ fst verifyRes
 
       let matchedLinks =
             [ "https://bad.referenc/"

--- a/tests/configs/github-config.yaml
+++ b/tests/configs/github-config.yaml
@@ -56,3 +56,6 @@ scanners:
     #
     # This affects which anchors are generated for headers.
     flavor: GitHub
+
+  # Whether copy-paste check is enabled globally.
+  copyPasteCheckEnabled: True

--- a/tests/golden/check-copy-paste/check-copy-paste.bats
+++ b/tests/golden/check-copy-paste/check-copy-paste.bats
@@ -1,0 +1,17 @@
+#!/usr/bin/env bats
+
+# SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+load '../helpers/bats-support/load'
+load '../helpers/bats-assert/load'
+load '../helpers/bats-file/load'
+load '../helpers'
+
+
+@test "Check possible copy-paste errors and copy-paste annotations " {
+  to_temp xrefcheck
+
+  assert_diff expected.gold
+}

--- a/tests/golden/check-copy-paste/expected.gold
+++ b/tests/golden/check-copy-paste/expected.gold
@@ -1,0 +1,48 @@
+=== Possible copy/paste errors ===
+
+  ➥  In file second-file.md
+     reference (relative) at src:13:1-29:
+       - text: "Lol Kek"
+       - link: ./first-file.md
+       - anchor: -
+     is possibly a bad copy paste of
+     reference (relative) at src:7:1-34:
+       - text: "First   file"
+       - link: ./first-file.md
+       - anchor: -
+
+  ➥  In file second-file.md
+     reference (relative) at src:14:1-30:
+       - text: "Baz quux"
+       - link: ./first-file.md
+       - anchor: -
+     is possibly a bad copy paste of
+     reference (relative) at src:7:1-34:
+       - text: "First   file"
+       - link: ./first-file.md
+       - anchor: -
+
+  ➥  In file second-file.md
+     reference (relative) at src:24:1-29:
+       - text: "fdw"
+       - link: ./first-file.md
+       - anchor: chor
+     is possibly a bad copy paste of
+     reference (relative) at src:23:1-32:
+       - text: "ff-cho"
+       - link: ./first-file.md
+       - anchor: chor
+
+  ➥  In file second-file.md
+     reference (external) at src:29:1-28:
+       - text: "gitlab"
+       - link: https://github.com
+       - anchor: -
+     is possibly a bad copy paste of
+     reference (external) at src:28:1-28:
+       - text: "github"
+       - link: https://github.com
+       - anchor: -
+
+Possible copy/paste errors dumped, 4 in total.
+All repository links are valid.

--- a/tests/golden/check-copy-paste/first-file.md
+++ b/tests/golden/check-copy-paste/first-file.md
@@ -1,0 +1,11 @@
+<!--
+ - SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -->
+
+# heading
+
+# anch
+
+# chor

--- a/tests/golden/check-copy-paste/second-file.md
+++ b/tests/golden/check-copy-paste/second-file.md
@@ -1,0 +1,29 @@
+<!--
+ - SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -->
+
+[ First   file  ](./first-file.md)
+
+<!-- This one is not reported because anchor is not the same -->
+[   Link 3](./first-file.md#heading)
+
+<!-- And these ones are checked and reported -->
+[   Lol Kek](./first-file.md)
+[   Baz quux](./first-file.md)
+
+<!-- These ones are not reported because none of link -->
+<!-- names is a subsequence of a link                 -->
+[  asd](./first-file.md#anch)
+[  fdw](./first-file.md#anch)
+
+<!-- These ones are reported because -->
+<!-- ff-cho is a subsequence of link+anchor -->
+[  ff-cho](./first-file.md#chor)
+[  fdw](./first-file.md#chor)
+
+
+<!-- check external links -->
+[github](https://github.com)
+[gitlab](https://github.com)

--- a/tests/golden/check-scan-errors/expected.gold
+++ b/tests/golden/check-scan-errors/expected.gold
@@ -18,7 +18,7 @@
   ➥  In file check-scan-errors.md
      scan error at src:21:1-50:
 
-     Unrecognised option "unrecognised-annotation" perhaps you meant <"ignore link"|"ignore paragraph"|"ignore all">
+     Unrecognised option "ignore unrecognised-annotation" perhaps you meant <"ignore link"|"ignore paragraph"|"ignore all">
 
   ➥  In file check-second-file.md
      scan error at src:9:1-29:


### PR DESCRIPTION
## Description
    
Problem: Currently xrefcheck is not able to detect possible bad
copy-pastes, when some links are referring the same file, but
from the link names it seems that one of
those links should refer other file.
    
Solution: Implement check, add corresponding settings to the config.


## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #1 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Fixes #64 

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](https://github.com/serokell/xrefcheck/tree/master/README.md)
    - Haddock

- Public contracts
  - [ ] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [ ] I added an entry to the [changelog](https://github.com/serokell/xrefcheck/tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [ ] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [ ] My code complies with the [style guide](https://github.com/serokell/style/blob/master/haskell.md).

#### ✓ Release Checklist

- [ ] I updated the version number in `package.yaml`.
- [ ] I updated the [changelog](https://github.com/serokell/xrefcheck/tree/master/CHANGES.md) and moved everything
      under the "Unreleased" section to a new section for this release version.
- [ ] (After merging) I edited the [auto-release](https://github.com/serokell/xrefcheck/releases/tag/auto-release).
    * Change the tag and title using the format `vX.Y.Z`.
    * Write a summary of all user-facing changes.
    * Deselect the "This is a pre-release" checkbox at the bottom.
- [ ] (After merging) I updated [`xrefcheck-action`](https://github.com/serokell/xrefcheck-action#updating-supported-versions).
- [ ] (After merging) I uploaded the package to [hackage](https://hackage.haskell.org/package/xrefcheck).
