### PR TITLE
Yuri romanowski/#64 add annotations for copypaste check

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,11 +36,13 @@ Unreleased
   + Now we call references to anchors in current file (e.g. `[a](#b)`) as
   `file-local` references instead of calling them `current file` (which was ambiguous).
 * [#233](https://github.com/serokell/xrefcheck/pull/233)
-  + Now xrefxcheck does not follow redirect links by default. It fails for permanent
+  + Now xrefcheck does not follow redirect links by default. It fails for permanent
     redirect responses (i.e. 301 and 308) and passes for temporary ones (i.e. 302, 303, 307).
 * [#231](https://github.com/serokell/xrefcheck/pull/231)
   + Anchor analysis takes now into account the appropriate case-sensitivity depending on
   the configured Markdown flavour.
+* [240](https://github.com/serokell/xrefcheck/pull/240)
+  + Now xrefcheck is able to detect possible copy-pastes relying on links and their names.
 
 0.2.2
 ==========

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Comparing to alternative solutions, this tool tries to achieve the following poi
 * Supports external links (`http`, `https`, `ftp` and `ftps`).
 * Detects broken and ambiguous anchors in local links.
 * Integration with GitHub Actions.
+* Detects possible bad copy-pastes of links.
 
 ## Dependencies [↑](#xrefcheck)
 
@@ -147,6 +148,21 @@ There are several ways to fix this:
 1. How does `xrefcheck` handle localhost links?
     * By default, `xrefcheck` will ignore links to localhost.
     * This behavior can be disabled by removing the corresponding entry from the `ignoreExternalRefsTo` list in the config file.
+
+1. How do I disable copy-paste check for specific links?
+    * Add a `<!-- xrefcheck: no duplication check in link -->` annotation before the link:
+      ```md
+      <!-- xrefcheck: no duplication check in link -->
+      Links with bad copypaste:
+      [good link](https://good.link.uri/).
+      [copypasted link](https://good.link.uri/).
+      ```
+      ```md
+      A [good link](https://good.link.uri/)
+      followed by an <!-- xrefcheck: no duplication check in link --> [copypasted intentionally](https://good.link.uri/).
+      ```
+    * You can use a `<!-- xrefcheck: no duplication check in paragraph -->` annotation to disable copy-paste check in a paragraph.
+    * You can use a `<!-- xrefcheck: no duplication check in file -->` annotation to disable copy-paste check within an entire file.
 
 ## Further work [↑](#xrefcheck)
 

--- a/src/Xrefcheck/Command.hs
+++ b/src/Xrefcheck/Command.hs
@@ -28,7 +28,7 @@ import Xrefcheck.Scan
 import Xrefcheck.Scanners.Markdown (markdownSupport)
 import Xrefcheck.System (askWithinCI)
 import Xrefcheck.Util
-import Xrefcheck.Verify (reportVerifyErrs, verifyErrors, verifyRepo)
+import Xrefcheck.Verify (reportCopyPasteErrors, reportVerifyErrs, verifyErrors, verifyRepo)
 
 readConfig :: FilePath -> IO Config
 readConfig path = fmap (normaliseConfigFilePaths . overrideConfig) do
@@ -81,11 +81,12 @@ defaultAction Options{..} = do
 
     whenJust (nonEmpty $ sortBy (compare `on` seFile) scanErrs) $ reportScanErrs
 
-    verifyRes <- allowRewrite showProgressBar $ \rw -> do
+    (verifyRes, copyPasteErrors) <- allowRewrite showProgressBar $ \rw -> do
       let fullConfig = config
             { cNetworking = addNetworkingOptions (cNetworking config) oNetworkingOptions }
       verifyRepo rw fullConfig oMode oRoot repoInfo
 
+    whenJust (nonEmpty copyPasteErrors) reportCopyPasteErrors
     case verifyErrors verifyRes of
       Nothing | null scanErrs -> fmtLn "All repository links are valid."
       Nothing -> exitFailure

--- a/src/Xrefcheck/Config.hs
+++ b/src/Xrefcheck/Config.hs
@@ -73,6 +73,8 @@ data ScannersConfig' f = ScannersConfig
   , scAnchorSimilarityThreshold :: Field f Double
     -- ^ On 'anchor not found' error, how much similar anchors should be displayed as
     -- hint. Number should be between 0 and 1, larger value means stricter filter.
+  , scCopyPasteCheckEnabled :: Field f Bool
+    -- ^ Whether copy-paste check is enabled globally.
   } deriving stock (Generic)
 
 makeLensesWith postfixFields ''Config'
@@ -94,6 +96,9 @@ overrideConfig config
                   , scAnchorSimilarityThreshold =
                     fromMaybe (scAnchorSimilarityThreshold defScanners)
                     $ scAnchorSimilarityThreshold (cScanners config)
+                  , scCopyPasteCheckEnabled =
+                    fromMaybe (scCopyPasteCheckEnabled defScanners)
+                    $ scCopyPasteCheckEnabled (cScanners config)
                   }
     }
   where

--- a/src/Xrefcheck/Config/Default.hs
+++ b/src/Xrefcheck/Config/Default.hs
@@ -67,6 +67,9 @@ scanners:
     #
     # This affects which anchors are generated for headers.
     flavor: #s{flavor}
+
+  # Whether copy-paste check is enabled globally.
+  copyPasteCheckEnabled: True
 |]
   where
     ignoreLocalRefsFrom :: NonEmpty Text

--- a/src/Xrefcheck/Core.hs
+++ b/src/Xrefcheck/Core.hs
@@ -15,9 +15,9 @@ import Control.Lens (makeLenses)
 import Data.Aeson (FromJSON (..), withText)
 import Data.Char (isAlphaNum)
 import Data.Char qualified as C
-import Data.Default (Default (..))
 import Data.DList (DList)
 import Data.DList qualified as DList
+import Data.Default (Default (..))
 import Data.List qualified as L
 import Data.Reflection (Given)
 import Data.Text qualified as T

--- a/src/Xrefcheck/Core.hs
+++ b/src/Xrefcheck/Core.hs
@@ -61,7 +61,7 @@ instance FromJSON Flavor where
 -- We keep this in text because scanners for different formats use different
 -- representation of this thing, and it actually appears in reports only.
 newtype Position = Position (Maybe Text)
-  deriving stock (Show, Eq, Generic)
+  deriving stock (Show, Eq, Generic, Ord)
 
 instance Given ColorMode => Buildable Position where
   build (Position pos) = case pos of
@@ -77,7 +77,7 @@ data Reference = Reference
   , rAnchor :: Maybe Text
     -- ^ Section or custom anchor tag.
   , rPos    :: Position
-  } deriving stock (Show, Generic)
+  } deriving stock (Show, Generic, Eq, Ord)
 
 -- | Context of anchor.
 data AnchorType

--- a/src/Xrefcheck/Scan.hs
+++ b/src/Xrefcheck/Scan.hs
@@ -117,18 +117,27 @@ data ScanErrorDescription
   = LinkErr
   | FileErr
   | ParagraphErr Text
+  | LinkErrCpc
+  | FileErrCpc
+  | ParagraphErrCpc Text
   | UnrecognisedErr Text
   deriving stock (Show, Eq)
 
 instance Buildable ScanErrorDescription where
   build = \case
     LinkErr -> [int||Expected a LINK after "ignore link" annotation|]
+    LinkErrCpc -> [int||Expected a LINK after "no duplication check in link" annotation|]
     FileErr -> [int||Annotation "ignore all" must be at the top of \
+                     markdown or right after comments at the top|]
+    FileErrCpc -> [int||Annotation "no duplication check in file" must be at the top of \
                      markdown or right after comments at the top|]
     ParagraphErr txt -> [int||Expected a PARAGRAPH after \
                               "ignore paragraph" annotation, but found #{txt}|]
-    UnrecognisedErr txt -> [int||Unrecognised option "#{txt}" perhaps you meant \
-                                 <"ignore link"|"ignore paragraph"|"ignore all">|]
+    ParagraphErrCpc txt -> [int||Expected a PARAGRAPH after \
+                              "no duplication check in paragraph" annotation, but found #{txt}|]
+    UnrecognisedErr txt -> [int||Unrecognised option "#{txt}", perhaps you meant
+                                 <"ignore link"|"ignore paragraph"|"ignore all">
+                                 or "no duplication check in <link|paragraph|file>"?|]
 
 specificFormatsSupport :: [([Extension], ScanAction)] -> FormatsSupport
 specificFormatsSupport formats = \ext -> M.lookup ext formatsMap

--- a/src/Xrefcheck/Scanners/Markdown.hs
+++ b/src/Xrefcheck/Scanners/Markdown.hs
@@ -54,6 +54,24 @@ instance Buildable C.Node where
   build (C.Node _mpos ty mSubs) = nameF (show ty) $
     maybe "[]" interpolateBlockListF (nonEmpty mSubs)
 
+data Node a = Node
+  { _ndPos :: Maybe PosInfo
+  , _ndType :: NodeType
+  , _ndInfo :: a
+  , _ndSubs :: [Node a]
+  }
+
+instance Buildable (Node a) where
+  build (Node _mpos ty _info mSubs) = nameF (show ty) $
+    maybe "[]" interpolateBlockListF (nonEmpty mSubs)
+
+-- Here and below CPC stands for "copy/paste check"
+type NodeCPC = Node CopyPasteCheck
+
+newtype CopyPasteCheck = CopyPasteCheck
+  { cpcShouldCheck :: Bool
+  } deriving stock (Show, Eq, Generic)
+
 toPosition :: Maybe PosInfo -> Position
 toPosition = Position . \case
   Nothing -> Nothing
@@ -68,7 +86,7 @@ toPosition = Position . \case
         |]
 
 -- | Extract text from the topmost node.
-nodeExtractText :: (C.Node) -> Text
+nodeExtractText :: Node info -> Text
 nodeExtractText = T.strip . mconcat . map extractText . nodeFlatten
   where
     extractText = \case
@@ -76,8 +94,8 @@ nodeExtractText = T.strip . mconcat . map extractText . nodeFlatten
       CODE t -> t
       _ -> ""
 
-    nodeFlatten :: (C.Node) -> [NodeType]
-    nodeFlatten (C.Node _pos ty subs) = ty : concatMap nodeFlatten subs
+    nodeFlatten :: Node info -> [NodeType]
+    nodeFlatten (Node _pos ty _info subs) = ty : concatMap nodeFlatten subs
 
 
 data IgnoreMode
@@ -120,6 +138,7 @@ makeLensesFor [("_ignoreMode", "ignoreMode")] 'Ignore
 
 data Annotation
   = IgnoreAnnotation IgnoreMode
+  | IgnoreCopyPasteCheck IgnoreMode
   | InvalidAnnotation Text
   deriving stock (Eq)
 
@@ -127,6 +146,8 @@ data Annotation
 
 data ScannerState = ScannerState
   { _ssIgnore :: Maybe Ignore
+  , _ssIgnoreCopyPasteCheck :: Maybe Ignore
+  , _ssParagraphExpectedAfterCpcAnnotation :: Bool
   , _ssParentNodeType :: Maybe NodeType
   -- ^ @cataNodeWithParentNodeInfo@ allows to get a @NodeType@ of parent node from this field
   }
@@ -135,7 +156,9 @@ makeLenses ''ScannerState
 initialScannerState :: ScannerState
 initialScannerState = ScannerState
   { _ssIgnore = Nothing
+  , _ssIgnoreCopyPasteCheck = Nothing
   , _ssParentNodeType = Nothing
+  , _ssParagraphExpectedAfterCpcAnnotation = False
   }
 
 type ScannerM a = StateT ScannerState (Writer [ScanError]) a
@@ -155,40 +178,49 @@ cataNodeWithParentNodeInfo f node = cataNode f' node
       map (ssParentNodeType .= Just ty >>) childScanners
 
 -- | Find ignore annotations (ignore paragraph and ignore link)
--- and remove nodes that should be ignored.
-processAnnotations :: FilePath -> C.Node -> Writer [ScanError] C.Node
+-- and remove nodes that should be ignored;
+-- find copy/paste check annotations (ignore for paragraph and for link)
+-- and label nodes with a boolean meaning whether they should be
+-- copy/paste checked.
+processAnnotations :: FilePath -> C.Node -> Writer [ScanError] NodeCPC
 processAnnotations fp = withIgnoreMode . cataNodeWithParentNodeInfo process
   where
     process
       :: Maybe PosInfo
       -> NodeType
-      -> [ScannerM C.Node]
-      -> ScannerM C.Node
+      -> [ScannerM NodeCPC]
+      -> ScannerM NodeCPC
     process pos ty subs = do
       let node = C.Node pos ty []
-      use ssIgnore >>= \ign -> do
+      use ssIgnore >>= \ign ->
+        use ssIgnoreCopyPasteCheck >>= \ignCPC -> do
         -- When no `Ignore` state is set check next node for annotation,
         -- if found then set it as new `IgnoreMode` otherwise skip node.
-        let mbAnnotation = getAnnotation node
-        case mbAnnotation of
+        let shouldCheckCPC = CopyPasteCheck $ isNothing ignCPC
+        let traverseChildren = Node pos ty shouldCheckCPC <$> sequence subs
+        case getAnnotation node of
           Just ann -> handleAnnotation pos ty ann
           Nothing -> do
             case ty of
-              PARAGRAPH -> handleParagraph ign pos ty subs
-              LINK {}   -> handleLink      ign pos ty subs
-              IMAGE {}  -> handleLink      ign pos ty subs
-              _         -> handleOther     ign pos ty subs
+              PARAGRAPH -> handleParagraph ign    traverseChildren
+              LINK {}   -> handleLink      ign ty traverseChildren
+              IMAGE {}  -> handleLink      ign ty traverseChildren
+              _         -> handleOther     ign ty traverseChildren
 
     handleLink ::
       Maybe Ignore ->
-      Maybe PosInfo ->
       NodeType ->
-      [ScannerM C.Node] ->
-      ScannerM C.Node
-    handleLink ign pos ty subs = do
-      let traverseChildren = C.Node pos ty <$> sequence subs
-      -- It can be checked that it's correct for all the cases
+      ScannerM NodeCPC ->
+      ScannerM NodeCPC
+    handleLink ign ty traverseChildren = do
+      -- It's common for all ignore states
       ssIgnore .= Nothing
+      -- If there was a copy/paste ignore annotation that expected link,
+      -- reset this state
+      resetCpcIgnoreIfLink
+      -- If right now there was a copy/paste ignore annotation for paragraph,
+      -- emit an error and reset these states.
+      reportExpectedParagraphAfterIgnoreCpcAnnotation ty
 
       case ign of
         Nothing -> traverseChildren
@@ -200,73 +232,122 @@ processAnnotations fp = withIgnoreMode . cataNodeWithParentNodeInfo process
 
     handleParagraph ::
       Maybe Ignore ->
-      Maybe PosInfo ->
-      NodeType ->
-      [ScannerM C.Node] ->
-      ScannerM C.Node
-    handleParagraph ign pos ty subs = do
-      let traverseChildren = C.Node pos ty <$> sequence subs
+      ScannerM NodeCPC ->
+      ScannerM NodeCPC
+    handleParagraph ign traverseChildren = do
+      -- If a new paragraph was expected (this stands for True), now we
+      -- don't expect paragraphs any more.
+      ssParagraphExpectedAfterCpcAnnotation .= False
       node <- case ign of
-        Nothing -> traverseChildren
+        Nothing ->
+          wrapTraverseNodeWithLinkExpectedForCpc traverseChildren
         Just (Ignore IMSParagraph _) -> do
           ssIgnore .= Nothing
           pure defNode
         Just (Ignore (IMSLink ignoreLinkState) modePos) ->
-          traverseNodeWithLinkExpected ignoreLinkState modePos pos ty subs
+          wrapTraverseNodeWithLinkExpected ignoreLinkState modePos $
+          wrapTraverseNodeWithLinkExpectedForCpc traverseChildren
+
+      ssIgnoreCopyPasteCheck .= Nothing
 
       use ssIgnore >>= \case
-        Just (Ignore (IMSLink ExpectingLinkInParagraph) pragmaPos) ->
+        Just (Ignore (IMSLink ExpectingLinkInParagraph) pragmaPos) -> do
           lift $ tell $ makeError pragmaPos fp LinkErr
+          ssIgnore .= Nothing
         _ -> pass
+      use ssIgnoreCopyPasteCheck >>= \case
+        Just (Ignore (IMSLink ExpectingLinkInParagraph) pragmaPos) -> do
+          lift $ tell $ makeError pragmaPos fp LinkErrCpc
+          ssIgnoreCopyPasteCheck .= Nothing
+        _ -> pass
+
       pure node
 
     handleOther ::
       Maybe Ignore ->
-      Maybe PosInfo ->
       NodeType ->
-      [ScannerM C.Node] ->
-      ScannerM C.Node
-    handleOther ign pos ty subs = do
-      let traverseChildren = C.Node pos ty <$> sequence subs
+      ScannerM NodeCPC ->
+      ScannerM NodeCPC
+    handleOther ign ty traverseChildren = do
+      -- If right now there was a copy/paste ignore annotation for paragraph,
+      -- emit an error and reset these states.
+      reportExpectedParagraphAfterIgnoreCpcAnnotation ty
 
       case ign of
-        Nothing -> traverseChildren
+        Nothing ->
+          wrapTraverseNodeWithLinkExpectedForCpc traverseChildren
         Just (Ignore IMSParagraph modePos) -> do
           reportExpectedParagraphAfterIgnoreAnnotation modePos ty
           ssIgnore .= Nothing
-          traverseChildren
-        Just (Ignore (IMSLink ignoreLinkState) modePos) -> do
-          traverseNodeWithLinkExpected ignoreLinkState modePos pos ty subs
+          wrapTraverseNodeWithLinkExpectedForCpc traverseChildren
+        Just (Ignore (IMSLink ignoreLinkState) modePos) ->
+          wrapTraverseNodeWithLinkExpected ignoreLinkState modePos $
+          wrapTraverseNodeWithLinkExpectedForCpc traverseChildren
 
     reportExpectedParagraphAfterIgnoreAnnotation :: Maybe PosInfo -> NodeType -> ScannerM ()
     reportExpectedParagraphAfterIgnoreAnnotation modePos ty =
       lift . tell . makeError modePos fp . ParagraphErr $ prettyType ty
 
-    traverseNodeWithLinkExpected ::
+    resetCpcIgnoreIfLink :: ScannerM ()
+    resetCpcIgnoreIfLink = do
+      curCpcIgnore <- use ssIgnoreCopyPasteCheck
+      case _ignoreMode <$> curCpcIgnore of
+        Just (IMSLink _) -> ssIgnoreCopyPasteCheck .= Nothing
+        _ -> pass
+
+    reportExpectedParagraphAfterIgnoreCpcAnnotation ::
+      NodeType -> ScannerM ()
+    reportExpectedParagraphAfterIgnoreCpcAnnotation ty =
+      use ssIgnoreCopyPasteCheck >>= \case
+        Just (Ignore IMSParagraph modePos) ->
+          whenM (use ssParagraphExpectedAfterCpcAnnotation) $ do
+            lift . tell . makeError modePos fp . ParagraphErrCpc $ prettyType ty
+            ssParagraphExpectedAfterCpcAnnotation .= False
+            ssIgnoreCopyPasteCheck .= Nothing
+        _ -> pass
+
+    wrapTraverseNodeWithLinkExpected ::
       IgnoreLinkState ->
       Maybe PosInfo ->
-      Maybe PosInfo ->
-      NodeType ->
-      [ScannerM C.Node] ->
-      ScannerM C.Node
-    traverseNodeWithLinkExpected ignoreLinkState modePos pos ty subs = do
-      when (ignoreLinkState == ExpectingLinkInSubnodes) $
-        ssIgnore . _Just . ignoreMode .= IMSLink ParentExpectsLink
-      node' <- C.Node pos ty <$> sequence subs
-      when (ignoreLinkState == ExpectingLinkInSubnodes) $ do
+      ScannerM NodeCPC ->
+      ScannerM NodeCPC
+    wrapTraverseNodeWithLinkExpected ignoreLinkState modePos =
+      if ignoreLinkState /= ExpectingLinkInSubnodes
+      then id
+      else \traverse' -> do
+        ssIgnore . _Just . ignoreMode .=  IMSLink ParentExpectsLink
+        node' <- traverse'
         currentIgnore <- use ssIgnore
         case currentIgnore of
           Just (Ignore {_ignoreMode = IMSLink ParentExpectsLink}) -> do
             lift $ tell $ makeError modePos fp LinkErr
             ssIgnore .= Nothing
           _ -> pass
-      return node'
+        return node'
+
+    wrapTraverseNodeWithLinkExpectedForCpc ::
+      ScannerM NodeCPC ->
+      ScannerM NodeCPC
+    wrapTraverseNodeWithLinkExpectedForCpc traverse' = do
+      ignoreCpc <- use ssIgnoreCopyPasteCheck
+      case ignoreCpc of
+        Just (Ignore (IMSLink ExpectingLinkInSubnodes) modePos) -> do
+          ssIgnoreCopyPasteCheck . _Just . ignoreMode .=  IMSLink ParentExpectsLink
+          node' <- traverse'
+          currentIgnore <- use ssIgnoreCopyPasteCheck
+          case currentIgnore of
+            Just (Ignore {_ignoreMode = IMSLink ParentExpectsLink}) -> do
+              lift $ tell $ makeError modePos fp LinkErrCpc
+              ssIgnoreCopyPasteCheck .= Nothing
+            _ -> pass
+          return node'
+        _ -> traverse'
 
     handleAnnotation
       :: Maybe PosInfo
       -> NodeType
       -> Annotation
-      -> ScannerM C.Node
+      -> ScannerM NodeCPC
     handleAnnotation pos nodeType = \case
       IgnoreAnnotation mode -> do
         let reportIfThereWasAnnotation :: ScannerM ()
@@ -300,6 +381,41 @@ processAnnotations fp = withIgnoreMode . cataNodeWithParentNodeInfo process
         whenJust mbIgnoreModeState $ \ignoreModeState ->
           (ssIgnore .= Just (Ignore ignoreModeState correctPos))
         pure defNode
+      IgnoreCopyPasteCheck mode -> do
+        mbIgnoreModeState <- case mode of
+          IMLink -> use ssParentNodeType <&> Just . IMSLink . \case
+             Just PARAGRAPH -> ExpectingLinkInParagraph
+             _ -> ExpectingLinkInSubnodes
+
+          IMParagraph -> do
+            ssParagraphExpectedAfterCpcAnnotation .= True
+            pure $ Just IMSParagraph
+
+          -- We don't expect to find an `ignore all` annotation here,
+          -- since that annotation should be at the top of the file and
+          -- any correct annotations should be handled in `checkGlobalAnnotations`
+          -- function.
+          IMAll -> do
+            lift . tell $ makeError correctPos fp FileErrCpc
+            pure Nothing
+
+        whenJust mbIgnoreModeState $ \ignoreModeState -> do
+          let setupNewCpcState = ssIgnoreCopyPasteCheck .= Just (Ignore ignoreModeState correctPos)
+          use ssIgnoreCopyPasteCheck >>= \case
+            Nothing -> setupNewCpcState
+            Just (Ignore curIgn prevPos)
+              | IMSLink _ <- curIgn -> do
+              lift $ tell $ makeError prevPos fp LinkErrCpc
+              setupNewCpcState
+              | IMSParagraph <- curIgn -> case ignoreModeState of
+                  IMSParagraph -> do
+                    lift . tell . makeError prevPos fp . ParagraphErrCpc $ prettyType nodeType
+                    setupNewCpcState
+                  -- It's OK to have link annotation when paragraph is ignored
+                  -- because in this case all links and all annotations are ignored.
+                  _ -> pass
+        pure defNode
+
       InvalidAnnotation msg -> do
         lift . tell $ makeError correctPos fp $ UnrecognisedErr msg
         pure defNode
@@ -312,8 +428,8 @@ processAnnotations fp = withIgnoreMode . cataNodeWithParentNodeInfo process
       in fromMaybe "" mType
 
     withIgnoreMode
-      :: ScannerM C.Node
-      -> Writer [ScanError] C.Node
+      :: ScannerM (Node info)
+      -> Writer [ScanError] (Node info)
     withIgnoreMode action = action `runStateT` initialScannerState >>= \case
       -- We expect `Ignore` state to be `Nothing` when we reach EOF,
       -- otherwise that means there was an annotation that didn't match
@@ -328,8 +444,8 @@ processAnnotations fp = withIgnoreMode . cataNodeWithParentNodeInfo process
       (node, _) -> pure node
 
 -- | Custom `foldMap` for source tree.
-foldNode :: (Monoid a, Monad m) => (C.Node -> m a) -> C.Node -> m a
-foldNode action node@(C.Node _ _ subs) = do
+foldNode :: (Monoid a, Monad m) => (Node info -> m a) -> Node info -> m a
+foldNode action node@(Node _ _ _ subs) = do
   a <- action node
   b <- concatForM subs (foldNode action)
   return (a <> b)
@@ -342,16 +458,16 @@ nodeExtractInfo
   -> C.Node
   -> ExtractorM FileInfo
 nodeExtractInfo fp (C.Node nPos nTy nSubs) = do
-  let (ignoreFile, contentNodes) = checkGlobalAnnotations nSubs
+  let (ignoreFile, ignoreCpcInFile, contentNodes) = checkGlobalAnnotations nSubs
   if ignoreFile
   then return def
-  else diffToFileInfo <$>
+  else diffToFileInfo (not ignoreCpcInFile) <$>
        (lift (processAnnotations fp $ C.Node nPos nTy contentNodes)
          >>= foldNode extractor)
 
   where
-    extractor :: C.Node -> ExtractorM FileInfoDiff
-    extractor node@(C.Node pos ty _) =
+    extractor :: NodeCPC -> ExtractorM FileInfoDiff
+    extractor node@(Node pos ty info _) =
       case ty of
         HTML_BLOCK _ -> do
           return mempty
@@ -401,15 +517,17 @@ nodeExtractInfo fp (C.Node nPos nTy nSubs) = do
                  t : ts -> (t, Just $ T.intercalate "#" ts)
                  []     -> error "impossible"
          return $ FileInfoDiff
-           (DList.singleton $ Reference {rName, rPos, rLink, rAnchor})
+           (DList.singleton $
+              Reference {rName, rPos, rLink, rAnchor, rCheckCopyPaste = cpcShouldCheck info})
            DList.empty
 
 -- | Check for global annotations, ignoring simple comments if there are any.
-checkGlobalAnnotations :: [C.Node] -> (Bool, [C.Node])
+checkGlobalAnnotations :: [C.Node] -> (Bool, Bool, [C.Node])
 checkGlobalAnnotations nodes = do
   let (headerNodes, contentsNodes) = span isHeaderNode nodes
       ignoreFile = any isIgnoreFile headerNodes
-  (ignoreFile, contentsNodes)
+      ignoreCpcInFile = any isIgnoreCpcWithinFile headerNodes
+  (ignoreFile, ignoreCpcInFile, contentsNodes)
   where
     isSimpleComment :: C.Node -> Bool
     isSimpleComment node = do
@@ -420,15 +538,20 @@ checkGlobalAnnotations nodes = do
     isIgnoreFile :: C.Node -> Bool
     isIgnoreFile = (Just (IgnoreAnnotation IMAll) ==) . getAnnotation
 
+    isIgnoreCpcWithinFile :: C.Node -> Bool
+    isIgnoreCpcWithinFile = (Just (IgnoreCopyPasteCheck IMAll) ==) . getAnnotation
+
     isHeaderNode :: C.Node -> Bool
     isHeaderNode node =
       any ($ node)
         [ isSimpleComment
         , isIgnoreFile
+        , isIgnoreCpcWithinFile
         ]
 
-defNode :: C.Node
-defNode = C.Node Nothing DOCUMENT [] -- hard-coded default Node
+-- | Hard-coded default Node
+defNode :: NodeCPC
+defNode = Node Nothing DOCUMENT (CopyPasteCheck False) []
 
 makeError
   :: Maybe PosInfo
@@ -473,6 +596,8 @@ textToMode :: Text -> Annotation
 textToMode annText = case wordsList of
   ("ignore" : [x])
     | Just ignMode <- getIgnoreMode x -> IgnoreAnnotation ignMode
+  ("no" : "duplication" : "check" : "in" : [x])
+    | Just ignMode <- getIgnoreMode x -> IgnoreCopyPasteCheck ignMode
   _ -> InvalidAnnotation annText
   where
     wordsList = words annText
@@ -482,6 +607,7 @@ getIgnoreMode = \case
   "link" -> Just IMLink
   "paragraph" -> Just IMParagraph
   "all" -> Just IMAll
+  "file" -> Just IMAll
   _ -> Nothing
 
 parseFileInfo :: MarkdownConfig -> FilePath -> LT.Text -> (FileInfo, [ScanError])

--- a/src/Xrefcheck/Verify.hs
+++ b/src/Xrefcheck/Verify.hs
@@ -409,7 +409,7 @@ verifyRepo
                                  -- user that we are scanning only files
                                  -- added to Git while gathering RepoInfo.
 
-      toCheckCopyPaste = map (second _fiReferences) filesToScan
+      toCheckCopyPaste = map (second _fiReferences) $ filter (_fiCopyPasteCheck . snd) filesToScan
       toScan = concatMap (\(file, fileInfo) -> map (file,) $ _fiReferences fileInfo) filesToScan
       copyPasteErrors = if scCopyPasteCheckEnabled cScanners
                         then [ res
@@ -460,7 +460,8 @@ checkCopyPaste file refs = do
   let getLinkAndAnchor x = (rLink x, rAnchor x)
       groupedRefs =
           L.groupBy ((==) `on` getLinkAndAnchor) $
-          sortBy (compare `on` getLinkAndAnchor) refs
+          sortBy (compare `on` getLinkAndAnchor) $
+          filter rCheckCopyPaste refs
   concatMap checkGroup groupedRefs
   where
     checkGroup :: [Reference] -> [CopyPasteCheckResult]

--- a/tests/Test/Xrefcheck/CopyPasteCheckSpec.hs
+++ b/tests/Test/Xrefcheck/CopyPasteCheckSpec.hs
@@ -26,12 +26,14 @@ test_copyPasteCheck = testGroup "Copypaste check"
           anchor = Just "heading"
           differentAnchor = Nothing
           defPos = Position Nothing
-          original1 = Reference "_-  First -  - File" link anchor defPos
-          original2 = Reference "_-  First - fi - le" link anchor defPos
-          notCopied = Reference " Link 2 " link differentAnchor defPos
-          copied1 = Reference " foo bar" link anchor defPos
-          copied2 = Reference " Baz quux" link anchor defPos
-          input = [original1, original2, notCopied, copied1, copied2]
+          original1 = Reference "_-  First -  - File" link anchor defPos True
+          original2 = Reference "_-  First - fi - le" link anchor defPos True
+          notCopied = Reference " Link 2 " link differentAnchor defPos True
+          copied1 = Reference " foo bar" link anchor defPos True
+          copied2 = Reference " Baz quux" link anchor defPos True
+          -- Do not report link with False
+          copied3 = Reference " Qib yse" link anchor defPos False
+          input = [original1, original2, notCopied, copied1, copied2, copied3]
           res = checkCopyPaste testPath input
           expectedRes =
           -- only first matching link is shown in the output
@@ -43,19 +45,30 @@ test_copyPasteCheck = testGroup "Copypaste check"
       let link = "./first-file"
           anchor = Just "heading"
           defPos = Position Nothing
-          original1 = Reference "_Foo bar" link anchor defPos
-          original2 = Reference " Baz quux" link anchor defPos
-          original3 = Reference " Foo qubarx" link anchor defPos
+          original1 = Reference "_Foo bar" link anchor defPos True
+          original2 = Reference " Baz quux" link anchor defPos True
+          original3 = Reference " Foo qubarx" link anchor defPos True
           input = [original1, original2, original3]
           res = checkCopyPaste testPath input
           expectedRes = []
       res @?= expectedRes
-  , testCase "Check external links" $ do
+  , testCase "Succeed if there is a link with a matching name but with check disabled" $ do
+      let link = "./first-file"
+          anchor = Just "heading"
+          defPos = Position Nothing
+          original1 = Reference "_-_first-fIlE-_-" link anchor defPos False
+          original2 = Reference " Baz quux" link anchor defPos True
+          original3 = Reference " Foo qubarx" link anchor defPos True
+          input = [original1, original2, original3]
+          res = checkCopyPaste testPath input
+          expectedRes = []
+      res @?= expectedRes
+  , testCase "Report external links" $ do
       let link = "https://github.com"
           anchor = Nothing
           defPos = Position Nothing
-          original = Reference "github" link anchor defPos
-          copied = Reference "gitlab" link anchor defPos
+          original = Reference "github" link anchor defPos True
+          copied = Reference "gitlab" link anchor defPos True
           input = [original, copied]
           res = checkCopyPaste testPath input
           expectedRes =

--- a/tests/Test/Xrefcheck/CopyPasteCheckSpec.hs
+++ b/tests/Test/Xrefcheck/CopyPasteCheckSpec.hs
@@ -1,0 +1,65 @@
+{- SPDX-FileCopyrightText: 2019 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -}
+
+module Test.Xrefcheck.CopyPasteCheckSpec where
+
+import Universum
+
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (Assertion, testCase, (@?=))
+
+import Xrefcheck.Core
+import Xrefcheck.Verify
+
+assertUnordered :: (Show a, Ord a) => [a] -> [a] -> Assertion
+assertUnordered = (@?=) `on` sort
+
+testPath :: FilePath
+testPath = "test-path"
+
+test_copyPasteCheck :: TestTree
+test_copyPasteCheck = testGroup "Copypaste check"
+  [ testCase "Detect copypaste error if there is a link with a matching name" $ do
+      let link = "./first-file"
+          anchor = Just "heading"
+          differentAnchor = Nothing
+          defPos = Position Nothing
+          original1 = Reference "_-  First -  - File" link anchor defPos
+          original2 = Reference "_-  First - fi - le" link anchor defPos
+          notCopied = Reference " Link 2 " link differentAnchor defPos
+          copied1 = Reference " foo bar" link anchor defPos
+          copied2 = Reference " Baz quux" link anchor defPos
+          input = [original1, original2, notCopied, copied1, copied2]
+          res = checkCopyPaste testPath input
+          expectedRes =
+          -- only first matching link is shown in the output
+            [ CopyPasteCheckResult testPath original1 copied1
+            , CopyPasteCheckResult testPath original1 copied2
+            ]
+      res `assertUnordered` expectedRes
+  , testCase "Succeed if there is not link with a matching name" $ do
+      let link = "./first-file"
+          anchor = Just "heading"
+          defPos = Position Nothing
+          original1 = Reference "_Foo bar" link anchor defPos
+          original2 = Reference " Baz quux" link anchor defPos
+          original3 = Reference " Foo qubarx" link anchor defPos
+          input = [original1, original2, original3]
+          res = checkCopyPaste testPath input
+          expectedRes = []
+      res @?= expectedRes
+  , testCase "Check external links" $ do
+      let link = "https://github.com"
+          anchor = Nothing
+          defPos = Position Nothing
+          original = Reference "github" link anchor defPos
+          copied = Reference "gitlab" link anchor defPos
+          input = [original, copied]
+          res = checkCopyPaste testPath input
+          expectedRes =
+            [ CopyPasteCheckResult testPath original copied
+            ]
+      res @?= expectedRes
+  ]

--- a/tests/Test/Xrefcheck/IgnoreAnnotationsSpec.hs
+++ b/tests/Test/Xrefcheck/IgnoreAnnotationsSpec.hs
@@ -18,7 +18,8 @@ import Xrefcheck.Scanners.Markdown
 
 test_ignoreAnnotations :: [TestTree]
 test_ignoreAnnotations =
-  [ testGroup "Parsing failures"
+  [ testGroup "Parsing failures" $
+    [ testGroup "Ignore annotations"
       [ testCase "Check if broken link annotation produce error" do
           let file = "tests/markdowns/with-annotations/no_link.md"
           errs <- getErrs file
@@ -31,35 +32,71 @@ test_ignoreAnnotations =
           let file = "tests/markdowns/with-annotations/unexpected_ignore_file.md"
           errs <- getErrs file
           errs @?= makeError (Just $ PosInfo 9 1 9 29) file FileErr
-      , testCase "Check if broken unrecognised annotation produce error" do
+      ]
+    , testGroup "Ignore copypaste check annotations"
+      [ testCase "Check if broken copypaste link annotation produce error" do
+          let file = "tests/markdowns/with-annotations/no_link_cpc.md"
+          errs <- getErrs file
+          errs @?= makeError (Just $ PosInfo 7 1 7 48) file LinkErrCpc
+      , testCase "Check if broken copypaste paragraph annotation produce error" do
+          let file = "tests/markdowns/with-annotations/no_paragraph_cpc.md"
+          errs <- getErrs file
+          errs @?= makeError (Just $ PosInfo 7 1 7 53) file (ParagraphErrCpc "HEADING")
+      , testCase "Check if broken copypaste ignore file annotation produce error" do
+          let file = "tests/markdowns/with-annotations/unexpected_ignore_file_cpc.md"
+          errs <- getErrs file
+          errs @?= makeError (Just $ PosInfo 9 1 9 47) file FileErrCpc
+      ]
+    , testCase "Check if broken unrecognised annotation produce error" do
           let file = "tests/markdowns/with-annotations/unrecognised_option.md"
           errs <- getErrs file
           errs @?= makeError (Just $ PosInfo 7 1 7 46) file (UnrecognisedErr "ignore unrecognised-option")
-      ]
-  , testGroup "\"ignore link\" mode"
-      [ testCase "Check \"ignore link\" performance" $ do
-          let file = "tests/markdowns/with-annotations/ignore_link.md"
-          (fi, errs) <- parse GitHub file
-          getRefs fi @?=
-            ["team", "team", "team", "hire-us", "how-we-work", "privacy", "link2", "link2", "link3"]
-          errs @?= makeError (Just $ PosInfo 42 1 42 31) file LinkErr
-      ]
-  , testGroup "\"ignore paragraph\" mode"
-      [ testCase "Check \"ignore paragraph\" performance" $ do
-         (fi, errs) <- parse GitHub "tests/markdowns/with-annotations/ignore_paragraph.md"
-         getRefs fi @?= ["blog", "contacts"]
-         errs @?= []
-      ]
-  , testGroup "\"ignore all\" mode"
-      [ testCase "Check \"ignore all\" performance" $ do
-        (fi, errs) <- parse GitHub "tests/markdowns/with-annotations/ignore_file.md"
-        getRefs fi @?= []
-        errs @?= []
-      ]
+    ]
+  , testGroup "Check ignore pragmas" $
+    [ testGroup "\"ignore link\" mode"
+        [ testCase "Check \"ignore link\" performance" $ do
+            let file = "tests/markdowns/with-annotations/ignore_link.md"
+            (fi, errs) <- parse GitHub file
+            getRefs fi @?=
+              ["team", "team", "team", "hire-us", "how-we-work", "privacy", "link2", "link2", "link3"]
+            errs @?= makeError (Just $ PosInfo 42 1 42 31) file LinkErr
+        ]
+    , testGroup "\"ignore paragraph\" mode"
+        [ testCase "Check \"ignore paragraph\" performance" $ do
+           (fi, errs) <- parse GitHub "tests/markdowns/with-annotations/ignore_paragraph.md"
+           getRefs fi @?= ["blog", "contacts"]
+           errs @?= []
+        ]
+    , testGroup "\"ignore all\" mode"
+        [ testCase "Check \"ignore all\" performance" $ do
+          (fi, errs) <- parse GitHub "tests/markdowns/with-annotations/ignore_file.md"
+          getRefs fi @?= []
+          errs @?= []
+        ]
+    ]
+  , testGroup "Check ignore copypaste check pragmas" $
+        [ testCase "Check ignore duplication check for link pragmas" $ do
+            let file = "tests/markdowns/with-annotations/ignore_link_cpc.md"
+            (fi, errs) <- parse GitHub file
+            getRefsWithCpc fi @?=
+              ["team", "team", "team", "hire-us", "how-we-work", "privacy", "link2", "link2", "link3"]
+            errs @?= makeError (Just $ PosInfo 42 1 42 48) file LinkErrCpc
+        , testCase "Check ignore copypaste check for paragraph pragmas" $ do
+           (fi, errs) <- parse GitHub "tests/markdowns/with-annotations/ignore_paragraph_cpc.md"
+           getRefsWithCpc fi @?= ["blog", "contacts"]
+           errs @?= []
+        , testCase "Check ignore copypaste check in file performance" $ do
+          (fi, errs) <- parse GitHub "tests/markdowns/with-annotations/ignore_file_cpc.md"
+          fi ^. fiCopyPasteCheck @?= False
+          errs @?= []
+        ]
   ]
   where
     getRefs :: FileInfo -> [Text]
     getRefs fi = map rName $ fi ^. fiReferences
+
+    getRefsWithCpc :: FileInfo -> [Text]
+    getRefsWithCpc fi = map rName $ filter rCheckCopyPaste $ fi ^. fiReferences
 
     getErrs :: FilePath -> IO [ScanError]
     getErrs path = snd <$> parse GitHub path

--- a/tests/Test/Xrefcheck/IgnoreAnnotationsSpec.hs
+++ b/tests/Test/Xrefcheck/IgnoreAnnotationsSpec.hs
@@ -34,7 +34,7 @@ test_ignoreAnnotations =
       , testCase "Check if broken unrecognised annotation produce error" do
           let file = "tests/markdowns/with-annotations/unrecognised_option.md"
           errs <- getErrs file
-          errs @?= makeError (Just $ PosInfo 7 1 7 46) file (UnrecognisedErr "unrecognised-option")
+          errs @?= makeError (Just $ PosInfo 7 1 7 46) file (UnrecognisedErr "ignore unrecognised-option")
       ]
   , testGroup "\"ignore link\" mode"
       [ testCase "Check \"ignore link\" performance" $ do

--- a/tests/Test/Xrefcheck/IgnoreRegexSpec.hs
+++ b/tests/Test/Xrefcheck/IgnoreRegexSpec.hs
@@ -44,7 +44,7 @@ test_ignoreRegex = give WithoutColors $
       verifyRes <- allowRewrite showProgressBar $ \rw ->
         verifyRepo rw config verifyMode root $ srRepoInfo scanResult
 
-      let brokenLinks = pickBrokenLinks verifyRes
+      let brokenLinks = pickBrokenLinks $ fst verifyRes
 
       let matchedLinks =
             [ "https://bad.referenc/"

--- a/tests/Test/Xrefcheck/TooManyRequestsSpec.hs
+++ b/tests/Test/Xrefcheck/TooManyRequestsSpec.hs
@@ -63,7 +63,7 @@ test_tooManyRequests = testGroup "429 response tests"
                   }
               }
         _ <- verifyReferenceWithProgress
-          (Reference "" "http://127.0.0.1:5000/429" Nothing (Position Nothing))
+          (Reference "" "http://127.0.0.1:5000/429" Nothing (Position Nothing) False)
           progressRef
         Progress{..} <- vrExternal <$> readIORef progressRef
         let ttc = ttTimeToCompletion <$> pTaskTimestamp
@@ -88,7 +88,7 @@ test_tooManyRequests = testGroup "429 response tests"
                   }
               }
         _ <- verifyReferenceWithProgress
-          (Reference "" "http://127.0.0.1:5000/429" Nothing (Position Nothing))
+          (Reference "" "http://127.0.0.1:5000/429" Nothing (Position Nothing) False)
           progressRef
         Progress{..} <- vrExternal <$> readIORef progressRef
         let ttc = fromMaybe (sec 0) $ ttTimeToCompletion <$> pTaskTimestamp
@@ -114,7 +114,7 @@ test_tooManyRequests = testGroup "429 response tests"
                   }
               }
         _ <- verifyReferenceWithProgress
-          (Reference "" "http://127.0.0.1:5000/429" Nothing (Position Nothing))
+          (Reference "" "http://127.0.0.1:5000/429" Nothing (Position Nothing) False)
           progressRef
         Progress{..} <- vrExternal <$> readIORef progressRef
         let ttc = ttTimeToCompletion <$> pTaskTimestamp

--- a/tests/Test/Xrefcheck/UtilRequests.hs
+++ b/tests/Test/Xrefcheck/UtilRequests.hs
@@ -62,7 +62,7 @@ checkLinkAndProgressWithServer mock link progress vrExpectation =
 
 verifyLink :: Text -> IO (VerifyResult VerifyError, Progress Int)
 verifyLink link = do
-  let reference = Reference "" link Nothing (Position Nothing)
+  let reference = Reference "" link Nothing (Position Nothing) False
   progRef <- newIORef $ initVerifyProgress [reference]
   result <- verifyReferenceWithProgress reference progRef
   p <- readIORef progRef

--- a/tests/configs/github-config.yaml
+++ b/tests/configs/github-config.yaml
@@ -56,3 +56,6 @@ scanners:
     #
     # This affects which anchors are generated for headers.
     flavor: GitHub
+
+  # Whether copy-paste check is enabled globally.
+  copyPasteCheckEnabled: True

--- a/tests/golden/check-copy-paste/check-copy-paste.bats
+++ b/tests/golden/check-copy-paste/check-copy-paste.bats
@@ -1,0 +1,17 @@
+#!/usr/bin/env bats
+
+# SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+load '../helpers/bats-support/load'
+load '../helpers/bats-assert/load'
+load '../helpers/bats-file/load'
+load '../helpers'
+
+
+@test "Check possible copy-paste errors and copy-paste annotations " {
+  to_temp xrefcheck
+
+  assert_diff expected.gold
+}

--- a/tests/golden/check-copy-paste/expected.gold
+++ b/tests/golden/check-copy-paste/expected.gold
@@ -1,0 +1,48 @@
+=== Possible copy/paste errors ===
+
+  ➥  In file second-file.md
+     reference (relative) at src:13:1-29:
+       - text: "Lol Kek"
+       - link: ./first-file.md
+       - anchor: -
+     is possibly a bad copy paste of
+     reference (relative) at src:7:1-34:
+       - text: "First   file"
+       - link: ./first-file.md
+       - anchor: -
+
+  ➥  In file second-file.md
+     reference (relative) at src:14:1-30:
+       - text: "Baz quux"
+       - link: ./first-file.md
+       - anchor: -
+     is possibly a bad copy paste of
+     reference (relative) at src:7:1-34:
+       - text: "First   file"
+       - link: ./first-file.md
+       - anchor: -
+
+  ➥  In file second-file.md
+     reference (relative) at src:24:1-29:
+       - text: "fdw"
+       - link: ./first-file.md
+       - anchor: chor
+     is possibly a bad copy paste of
+     reference (relative) at src:23:1-32:
+       - text: "ff-cho"
+       - link: ./first-file.md
+       - anchor: chor
+
+  ➥  In file second-file.md
+     reference (external) at src:29:1-28:
+       - text: "gitlab"
+       - link: https://github.com
+       - anchor: -
+     is possibly a bad copy paste of
+     reference (external) at src:28:1-28:
+       - text: "github"
+       - link: https://github.com
+       - anchor: -
+
+Possible copy/paste errors dumped, 4 in total.
+All repository links are valid.

--- a/tests/golden/check-copy-paste/expected.gold
+++ b/tests/golden/check-copy-paste/expected.gold
@@ -1,48 +1,111 @@
+<<<<<<< HEAD
 === Possible copy/paste errors ===
 
   ➥  In file second-file.md
      reference (relative) at src:13:1-29:
+=======
+=== Scan errors found ===
+
+  ➥  In file second-file.md
+     scan error at src:35:1-25:
+
+     Unrecognised option "no dh", perhaps you meant
+     <"ignore link"|"ignore paragraph"|"ignore all">
+     or "no duplication check in <link|paragraph|file>"?
+
+  ➥  In file second-file.md
+     scan error at src:40:1-53:
+
+     Expected a PARAGRAPH after "no duplication check in paragraph" annotation, but found HEADING
+
+  ➥  In file second-file.md
+     scan error at src:46:1-48:
+
+     Expected a LINK after "no duplication check in link" annotation
+
+  ➥  In file second-file.md
+     scan error at src:51:1-48:
+
+     Annotation "no duplication check in file" must be at the top of markdown or right after comments at the top
+
+Scan errors dumped, 4 in total.
+=== Possible copy/paste errors ===
+
+  ➥  In file second-file.md
+     reference (relative) at src:20:1-29:
+>>>>>>> 26d87b9... [#64] Implement copy/paste protection checks
        - text: "Lol Kek"
        - link: ./first-file.md
        - anchor: -
      is possibly a bad copy paste of
+<<<<<<< HEAD
      reference (relative) at src:7:1-34:
+=======
+     reference (relative) at src:10:1-34:
+>>>>>>> 26d87b9... [#64] Implement copy/paste protection checks
        - text: "First   file"
        - link: ./first-file.md
        - anchor: -
 
   ➥  In file second-file.md
+<<<<<<< HEAD
      reference (relative) at src:14:1-30:
+=======
+     reference (relative) at src:21:1-30:
+>>>>>>> 26d87b9... [#64] Implement copy/paste protection checks
        - text: "Baz quux"
        - link: ./first-file.md
        - anchor: -
      is possibly a bad copy paste of
+<<<<<<< HEAD
      reference (relative) at src:7:1-34:
+=======
+     reference (relative) at src:10:1-34:
+>>>>>>> 26d87b9... [#64] Implement copy/paste protection checks
        - text: "First   file"
        - link: ./first-file.md
        - anchor: -
 
   ➥  In file second-file.md
+<<<<<<< HEAD
      reference (relative) at src:24:1-29:
+=======
+     reference (relative) at src:31:1-29:
+>>>>>>> 26d87b9... [#64] Implement copy/paste protection checks
        - text: "fdw"
        - link: ./first-file.md
        - anchor: chor
      is possibly a bad copy paste of
+<<<<<<< HEAD
      reference (relative) at src:23:1-32:
+=======
+     reference (relative) at src:30:1-32:
+>>>>>>> 26d87b9... [#64] Implement copy/paste protection checks
        - text: "ff-cho"
        - link: ./first-file.md
        - anchor: chor
 
   ➥  In file second-file.md
+<<<<<<< HEAD
      reference (external) at src:29:1-28:
+=======
+     reference (external) at src:70:1-28:
+>>>>>>> 26d87b9... [#64] Implement copy/paste protection checks
        - text: "gitlab"
        - link: https://github.com
        - anchor: -
      is possibly a bad copy paste of
+<<<<<<< HEAD
      reference (external) at src:28:1-28:
+=======
+     reference (external) at src:69:1-28:
+>>>>>>> 26d87b9... [#64] Implement copy/paste protection checks
        - text: "github"
        - link: https://github.com
        - anchor: -
 
 Possible copy/paste errors dumped, 4 in total.
+<<<<<<< HEAD
 All repository links are valid.
+=======
+>>>>>>> 26d87b9... [#64] Implement copy/paste protection checks

--- a/tests/golden/check-copy-paste/first-file.md
+++ b/tests/golden/check-copy-paste/first-file.md
@@ -1,0 +1,11 @@
+<!--
+ - SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -->
+
+# heading
+
+# anch
+
+# chor

--- a/tests/golden/check-copy-paste/first-file.md
+++ b/tests/golden/check-copy-paste/first-file.md
@@ -4,6 +4,13 @@
  - SPDX-License-Identifier: MPL-2.0
  -->
 
+<!-- xrefcheck: no duplication check in file -->
+
+<!-- These links are not checked for copypaste
+     because thes checks are disabled in this file -->
+[  Second - ---file-  ](./second-file.md)
+[   Link 2](./second-file.md)
+
 # heading
 
 # anch

--- a/tests/golden/check-copy-paste/second-file.md
+++ b/tests/golden/check-copy-paste/second-file.md
@@ -4,7 +4,14 @@
  - SPDX-License-Identifier: MPL-2.0
  -->
 
+<!-- this file should throw 4 scan errors and
+     report 4 possible copypastes (3 local and 1 external) -->
+
 [ First   file  ](./first-file.md)
+
+<!-- This link is not checked for copypaste -->
+<!-- xrefcheck: no duplication check in link -->
+[   Link 2](./first-file.md)
 
 <!-- This one is not reported because anchor is not the same -->
 [   Link 3](./first-file.md#heading)
@@ -24,6 +31,45 @@
 [  fdw](./first-file.md#chor)
 
 
+<!-- emit error: unrecognized annotation -->
+<!-- xrefcheck: no dh -->
+
+<!-- this emits an error because of expected -->
+<!-- paragraph after the annotation -->
+
+<!-- xrefcheck: no duplication check in paragraph -->
+
+# asd
+
+<!-- this emits an error because of expected -->
+<!-- link after the annotation               -->
+<!-- xrefcheck: no duplication check in link -->
+
+# asd
+
+<!-- this emits an error -->
+<!-- xrefcheck: no duplication check in file -->
+
+<!-- Some different pragmas within one link are OK -->
+<!-- xrefcheck: ignore link -->
+<!-- xrefcheck: no duplication check in link -->
+[   Link 3](./first-file.md)
+
+<!-- Some different pragmas within one paragraph are OK -->
+<!-- xrefcheck: no duplication check in paragraph -->
+<!-- xrefcheck: ignore paragraph -->
+hello, how are you, bye
+
+<!-- this paragraph is totally ignored and hence not checked -->
+<!-- xrefcheck: ignore paragraph -->
+[github](https://github.com)
+[gitlab](https://github.com)
+
 <!-- check external links -->
+[github](https://github.com)
+[gitlab](https://github.com)
+
+<!-- here links are verified, but not checked for copypaste -->
+<!-- xrefcheck: no duplication check in paragraph -->
 [github](https://github.com)
 [gitlab](https://github.com)

--- a/tests/golden/check-copy-paste/second-file.md
+++ b/tests/golden/check-copy-paste/second-file.md
@@ -1,0 +1,29 @@
+<!--
+ - SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -->
+
+[ First   file  ](./first-file.md)
+
+<!-- This one is not reported because anchor is not the same -->
+[   Link 3](./first-file.md#heading)
+
+<!-- And these ones are checked and reported -->
+[   Lol Kek](./first-file.md)
+[   Baz quux](./first-file.md)
+
+<!-- These ones are not reported because none of link -->
+<!-- names is a subsequence of a link                 -->
+[  asd](./first-file.md#anch)
+[  fdw](./first-file.md#anch)
+
+<!-- These ones are reported because -->
+<!-- ff-cho is a subsequence of link+anchor -->
+[  ff-cho](./first-file.md#chor)
+[  fdw](./first-file.md#chor)
+
+
+<!-- check external links -->
+[github](https://github.com)
+[gitlab](https://github.com)

--- a/tests/golden/check-scan-errors/expected.gold
+++ b/tests/golden/check-scan-errors/expected.gold
@@ -18,7 +18,7 @@
   ➥  In file check-scan-errors.md
      scan error at src:21:1-50:
 
-     Unrecognised option "unrecognised-annotation" perhaps you meant <"ignore link"|"ignore paragraph"|"ignore all">
+     Unrecognised option "ignore unrecognised-annotation" perhaps you meant <"ignore link"|"ignore paragraph"|"ignore all">
 
   ➥  In file check-second-file.md
      scan error at src:9:1-29:

--- a/tests/golden/check-scan-errors/expected.gold
+++ b/tests/golden/check-scan-errors/expected.gold
@@ -18,7 +18,9 @@
   ➥  In file check-scan-errors.md
      scan error at src:21:1-50:
 
-     Unrecognised option "ignore unrecognised-annotation" perhaps you meant <"ignore link"|"ignore paragraph"|"ignore all">
+     Unrecognised option "ignore unrecognised-annotation", perhaps you meant
+     <"ignore link"|"ignore paragraph"|"ignore all">
+     or "no duplication check in <link|paragraph|file>"?
 
   ➥  In file check-second-file.md
      scan error at src:9:1-29:

--- a/tests/markdowns/with-annotations/ignore_file_cpc.md
+++ b/tests/markdowns/with-annotations/ignore_file_cpc.md
@@ -1,0 +1,19 @@
+<!--
+ - SPDX-FileCopyrightText: 2018-2019 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -->
+
+ <!-- a comment -->
+ <!-- another comment -->
+
+<!-- xrefcheck: no duplication check in all -->
+
+Serokell [web-site](https://serokell.io/)
+Serokell [team](https://serokell.io/team)
+
+Serokell [blog](https://serokell.io/blog)
+
+Serokell [labs](https://serokell.io/labs)
+
+Serokell [contacts](https://serokell.io/contacts)

--- a/tests/markdowns/with-annotations/ignore_link_cpc.md
+++ b/tests/markdowns/with-annotations/ignore_link_cpc.md
@@ -1,0 +1,49 @@
+<!--
+ - SPDX-FileCopyrightText: 2018-2019 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -->
+
+### Do not check the first link in the paragraph
+
+<!-- xrefcheck: no duplication check in link-->
+Serokell [web-site](https://serokell.io/)
+Serokell [team](https://serokell.io/team)
+
+<!-- xrefcheck: no duplication check in link-->
+
+Serokell [blog](https://serokell.io/blog)
+
+Serokell <!-- xrefcheck: no duplication check in link --> [labs](https://serokell.io/labs)
+
+Serokell <!-- xrefcheck: no duplication check in link -->
+[contacts](https://serokell.io/contacts) and again
+[team](https://serokell.io/team)
+
+### Do not check not the first link in the paragraph
+
+[team](https://serokell.io/team) again and <!-- xrefcheck: no duplication check in link --> [projects](https://serokell.io/projects)
+
+Also [hire-us](https://serokell.io/hire-us) and <!--xrefcheck: no duplication check in link -->
+[fintech](https://serokell.io/fintech-development)
+development
+
+Here are [how-we-work](https://serokell.io/how-we-work) and [privacy](https://serokell.io/privacy)
+and <!-- xrefcheck: no duplication check in link -->     [ml consulting](https://serokell.io/machine-learning-consulting)
+
+<!-- xrefcheck: no duplication check in link -->
+Do not check link bug _regression test_ [link1](link1) [link2](link2)
+
+<!-- xrefcheck: no duplication check in link -->
+Another no duplication check in link bug _some [link1](link1) emphasis_ [link2](link2)
+
+### Do not check pragma should be followed by
+
+<!-- xrefcheck: no duplication check in link -->
+
+This annotation expects link in paragraph right after it.
+
+So [link3](link3) is not checked for copypaste.
+
+Annotation inside paragraph <!-- xrefcheck: no duplication check in link --> allows
+softbreaks and __other *things*__ in paragraph, so [link4](link4) is checked for copypaste.

--- a/tests/markdowns/with-annotations/ignore_paragraph_cpc.md
+++ b/tests/markdowns/with-annotations/ignore_paragraph_cpc.md
@@ -1,0 +1,16 @@
+<!--
+ - SPDX-FileCopyrightText: 2018-2019 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -->
+
+<!-- xrefcheck:no duplication check in paragraph -->
+Serokell [web-site](https://serokell.io/)
+Serokell [team](https://serokell.io/team)
+
+Serokell [blog](https://serokell.io/blog)
+
+<!-- xrefcheck: no duplication check in paragraph -->
+Serokell [labs](https://serokell.io/labs)
+
+Serokell [contacts](https://serokell.io/contacts)

--- a/tests/markdowns/with-annotations/no_link_cpc.md
+++ b/tests/markdowns/with-annotations/no_link_cpc.md
@@ -1,0 +1,8 @@
+<!--
+ - SPDX-FileCopyrightText: 2018-2019 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -->
+
+<!-- xrefcheck: no duplication check in link -->
+not a link

--- a/tests/markdowns/with-annotations/no_paragraph_cpc.md
+++ b/tests/markdowns/with-annotations/no_paragraph_cpc.md
@@ -1,0 +1,9 @@
+<!--
+ - SPDX-FileCopyrightText: 2018-2019 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -->
+
+<!-- xrefcheck: no duplication check in paragraph -->
+
+# not a paragraph

--- a/tests/markdowns/with-annotations/unexpected_ignore_file_cpc.md
+++ b/tests/markdowns/with-annotations/unexpected_ignore_file_cpc.md
@@ -1,0 +1,11 @@
+<!--
+ - SPDX-FileCopyrightText: 2018-2019 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -->
+
+the first paragraph
+
+<!--xrefcheck: no duplication check in file -->
+
+the second paragraph


### PR DESCRIPTION
## Description
    
Problem: Currently xrefcheck is able to detect possibly bad
copy-pastes, but there is no way to disable those checks
locally for a file/paragraph/link.
    
Solution: Add support for related annotations for `.md` files.


## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #1 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Fixes #64 

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](https://github.com/serokell/xrefcheck/tree/master/README.md)
    - Haddock

- Public contracts
  - [ ] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [ ] I added an entry to the [changelog](https://github.com/serokell/xrefcheck/tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [ ] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [ ] My code complies with the [style guide](https://github.com/serokell/style/blob/master/haskell.md).

#### ✓ Release Checklist

- [ ] I updated the version number in `package.yaml`.
- [ ] I updated the [changelog](https://github.com/serokell/xrefcheck/tree/master/CHANGES.md) and moved everything
      under the "Unreleased" section to a new section for this release version.
- [ ] (After merging) I edited the [auto-release](https://github.com/serokell/xrefcheck/releases/tag/auto-release).
    * Change the tag and title using the format `vX.Y.Z`.
    * Write a summary of all user-facing changes.
    * Deselect the "This is a pre-release" checkbox at the bottom.
- [ ] (After merging) I updated [`xrefcheck-action`](https://github.com/serokell/xrefcheck-action#updating-supported-versions).
- [ ] (After merging) I uploaded the package to [hackage](https://hackage.haskell.org/package/xrefcheck).
