### PR TITLE
[#25] Redirect links with configuration rules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,8 +9,8 @@ Unreleased
 
 * [#176](https://github.com/serokell/xrefcheck/pull/176)
   + Enabled `autolink` extension for `cmark-gfm`, so now we're finding strings
-  like `www.google.com` or `https://google.com`, treating them as links
-  and checking.
+    like `www.google.com` or `https://google.com`, treating them as links
+    and checking.
 * [#175](https://github.com/serokell/xrefcheck/pull/175)
   + Reorganize top-level config keys.
 * [#178](https://github.com/serokell/xrefcheck/pull/178)
@@ -19,13 +19,13 @@ Unreleased
   + Add support for image links.
 * [#199](https://github.com/serokell/xrefcheck/pull/199)
   + Now annotation
-  `<!-- xrefcheck: ignore all -->` instead of `<!-- xrefcheck: ignore file -->`
-  should be used to disable checking for links in file, so it's clearer that
-  file itself is not ignored (and links can target it).
+    `<!-- xrefcheck: ignore all -->` instead of `<!-- xrefcheck: ignore file -->`
+    should be used to disable checking for links in file, so it's clearer that
+    file itself is not ignored (and links can target it).
 * [#215](https://github.com/serokell/xrefcheck/pull/215)
   + Now we notify user when there are scannable files that were not added to Git
-  yet. Also added CLI option `--include-untracked` to scan such files and treat
-  as existing.
+    yet. Also added CLI option `--include-untracked` to scan such files and treat
+    as existing.
 * [#191](https://github.com/serokell/xrefcheck/pull/191)
   + Now we consider slash `/` (and only it) as path separator in local links for all OS,
     so xrefcheck's report is OS-independent
@@ -40,10 +40,14 @@ Unreleased
     redirect responses (i.e. 301 and 308) and passes for temporary ones (i.e. 302, 303, 307).
 * [#231](https://github.com/serokell/xrefcheck/pull/231)
   + Anchor analysis takes now into account the appropriate case-sensitivity depending on
-  the configured Markdown flavour.
+    the configured Markdown flavour.
 * [#254](https://github.com/serokell/xrefcheck/pull/254)
   + Now the `dump-config` command does not overwrite a file unless explicitly told with a
     `--force` flag. Also, a `--stdout` flag allows to print the config to stdout instead.
+    the configured Markdown flavour.
+* [#250](https://github.com/serokell/xrefcheck/pull/250)
+  + Now the redirect behavior for external references can be modified via rules in the
+    configuration file with the `externalRefRedirects` parameter.
 
 0.2.2
 ==========
@@ -95,7 +99,7 @@ Unreleased
   + Make possible to specify whether ignore localhost links, use
   `check-localhost` CLA argument (by default localhost links will not be checked).
   + Make possible to ignore auth failures (assume 'protected' links
-  valid), use `ignoreAuthFailures` parameter of config.
+    valid), use `ignoreAuthFailures` parameter of config.
 * [#66](https://github.com/serokell/xrefcheck/pull/66)
   + Added support for ftp links.
 * [#74](https://github.com/serokell/xrefcheck/pull/83)
@@ -144,10 +148,10 @@ Unreleased
   + Switch to lts-17.3.
 * [#53](https://github.com/serokell/xrefcheck/pull/53)
   + Make possible to include a regular expression in
-  `ignoreRefs` parameter of config to ignore external
-  references.
+    `ignoreRefs` parameter of config to ignore external
+    references.
   + Add support of right in-place ignoring annotations
-  such as `ignore file`, `ignore paragraph` and `ignore link`.
+    such as `ignore file`, `ignore paragraph` and `ignore link`.
 
 0.1.2
 =======

--- a/README.md
+++ b/README.md
@@ -162,8 +162,8 @@ There are several ways to fix this:
         - to: "https?://forbidden.com.*"
           on: 307
           outcome: invalid
-        - from: "^http://.*"
-          to: "^https://.*"
+        - from: "http://.*"
+          to: "https://.*"
           outcome: follow
       ```
 

--- a/README.md
+++ b/README.md
@@ -141,8 +141,36 @@ There are several ways to fix this:
     * This behavior can be disabled by setting `ignoreAuthFailures: false` in the config file.
 
 1. How does `xrefcheck` handle redirects?
-    * Permanent redirects (i.e. 301 and 308) are reported as errors.
-    * Temporary redirects (i.e. 302, 303 and 307) are assumed to be valid.
+    * The rules from the default configuration are as follows:
+      * Permanent redirects (i.e. 301 and 308) are reported as errors.
+      * Temporary redirects (i.e. 302, 303 and 307) are assumed to be valid.
+    * Redirect rules can be specified with the `externalRefRedirects` parameter within `networking`, which accepts an array of
+      rules with keys `from`, `to`, `on` and `outcome`. The rule applied is the first one that matches with
+      the `from`, `to` and `on` fields, if any, where
+      * `from` is a regular expression, as in `ignoreExternalRefsTo`, for the source link in a single redirection step. Its absence means that
+        every link matches.
+      * `to` is a regular expression for the target link in a single redirection step. Its absence also means that every link matches.
+      * `on` accepts `temporary`, `permanent` or a specific redirect HTTP code. Its absence also means that
+        every response code matches.
+      * The `outcome` parameter accepts `valid`, `invalid` or `follow`. The last one follows the redirect by applying the
+        same configuration rules.
+
+      For example, this configuration forbids 307 redirects to a specific domain and makes redirections from HTTP to HTTPS to be followed:
+
+      ```
+      externalRefRedirects:
+        - to: "https?://forbidden.com.*"
+          on: 307
+          outcome: invalid
+        - from: "^http://.*"
+          to: "^https://.*"
+          outcome: follow
+      ```
+
+      The first one applies if both of them match.
+
+    * The number of redirects allowed in a single redirect chain is limited and can be configured with the
+      `maxRedirectFollows` parameter, also within `networking`. A number smaller than 0 disables the limit.
 
 1. How does `xrefcheck` handle localhost links?
     * By default, `xrefcheck` will ignore links to localhost.

--- a/ftp-tests/Test/Xrefcheck/FtpLinks.hs
+++ b/ftp-tests/Test/Xrefcheck/FtpLinks.hs
@@ -15,7 +15,7 @@ import Test.Tasty (TestTree, askOption, testGroup)
 import Test.Tasty.HUnit (assertBool, assertFailure, testCase, (@?=))
 import Test.Tasty.Options as Tasty (IsOption (..), OptionDescription (Option), safeRead)
 
-import Xrefcheck.Config (Config, cExclusionsL, defConfig)
+import Xrefcheck.Config
 import Xrefcheck.Core (Flavor (GitHub))
 import Xrefcheck.Scan (ecIgnoreExternalRefsToL)
 import Xrefcheck.Verify (VerifyError (..), checkExternalResource)
@@ -48,27 +48,27 @@ test_FtpLinks = askOption $ \(FtpHostOpt host) -> do
   testGroup "Ftp links handler"
     [ testCase "handles correct link to file" $ do
         let link = host <> "/pub/file_exists.txt"
-        result <- runExceptT $ checkExternalResource config link
+        result <- runExceptT $ checkExternalResource emptyChain config link
         result @?= Right ()
 
     , testCase "handles empty link (host only)" $ do
         let link = host
-        result <- runExceptT $ checkExternalResource config link
+        result <- runExceptT $ checkExternalResource emptyChain config link
         result @?= Right ()
 
     , testCase "handles correct link to non empty directory" $ do
         let link = host <> "/pub/"
-        result <- runExceptT $ checkExternalResource config link
+        result <- runExceptT $ checkExternalResource emptyChain config link
         result @?= Right ()
 
     , testCase "handles correct link to empty directory" $ do
         let link = host <> "/empty/"
-        result <- runExceptT $ checkExternalResource config link
+        result <- runExceptT $ checkExternalResource emptyChain config link
         result @?= Right ()
 
     , testCase "throws exception when file not found" $ do
         let link = host <> "/pub/file_does_not_exists.txt"
-        result <- runExceptT $ checkExternalResource config link
+        result <- runExceptT $ checkExternalResource emptyChain config link
         case result of
           Right () ->
             assertFailure "No exception was raised, FtpEntryDoesNotExist expected"

--- a/src/Xrefcheck/Config/Default.hs
+++ b/src/Xrefcheck/Config/Default.hs
@@ -37,7 +37,7 @@ exclusions:
   # List of POSIX extended regular expressions.
   ignoreExternalRefsTo:
     # Ignore localhost links by default
-    - ^(https?|ftps?)://(localhost|127\\.0\\.0\\.1).*
+    - (https?|ftps?)://(localhost|127\\.0\\.0\\.1).*
 
 # Networking parameters.
 networking:

--- a/src/Xrefcheck/Data/Redirect.hs
+++ b/src/Xrefcheck/Data/Redirect.hs
@@ -1,0 +1,170 @@
+{- SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Xrefcheck.Data.Redirect
+  ( RedirectChain
+  , RedirectChainLink (..)
+  , emptyChain
+  , pushRequest
+  , hasRequest
+  , totalFollowed
+
+  , RedirectRule (..)
+  , RedirectRuleOn (..)
+  , RedirectRuleOutcome (..)
+  , redirectRule
+
+  , isPermanentRedirectCode
+  , isRedirectCode
+  , isTemporaryRedirectCode
+  ) where
+
+import Universum
+
+import Data.Aeson (genericParseJSON)
+import Data.Yaml (FromJSON (..), withText)
+import Fmt (Buildable (..))
+import Text.Regex.TDFA.Text (Regex)
+
+import Data.Sequence ((|>))
+import Xrefcheck.Scan ()
+import Xrefcheck.Util
+
+-- | A custom redirect rule.
+data RedirectRule = RedirectRule
+  { rrFrom :: Maybe Regex
+    -- ^ Redirect source links that match to apply the rule.
+    --
+    -- 'Nothing' matches any link.
+  , rrTo :: Maybe Regex
+    -- ^ Redirect target links that match to apply the rule.
+    --
+    -- 'Nothing' matches any link.
+  , rrOn :: Maybe RedirectRuleOn
+    -- ^ HTTP code selector to apply the rule.
+    --
+    -- 'Nothing' matches any code.
+  , rrOutcome :: RedirectRuleOutcome
+    -- ^ What to do when an HTTP response matches the rule.
+  } deriving stock (Generic)
+
+-- | Rule selector depending on the response HTTP code.
+data RedirectRuleOn
+    = RROCode Int
+      -- ^ An exact HTTP code
+    | RROPermanent
+      -- ^ Any HTTP code considered as permanent according to 'isPermanentRedirectCode'
+    | RROTemporary
+      -- ^ Any HTTP code considered as permanent according to 'isTemporaryRedirectCode'
+    deriving stock (Show, Eq)
+
+-- | What to do when receiving a redirect HTTP response.
+data RedirectRuleOutcome
+    = RROValid
+      -- ^ Consider it as valid
+    | RROInvalid
+      -- ^ Consider it as invalid
+    | RROFollow
+      -- ^ Try again by following the redirect
+    deriving stock (Show, Eq)
+
+-- | Links in a redirection chain.
+newtype RedirectChain = RedirectChain
+  { unRedirectChain :: Seq RedirectChainLink
+  } deriving newtype (Show, Eq)
+
+-- | A single link in a redirection chain.
+newtype RedirectChainLink = RedirectChainLink
+  { unRedirectChainLink :: Text
+  } deriving newtype (Show, Eq)
+
+instance FromList RedirectChain where
+  type ListElement RedirectChain = Text
+  fromList = RedirectChain . fromList . fmap RedirectChainLink
+
+emptyChain :: RedirectChain
+emptyChain = RedirectChain mempty
+
+pushRequest :: RedirectChain -> RedirectChainLink -> RedirectChain
+pushRequest (RedirectChain chain) = RedirectChain . (chain |>)
+
+hasRequest :: RedirectChain -> RedirectChainLink -> Bool
+hasRequest (RedirectChain chain) = (`elem` chain)
+
+totalFollowed :: RedirectChain -> Int
+totalFollowed = length . unRedirectChain
+
+instance Buildable RedirectChain where
+  build (RedirectChain linksStack) = build chainText
+    where
+      link (True, RedirectChainLink l) = "-| " <> l
+      link (False, RedirectChainLink l) = "-> " <> l
+
+      chainText = mconcat
+        $ intersperse "\n"
+        $ fmap link
+        $ zip (True : repeat False)
+        $ toList linksStack
+
+-- | Redirect rule to apply to a link when it has been responded with a given
+-- HTTP code.
+redirectRule :: Text -> Text -> Int -> [RedirectRule] -> Maybe RedirectRule
+redirectRule source target code rules =
+  find (matchRule source target code) rules
+
+-- | Check if a 'RedirectRule' matches a given link and HTTP code.
+matchRule :: Text -> Text -> Int -> RedirectRule -> Bool
+matchRule source target code RedirectRule{..} = and
+  [ matchCode
+  , matchLink source rrFrom
+  , matchLink target rrTo
+  ]
+  where
+    matchCode = case rrOn of
+      Nothing -> True
+      Just RROPermanent -> isPermanentRedirectCode code
+      Just RROTemporary -> isTemporaryRedirectCode code
+      Just (RROCode other) -> code == other
+
+    matchLink link = \case
+      Nothing -> True
+      Just regex -> doesMatchAnyRegex link [regex]
+
+isRedirectCode :: Int -> Bool
+isRedirectCode code = code >= 300 && code < 400
+
+isTemporaryRedirectCode :: Int -> Bool
+isTemporaryRedirectCode = flip elem [302, 303, 307]
+
+isPermanentRedirectCode :: Int -> Bool
+isPermanentRedirectCode = flip elem [301, 308]
+
+instance FromJSON (RedirectRule) where
+  parseJSON = genericParseJSON aesonConfigOption
+
+instance FromJSON (RedirectRuleOutcome) where
+  parseJSON = withText "Redirect rule outcome" $
+    \case
+      "valid" -> pure RROValid
+      "invalid" -> pure RROInvalid
+      "follow" -> pure RROFollow
+      _ -> fail "expected (valid|invalid|follow)"
+
+instance FromJSON (RedirectRuleOn) where
+  parseJSON v = code v
+    <|> text v
+    <|> fail "expected a redirect (3XX) HTTP code or (permanent|temporary)"
+    where
+      code cv = do
+        i <- parseJSON cv
+        guard $ isRedirectCode i
+        pure $ RROCode i
+      text = withText "Redirect rule on" $
+        \case
+          "permanent" -> pure RROPermanent
+          "temporary" -> pure RROTemporary
+          _ -> mzero

--- a/src/Xrefcheck/Scan.hs
+++ b/src/Xrefcheck/Scan.hs
@@ -23,6 +23,8 @@ module Xrefcheck.Scan
   , mkGatherScanError
   , scanRepo
   , specificFormatsSupport
+  , defaultCompOption
+  , defaultExecOption
   , ecIgnoreL
   , ecIgnoreLocalRefsToL
   , ecIgnoreRefsFromL

--- a/src/Xrefcheck/Util.hs
+++ b/src/Xrefcheck/Util.hs
@@ -10,6 +10,7 @@ module Xrefcheck.Util
   , (-:)
   , aesonConfigOption
   , composeFuncList
+  , doesMatchAnyRegex
   , posixTimeToTimeSecond
   , utcTimeToTimeSecond
   , unlessFunc
@@ -29,6 +30,7 @@ import Data.Time (UTCTime)
 import Data.Time.Clock (nominalDiffTimeToSeconds)
 import Data.Time.Clock.POSIX (POSIXTime, utcTimeToPOSIXSeconds)
 import Fmt (Builder)
+import Text.Regex.TDFA.Text (Regex, regexec)
 import Time (Second, Time (..), sec)
 
 import Xrefcheck.Util.Colorize
@@ -72,3 +74,12 @@ whenFunc False _ = id
 
 unlessFunc :: Bool -> (a -> a) -> (a -> a)
 unlessFunc = whenFunc . not
+
+doesMatchAnyRegex :: Text -> ([Regex] -> Bool)
+doesMatchAnyRegex src = any $ \regex ->
+  case regexec regex src of
+    Right res -> case res of
+      Just (before, match, after, _) ->
+        null before && null after && not (null match)
+      Nothing -> False
+    Left _ -> False

--- a/tests/Test/Xrefcheck/ConfigSpec.hs
+++ b/tests/Test/Xrefcheck/ConfigSpec.hs
@@ -18,7 +18,6 @@ import Test.Tasty.HUnit (assertFailure, testCase, (@?=))
 import Test.Tasty.QuickCheck (ioProperty, testProperty)
 
 import Xrefcheck.Config
-  (Config, cExclusionsL, cNetworkingL, defConfig, defConfigText, ncIgnoreAuthFailuresL)
 import Xrefcheck.Core (Flavor (GitHub), allFlavors)
 import Xrefcheck.Scan (ecIgnoreExternalRefsToL)
 import Xrefcheck.Verify (VerifyError (..), checkExternalResource)
@@ -31,7 +30,6 @@ test_config =
       testProperty (show flavor) $
         ioProperty $ evaluateWHNF_ @_ @Config (defConfig flavor)
         | flavor <- allFlavors]
-
   , testGroup "Filled default config matches the expected format"
     -- The config we match against can be regenerated with
     -- stack exec xrefcheck -- dump-config -t GitHub -o tests/configs/github-config.yaml --force
@@ -84,5 +82,5 @@ test_config =
   where
     checkLinkWithServer config link expectation =
       E.bracket (forkIO mockServer) killThread $ \_ -> do
-        result <- runExceptT $ checkExternalResource config link
+        result <- runExceptT $ checkExternalResource emptyChain config link
         result @?= expectation

--- a/tests/Test/Xrefcheck/RedirectChainSpec.hs
+++ b/tests/Test/Xrefcheck/RedirectChainSpec.hs
@@ -1,0 +1,113 @@
+{- SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -}
+
+module Test.Xrefcheck.RedirectChainSpec where
+
+import Universum
+
+import Data.CaseInsensitive qualified as CI
+import Data.Map qualified as M
+import Network.HTTP.Types (mkStatus)
+import Network.HTTP.Types.Header (hLocation)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase)
+import Web.Firefly (App, ToResponse (toResponse), route, run)
+
+import Test.Xrefcheck.UtilRequests
+import Xrefcheck.Config
+import Xrefcheck.Progress
+import Xrefcheck.Verify
+
+test_redirectRequests :: TestTree
+test_redirectRequests = testGroup "Redirect chain tests"
+  [ testCase "Missing location" $ do
+      setRef <- newIORef mempty
+      checkLinkAndProgressWithServer
+        (configMod 5)
+        setRef
+        mockRedirect
+        (link "/broken1")
+        progress
+        (VerifyResult [RedirectMissingLocation $ chain [ "/broken1", "/broken2", "/broken3"]])
+  , testCase "Cycle" $ do
+      setRef <- newIORef mempty
+      checkLinkAndProgressWithServer
+        (configMod 5)
+        setRef
+        mockRedirect
+        (link "/cycle1")
+        progress
+        (VerifyResult [RedirectChainCycle $ chain ["/cycle1", "/cycle2", "/cycle3", "/cycle4", "/cycle2"]])
+  , testGroup "Limit"
+      [ testCase "Takes effect" $ do
+          setRef <- newIORef mempty
+          checkLinkAndProgressWithServer
+            (configMod 2)
+            setRef
+            mockRedirect
+            (link "/cycle1")
+            progress
+            (VerifyResult [RedirectChainLimit $ chain ["/cycle1", "/cycle2", "/cycle3", "/cycle4"]])
+      , testCase "No redirects allowed" $ do
+          setRef <- newIORef mempty
+          checkLinkAndProgressWithServer
+            (configMod 0)
+            setRef
+            mockRedirect
+            (link "/cycle1")
+            progress
+            (VerifyResult [RedirectChainLimit $ chain ["/cycle1", "/cycle2"]])
+      , testCase "Negative" $ do
+          setRef <- newIORef mempty
+          checkLinkAndProgressWithServer
+            (configMod (-1))
+            setRef
+            mockRedirect
+            (link "/cycle1")
+            progress
+            (VerifyResult [RedirectChainCycle $ chain ["/cycle1", "/cycle2", "/cycle3", "/cycle4", "/cycle2"]])
+      ]
+  ]
+  where
+    link :: Text -> Text
+    link = ("http://127.0.0.1:5000" <>)
+
+    chain :: [Text] -> RedirectChain
+    chain = fromList . fmap link
+
+    progress :: Progress Int
+    progress = Progress
+      { pTotal = 1
+      , pCurrent = 1
+      , pErrorsUnfixable = 1
+      , pErrorsFixable = 0
+      , pTaskTimestamp = Nothing
+      }
+
+    configMod :: Int -> Config -> Config
+    configMod limit config = config
+      & cNetworkingL . ncExternalRefRedirectsL .~ [RedirectRule Nothing Nothing Nothing RROFollow]
+      & cNetworkingL . ncMaxRedirectFollowsL .~ limit
+
+    redirectRoute :: Text -> Maybe Text -> App ()
+    redirectRoute name to = route name $ pure $ toResponse
+      ( "" :: Text
+      , mkStatus 301 "Permanent redirect"
+      , M.fromList [(CI.map (decodeUtf8 @Text) hLocation, fmap link $ maybeToList to)]
+      )
+
+    mockRedirect :: IO ()
+    mockRedirect =
+      run 5000 do
+        -- A set of redirect routes that correspond to a broken chain.
+        redirectRoute "/broken1" $ Just "/broken2"
+        redirectRoute "/broken2" $ Just "/broken3"
+        redirectRoute "/broken3" Nothing
+
+        -- A set of redirect routes that correspond to a cycle.
+        redirectRoute "/cycle1" $ Just "/cycle2"
+        redirectRoute "/cycle2" $ Just "/cycle3"
+        redirectRoute "/cycle3" $ Just "/cycle4"
+        redirectRoute "/cycle4" $ Just "/cycle2"

--- a/tests/Test/Xrefcheck/RedirectConfigSpec.hs
+++ b/tests/Test/Xrefcheck/RedirectConfigSpec.hs
@@ -1,0 +1,190 @@
+{- SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -}
+
+module Test.Xrefcheck.RedirectConfigSpec where
+
+import Universum
+
+import Data.CaseInsensitive qualified as CI
+import Data.Map qualified as M
+import Network.HTTP.Types (mkStatus)
+import Network.HTTP.Types.Header (hLocation)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase)
+import Text.Regex.TDFA.Text qualified as R
+import Web.Firefly (App, Status, ToResponse (toResponse), route, run)
+
+import Test.Xrefcheck.UtilRequests
+import Xrefcheck.Config
+import Xrefcheck.Progress
+import Xrefcheck.Scan
+import Xrefcheck.Verify
+
+test_redirectRequests :: TestTree
+test_redirectRequests = testGroup "Redirect config tests"
+  [ testGroup "Match"
+      [ testGroup "By \"on\""
+          [ testCase "Do match" $ do
+              setRef <- newIORef mempty
+              checkLinkAndProgressWithServer
+                (configMod [RedirectRule Nothing Nothing (Just RROTemporary) RROInvalid] [])
+                setRef
+                mockRedirect
+                (link "/temporary-redirect")
+                (progress 1)
+                (VerifyResult [RedirectRuleError (chain ["/temporary-redirect", "/ok"]) (Just RROTemporary)])
+          , testCase "Do not match" $ do
+              setRef <- newIORef mempty
+              checkLinkAndProgressWithServer
+                (configMod [RedirectRule Nothing Nothing (Just RROPermanent) RROInvalid] [])
+                setRef
+                mockRedirect
+                (link "/temporary-redirect")
+                (progress 0)
+                (VerifyResult [])
+          ]
+      , testGroup "By \"to\""
+          [ testCase "Do match" $ do
+              setRef <- newIORef mempty
+              checkLinkAndProgressWithServer
+                (configMod [RedirectRule Nothing (regex "^.*/ok$") Nothing RROValid] [])
+                setRef
+                mockRedirect
+                (link "/permanent-redirect")
+                (progress 0)
+                (VerifyResult [])
+          , testCase "Do not match" $ do
+              setRef <- newIORef mempty
+              checkLinkAndProgressWithServer
+                (configMod [RedirectRule Nothing (regex "^.*/no-ok$") (Just RROPermanent) RROValid] [])
+                setRef
+                mockRedirect
+                (link "/permanent-redirect")
+                (progress 1)
+                (VerifyResult [RedirectRuleError (chain ["/permanent-redirect", "/ok"]) (Just RROPermanent)])
+          ]
+      , testGroup "By \"from\""
+          [ testCase "Do match" $ do
+              setRef <- newIORef mempty
+              checkLinkAndProgressWithServer
+                (configMod [RedirectRule (regex "^.*/permanent-.*$") Nothing Nothing RROValid] [])
+                setRef
+                mockRedirect
+                (link "/permanent-redirect")
+                (progress 0)
+                (VerifyResult [])
+          , testCase "Do not match" $ do
+              setRef <- newIORef mempty
+              checkLinkAndProgressWithServer
+                (configMod [RedirectRule (regex "^.*/temporary-.*$") Nothing (Just RROPermanent) RROValid] [])
+                setRef
+                mockRedirect
+                (link "/permanent-redirect")
+                (progress 1)
+                (VerifyResult [RedirectRuleError (chain ["/permanent-redirect", "/ok"]) (Just RROPermanent)])
+          ]
+      , testGroup "By \"from\", \"to\" and \"on\""
+        [ testCase "Do match" $ do
+            setRef <- newIORef mempty
+            checkLinkAndProgressWithServer
+              (configMod [RedirectRule (regex "^.*/follow[0-9]$") (regex "^.*/ok$") (Just (RROCode 307)) RROInvalid] [])
+              setRef
+              mockRedirect
+              (link "/follow3")
+              (progress 1)
+              (VerifyResult [RedirectRuleError (chain ["/follow3", "/ok"]) (Just (RROCode 307))])
+        , testCase "Do not match" $ do
+            setRef <- newIORef mempty
+            checkLinkAndProgressWithServer
+              (configMod [RedirectRule (regex "^.*/follow[0-9]$") (regex "^.*/ok$") (Just (RROCode 307)) RROInvalid] [])
+              setRef
+              mockRedirect
+              (link "/follow2")
+              (progress 0)
+              (VerifyResult [])
+        ]
+      , testCase "By any" $ do
+          setRef <- newIORef mempty
+          checkLinkAndProgressWithServer
+            (configMod [RedirectRule Nothing Nothing Nothing RROValid] [])
+            setRef
+            mockRedirect
+            (link "/follow1")
+            (progress 0)
+            (VerifyResult [])
+      ]
+  , testGroup "Chain"
+      [ testCase "End valid" $ do
+          setRef <- newIORef mempty
+          checkLinkAndProgressWithServer
+            (configMod [RedirectRule Nothing Nothing Nothing RROFollow] [])
+            setRef
+            mockRedirect
+            (link "/follow1")
+            (progress 0)
+            (VerifyResult [])
+      , testCase "End invalid" $ do
+          setRef <- newIORef mempty
+          checkLinkAndProgressWithServer
+            (configMod [RedirectRule Nothing Nothing (Just (RROCode 307)) RROInvalid, RedirectRule Nothing Nothing Nothing RROFollow] [])
+            setRef
+            mockRedirect
+            (link "/follow1")
+            (progress 1)
+            (VerifyResult [RedirectRuleError (chain ["/follow1", "/follow2", "/follow3", "/ok"]) (Just (RROCode 307))])
+      , testCase "Mixed with ignore" $ do
+          setRef <- newIORef mempty
+          checkLinkAndProgressWithServer
+            (configMod [RedirectRule Nothing Nothing (Just (RROCode 307)) RROInvalid, RedirectRule Nothing Nothing Nothing RROFollow] (maybeToList (regex "^.*/follow3$")))
+            setRef
+            mockRedirect
+            (link "/follow1")
+            (progress 0)
+            (VerifyResult [])
+      ]
+  ]
+  where
+    link :: Text -> Text
+    link = ("http://127.0.0.1:5000" <>)
+
+    chain :: [Text] -> RedirectChain
+    chain = fromList . fmap link
+
+    regex :: Text -> Maybe R.Regex
+    regex = rightToMaybe . R.compile defaultCompOption defaultExecOption
+
+    status :: Int -> Status
+    status code = mkStatus code "Redirect"
+
+    configMod :: [RedirectRule] -> [R.Regex] -> Config -> Config
+    configMod rules exclussions config = config
+      & cNetworkingL . ncExternalRefRedirectsL %~ (rules <>)
+      & cExclusionsL . ecIgnoreExternalRefsToL .~ exclussions
+
+    redirectRoute :: Text -> Int -> Maybe Text -> App ()
+    redirectRoute name code to = route name $ pure $ toResponse
+      ( "" :: Text
+      , status code
+      , M.fromList [(CI.map (decodeUtf8 @Text) hLocation, fmap link $ maybeToList to)]
+      )
+
+    progress :: Int -> Progress Int
+    progress errors = Progress
+      { pTotal = 1
+      , pCurrent = 1
+      , pErrorsUnfixable = errors
+      , pErrorsFixable = 0
+      , pTaskTimestamp = Nothing
+      }
+
+    mockRedirect :: IO ()
+    mockRedirect =
+      run 5000 do
+        route "/ok" $ pure $ toResponse ("Ok" :: Text)
+        redirectRoute "/permanent-redirect" 301 $ Just "/ok"
+        redirectRoute "/temporary-redirect" 302 $ Just "/ok"
+        redirectRoute "/follow1" 301 $ Just "/follow2"
+        redirectRoute "/follow2" 302 $ Just "/follow3"
+        redirectRoute "/follow3" 307 $ Just "/ok"

--- a/tests/Test/Xrefcheck/RedirectConfigSpec.hs
+++ b/tests/Test/Xrefcheck/RedirectConfigSpec.hs
@@ -49,7 +49,7 @@ test_redirectRequests = testGroup "Redirect config tests"
           [ testCase "Do match" $ do
               setRef <- newIORef mempty
               checkLinkAndProgressWithServer
-                (configMod [RedirectRule Nothing (regex "^.*/ok$") Nothing RROValid] [])
+                (configMod [RedirectRule Nothing (regex ".*/ok") Nothing RROValid] [])
                 setRef
                 mockRedirect
                 (link "/permanent-redirect")
@@ -58,7 +58,7 @@ test_redirectRequests = testGroup "Redirect config tests"
           , testCase "Do not match" $ do
               setRef <- newIORef mempty
               checkLinkAndProgressWithServer
-                (configMod [RedirectRule Nothing (regex "^.*/no-ok$") (Just RROPermanent) RROValid] [])
+                (configMod [RedirectRule Nothing (regex ".*/no-ok") (Just RROPermanent) RROValid] [])
                 setRef
                 mockRedirect
                 (link "/permanent-redirect")
@@ -69,7 +69,7 @@ test_redirectRequests = testGroup "Redirect config tests"
           [ testCase "Do match" $ do
               setRef <- newIORef mempty
               checkLinkAndProgressWithServer
-                (configMod [RedirectRule (regex "^.*/permanent-.*$") Nothing Nothing RROValid] [])
+                (configMod [RedirectRule (regex ".*/permanent-.*") Nothing Nothing RROValid] [])
                 setRef
                 mockRedirect
                 (link "/permanent-redirect")
@@ -78,7 +78,7 @@ test_redirectRequests = testGroup "Redirect config tests"
           , testCase "Do not match" $ do
               setRef <- newIORef mempty
               checkLinkAndProgressWithServer
-                (configMod [RedirectRule (regex "^.*/temporary-.*$") Nothing (Just RROPermanent) RROValid] [])
+                (configMod [RedirectRule (regex ".*/temporary-.*") Nothing (Just RROPermanent) RROValid] [])
                 setRef
                 mockRedirect
                 (link "/permanent-redirect")
@@ -89,7 +89,7 @@ test_redirectRequests = testGroup "Redirect config tests"
         [ testCase "Do match" $ do
             setRef <- newIORef mempty
             checkLinkAndProgressWithServer
-              (configMod [RedirectRule (regex "^.*/follow[0-9]$") (regex "^.*/ok$") (Just (RROCode 307)) RROInvalid] [])
+              (configMod [RedirectRule (regex ".*/follow[0-9]") (regex "^.*/ok$") (Just (RROCode 307)) RROInvalid] [])
               setRef
               mockRedirect
               (link "/follow3")
@@ -98,7 +98,7 @@ test_redirectRequests = testGroup "Redirect config tests"
         , testCase "Do not match" $ do
             setRef <- newIORef mempty
             checkLinkAndProgressWithServer
-              (configMod [RedirectRule (regex "^.*/follow[0-9]$") (regex "^.*/ok$") (Just (RROCode 307)) RROInvalid] [])
+              (configMod [RedirectRule (regex ".*/follow[0-9]") (regex "^.*/ok$") (Just (RROCode 307)) RROInvalid] [])
               setRef
               mockRedirect
               (link "/follow2")
@@ -137,7 +137,7 @@ test_redirectRequests = testGroup "Redirect config tests"
       , testCase "Mixed with ignore" $ do
           setRef <- newIORef mempty
           checkLinkAndProgressWithServer
-            (configMod [RedirectRule Nothing Nothing (Just (RROCode 307)) RROInvalid, RedirectRule Nothing Nothing Nothing RROFollow] (maybeToList (regex "^.*/follow3$")))
+            (configMod [RedirectRule Nothing Nothing (Just (RROCode 307)) RROInvalid, RedirectRule Nothing Nothing Nothing RROFollow] (maybeToList (regex ".*/follow3")))
             setRef
             mockRedirect
             (link "/follow1")

--- a/tests/configs/github-config.yaml
+++ b/tests/configs/github-config.yaml
@@ -54,21 +54,45 @@ networking:
   # On other errors xrefcheck fails immediately, without retrying.
   maxRetries: 3
 
-# Querying a given domain that ever returned 429 before,
-# this defines how many timeouts are allowed during retries.
-#
-# For such domains, timeouts likely mean hitting the rate limiter,
-# and so xrefcheck considers timeouts in the same way as 429 errors.
-#
-# For other domains, a timeout results in a respective error, no retry
-# attempts will be performed. Use `externalRefCheckTimeout` option
-# to increase the time after which timeout is declared.
-#
-# This option is similar to `maxRetries`, the difference is that
-# this `maxTimeoutRetries` option limits only the number of retries
-# caused by timeouts, and `maxRetries` limits the number of retries
-# caused both by 429s and timeouts.
+  # Querying a given domain that ever returned 429 before,
+  # this defines how many timeouts are allowed during retries.
+  #
+  # For such domains, timeouts likely mean hitting the rate limiter,
+  # and so xrefcheck considers timeouts in the same way as 429 errors.
+  #
+  # For other domains, a timeout results in a respective error, no retry
+  # attempts will be performed. Use `externalRefCheckTimeout` option
+  # to increase the time after which timeout is declared.
+  #
+  # This option is similar to `maxRetries`, the difference is that
+  # this `maxTimeoutRetries` option limits only the number of retries
+  # caused by timeouts, and `maxRetries` limits the number of retries
+  # caused both by 429s and timeouts.
   maxTimeoutRetries: 1
+
+  # Maximum number of links that can be followed in a single redirect
+  # chain.
+  #
+  # The link is considered as invalid if the limit is exceeded.
+  maxRedirectFollows: 10
+
+  # Rules to override the redirect behavior for external references that
+  # match, where
+  #   - 'from' is a regular expression for the source link in a single
+  #     redirection step. Its absence means that every link matches.
+  #   - 'to' is a regular expression for the target link in a single
+  #     redirection step. Its absence also means that every link matches.
+  #   - 'on' accepts 'temporary', 'permanent' or a specific redirect HTTP code.
+  #     Its absence also means that every response code matches.
+  #   - 'outcome' accepts 'valid', 'invalid' or 'follow'. The last one follows
+  #      the redirect by applying the same configuration rules so, for instance,
+  #      exclusion rules would also apply to the following links.
+  #
+  # The first one that matches is applied, and the link is considered
+  # as valid if none of them does match.
+  externalRefRedirects:
+    - on: permanent
+      outcome: invalid
 
 # Parameters of scanners for various file types.
 scanners:

--- a/tests/configs/github-config.yaml
+++ b/tests/configs/github-config.yaml
@@ -25,7 +25,7 @@ exclusions:
   # List of POSIX extended regular expressions.
   ignoreExternalRefsTo:
     # Ignore localhost links by default
-    - ^(https?|ftps?)://(localhost|127\.0\.0\.1).*
+    - (https?|ftps?)://(localhost|127\.0\.0\.1).*
 
 # Networking parameters.
 networking:

--- a/tests/golden/check-autolinks/check-autolinks.bats
+++ b/tests/golden/check-autolinks/check-autolinks.bats
@@ -35,10 +35,10 @@ assert_diff - <<EOF
        - link: http://www.commonmark.org
        - anchor: -
 
-     Permanent redirect found. Perhaps you want to replace the link:
-       http://www.commonmark.org
-     by:
-       https://commonmark.org/
+     Permanent redirect found:
+       -| http://www.commonmark.org
+       -> https://commonmark.org/
+          ^-- stopped before this one
 
 Invalid references dumped, 1 in total.
 EOF

--- a/tests/golden/check-ignoreExternalRefsTo/config-check-disabled.yaml
+++ b/tests/golden/check-ignoreExternalRefsTo/config-check-disabled.yaml
@@ -4,7 +4,7 @@
 
 exclusions:
   ignoreExternalRefsTo:
-    - ^(https?|ftps?)://(localhost|127\.0\.0\.1).*
+    - (https?|ftps?)://(localhost|127\.0\.0\.1).*
 
 scanners:
   markdown:

--- a/tests/golden/check-redirect-parse/bad-code.yaml
+++ b/tests/golden/check-redirect-parse/bad-code.yaml
@@ -9,5 +9,4 @@ scanners:
 networking:
   externalRefRedirects:
     - outcome: valid
-      to: ^.*$
       on: 404

--- a/tests/golden/check-redirect-parse/bad-code.yaml
+++ b/tests/golden/check-redirect-parse/bad-code.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: Unlicense
+
+scanners:
+  markdown:
+    flavor: GitHub
+
+networking:
+  externalRefRedirects:
+    - outcome: valid
+      to: ^.*$
+      on: 404

--- a/tests/golden/check-redirect-parse/bad-on.yaml
+++ b/tests/golden/check-redirect-parse/bad-on.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: Unlicense
+
+scanners:
+  markdown:
+    flavor: GitHub
+
+networking:
+  externalRefRedirects:
+    - outcome: valid
+      to: ^.*$
+      on: premanent

--- a/tests/golden/check-redirect-parse/bad-on.yaml
+++ b/tests/golden/check-redirect-parse/bad-on.yaml
@@ -9,5 +9,4 @@ scanners:
 networking:
   externalRefRedirects:
     - outcome: valid
-      to: ^.*$
       on: premanent

--- a/tests/golden/check-redirect-parse/bad-outcome.yaml
+++ b/tests/golden/check-redirect-parse/bad-outcome.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: Unlicense
+
+scanners:
+  markdown:
+    flavor: GitHub
+
+networking:
+  externalRefRedirects:
+    - outcome: flow

--- a/tests/golden/check-redirect-parse/bad-rule.yaml
+++ b/tests/golden/check-redirect-parse/bad-rule.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: Unlicense
+
+scanners:
+  markdown:
+    flavor: GitHub
+
+networking:
+  externalRefRedirects: [Bad]

--- a/tests/golden/check-redirect-parse/bad-rules.yaml
+++ b/tests/golden/check-redirect-parse/bad-rules.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: Unlicense
+
+scanners:
+  markdown:
+    flavor: GitHub
+
+networking:
+  externalRefRedirects: Bad

--- a/tests/golden/check-redirect-parse/bad-to.yaml
+++ b/tests/golden/check-redirect-parse/bad-to.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: Unlicense
+
+scanners:
+  markdown:
+    flavor: GitHub
+
+networking:
+  externalRefRedirects:
+    - outcome: valid
+      to: 42

--- a/tests/golden/check-redirect-parse/check-redirect-parse.bats
+++ b/tests/golden/check-redirect-parse/check-redirect-parse.bats
@@ -1,0 +1,93 @@
+#!/usr/bin/env bats
+
+# SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+load '../helpers/bats-support/load'
+load '../helpers/bats-assert/load'
+load '../helpers/bats-file/load'
+load '../helpers'
+
+
+@test "No redirect rules" {
+  to_temp xrefcheck -c no-rules.yaml
+
+assert_diff - <<EOF
+All repository links are valid.
+EOF
+}
+
+@test "Only outcome" {
+  to_temp xrefcheck -c only-outcome.yaml
+
+assert_diff - <<EOF
+All repository links are valid.
+EOF
+}
+
+@test "Only outcome and to" {
+  to_temp xrefcheck -c only-outcome-to.yaml
+
+assert_diff - <<EOF
+All repository links are valid.
+EOF
+}
+
+@test "Only outcome and on" {
+  to_temp xrefcheck -c only-outcome-to.yaml
+
+assert_diff - <<EOF
+All repository links are valid.
+EOF
+}
+
+@test "Full rule" {
+  to_temp xrefcheck -c full-rule.yaml
+
+assert_diff - <<EOF
+All repository links are valid.
+EOF
+}
+
+@test "Rules not an array error" {
+  run xrefcheck -c bad-rules.yaml
+
+  assert_output --partial "expected Array, but encountered String"
+}
+
+@test "Rule not an object error" {
+  run xrefcheck -c bad-rule.yaml
+
+  assert_output --partial "expected Object, but encountered String"
+}
+
+@test "Bad code error" {
+  run xrefcheck -c bad-code.yaml
+
+  assert_output --partial "expected a redirect (3XX) HTTP code or (permanent|temporary)"
+}
+
+@test "Bad on" {
+  run xrefcheck -c bad-on.yaml
+
+  assert_output --partial "expected a redirect (3XX) HTTP code or (permanent|temporary)"
+}
+
+@test "Bad to" {
+  run xrefcheck -c bad-to.yaml
+
+  assert_output --partial "expected String, but encountered Number"
+}
+
+@test "Bad outcome" {
+  run xrefcheck -c bad-outcome.yaml
+
+  assert_output --partial "expected (valid|invalid|follow)"
+}
+
+@test "No outcome error" {
+  run xrefcheck -c no-outcome.yaml
+
+  assert_output --partial "key \"outcome\" not found"
+}

--- a/tests/golden/check-redirect-parse/full-rule.yaml
+++ b/tests/golden/check-redirect-parse/full-rule.yaml
@@ -9,5 +9,5 @@ scanners:
 networking:
   externalRefRedirects:
     - outcome: valid
-      to: ^https://.*$
+      to: https://.*
       on: permanent

--- a/tests/golden/check-redirect-parse/full-rule.yaml
+++ b/tests/golden/check-redirect-parse/full-rule.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: Unlicense
+
+scanners:
+  markdown:
+    flavor: GitHub
+
+networking:
+  externalRefRedirects:
+    - outcome: valid
+      to: ^https://.*$
+      on: permanent

--- a/tests/golden/check-redirect-parse/no-outcome.yaml
+++ b/tests/golden/check-redirect-parse/no-outcome.yaml
@@ -10,5 +10,5 @@ networking:
   externalRefRedirects:
     - outcome: valid
       on: temporary
-    - to: ^https://.*$
+    - to: https://.*
       on: temporary

--- a/tests/golden/check-redirect-parse/no-outcome.yaml
+++ b/tests/golden/check-redirect-parse/no-outcome.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: Unlicense
+
+scanners:
+  markdown:
+    flavor: GitHub
+
+networking:
+  externalRefRedirects:
+    - outcome: valid
+      on: temporary
+    - to: ^https://.*$
+      on: temporary

--- a/tests/golden/check-redirect-parse/no-rules.yaml
+++ b/tests/golden/check-redirect-parse/no-rules.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: Unlicense
+
+scanners:
+  markdown:
+    flavor: GitHub
+
+networking:
+  externalRefRedirects: []

--- a/tests/golden/check-redirect-parse/only-outcome-on.yaml
+++ b/tests/golden/check-redirect-parse/only-outcome-on.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: Unlicense
+
+scanners:
+  markdown:
+    flavor: GitHub
+
+networking:
+  externalRefRedirects:
+    - outcome: invalid
+      on: 302

--- a/tests/golden/check-redirect-parse/only-outcome-to.yaml
+++ b/tests/golden/check-redirect-parse/only-outcome-to.yaml
@@ -9,4 +9,4 @@ scanners:
 networking:
   externalRefRedirects:
     - outcome: valid
-      to: ^https://.*$
+      to: https://.*

--- a/tests/golden/check-redirect-parse/only-outcome-to.yaml
+++ b/tests/golden/check-redirect-parse/only-outcome-to.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: Unlicense
+
+scanners:
+  markdown:
+    flavor: GitHub
+
+networking:
+  externalRefRedirects:
+    - outcome: valid
+      to: ^https://.*$

--- a/tests/golden/check-redirect-parse/only-outcome.yaml
+++ b/tests/golden/check-redirect-parse/only-outcome.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: Unlicense
+
+scanners:
+  markdown:
+    flavor: GitHub
+
+networking:
+  externalRefRedirects:
+    - outcome: follow


### PR DESCRIPTION
## Description

Problem: We previously changed the default behaviour of Xrefcheck when following link redirects, but did not provide a way to configure it.

Solution: We are adding a new field in the configuration file to allow writing a list of redirect rules that will be applied to links that match them.

## Related issue(s)

Relates #25 

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](https://github.com/serokell/xrefcheck/tree/master/README.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](https://github.com/serokell/xrefcheck/tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](https://github.com/serokell/style/blob/master/haskell.md).
