### PR TITLE
[#254] Revise dump-config command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,9 @@ Unreleased
 * [#231](https://github.com/serokell/xrefcheck/pull/231)
   + Anchor analysis takes now into account the appropriate case-sensitivity depending on
   the configured Markdown flavour.
+* [#254](https://github.com/serokell/xrefcheck/pull/254)
+  + Now the `dump-config` command does not overwrite a file unless explicitly told with a
+    `--force` flag. Also, a `--stdout` flag allows to print the config to stdout instead.
 
 0.2.2
 ==========

--- a/exec/Main.hs
+++ b/exec/Main.hs
@@ -10,7 +10,8 @@ import Universum
 import Main.Utf8 (withUtf8)
 import System.IO.CodePage (withCP65001)
 
-import Xrefcheck.CLI (Command (..), getCommand)
+import System.Directory (doesFileExist)
+import Xrefcheck.CLI (Command (..), DumpConfigMode (..), getCommand)
 import Xrefcheck.Command (defaultAction)
 import Xrefcheck.Config (defConfigText)
 
@@ -20,5 +21,10 @@ main = withUtf8 $ withCP65001 $ do
   case command of
     DefaultCommand options ->
       defaultAction options
-    DumpConfig repoType path ->
+    DumpConfig repoType (DCMFile forceFlag path) -> do
+      whenM ((not forceFlag &&) <$> doesFileExist path) do
+        putTextLn "Output file exists. Use --force to overwrite."
+        exitFailure
       writeFile path (defConfigText repoType)
+    DumpConfig repoType DCMStdout ->
+      putStr (defConfigText repoType)

--- a/package.yaml
+++ b/package.yaml
@@ -130,6 +130,7 @@ executables:
     dependencies:
       - xrefcheck
       - universum
+      - directory
       - with-utf8
       - code-page
 

--- a/package.yaml
+++ b/package.yaml
@@ -46,11 +46,11 @@ default-extensions:
   - StandaloneDeriving
   - TemplateHaskell
   - TupleSections
+  - TypeApplications
   - TypeFamilies
+  - TypeOperators
   - UndecidableInstances
   - ViewPatterns
-  - TypeApplications
-  - TypeOperators
 
 ghc-options:
   - -Weverything
@@ -85,8 +85,8 @@ library:
     - aeson-casing
     - async
     - bytestring
-    - containers
     - cmark-gfm >= 0.2.5
+    - containers
     - directory
     - dlist
     - filepath
@@ -96,14 +96,17 @@ library:
     - http-client
     - http-types
     - lens
-    - pretty-terminal
     - modern-uri
     - mtl
+    - nyan-interpolation
     - o-clock
     - optparse-applicative
+    - pretty-terminal
     - process
+    - reflection
     - regex-tdfa
     - req
+    - safe-exceptions
     - tagsoup
     - text
     - text-metrics
@@ -112,9 +115,6 @@ library:
     - universum
     - uri-bytestring
     - yaml
-    - reflection
-    - nyan-interpolation
-    - safe-exceptions
 
 executables:
   xrefcheck:
@@ -128,11 +128,11 @@ executables:
       - -with-rtsopts=-N
       - -O2
     dependencies:
-      - xrefcheck
-      - universum
-      - directory
-      - with-utf8
       - code-page
+      - directory
+      - universum
+      - with-utf8
+      - xrefcheck
 
 tests:
   xrefcheck-tests:
@@ -143,24 +143,24 @@ tests:
       - Paths_xrefcheck
     dependencies:
       - case-insensitive
-      - containers
       - cmark-gfm
-      - firefly
-      - xrefcheck
+      - containers
       - directory
+      - firefly
       - http-types
+      - modern-uri
+      - nyan-interpolation
       - o-clock
+      - reflection
       - regex-tdfa
       - tasty
       - tasty-hunit
       - tasty-quickcheck
       - time
       - universum
-      - modern-uri
       - uri-bytestring
+      - xrefcheck
       - yaml
-      - reflection
-      - nyan-interpolation
 
   ftp-tests:
     main: Main.hs
@@ -173,5 +173,5 @@ tests:
       - tagged
       - tasty
       - tasty-hunit
-      - xrefcheck
       - universum
+      - xrefcheck

--- a/src/Xrefcheck/CLI.hs
+++ b/src/Xrefcheck/CLI.hs
@@ -9,6 +9,7 @@ module Xrefcheck.CLI
   ( VerifyMode (..)
   , ExclusionOptions (..)
   , Command (..)
+  , DumpConfigMode (..)
   , Options (..)
   , NetworkingOptions (..)
 
@@ -70,7 +71,11 @@ modes =
 
 data Command
   = DefaultCommand Options
-  | DumpConfig Flavor FilePath
+  | DumpConfig Flavor DumpConfigMode
+
+data DumpConfigMode
+  = DCMFile Bool FilePath
+  | DCMStdout
 
 data Options = Options
   { oConfigPath        :: Maybe FilePath
@@ -218,7 +223,7 @@ dumpConfigOptions = hsubparser $
     info parser $
     progDesc "Dump default configuration into a file."
   where
-    parser = DumpConfig <$> repoTypeOption <*> outputOption
+    parser = DumpConfig <$> repoTypeOption <*> mode
 
     repoTypeOption =
       option repoTypeReadM $
@@ -230,6 +235,22 @@ dumpConfigOptions = hsubparser $
       Can be (#{intercalate " | " $ map show allFlavors}). \
       Case insensitive.
       |]
+
+    mode =
+      stdoutMode <|> fileMode
+
+    fileMode =
+      DCMFile <$> forceMode <*> outputOption
+
+    stdoutMode =
+      flag' DCMStdout $
+      long "stdout" <>
+      help "Write the config file to stdout."
+
+    forceMode =
+      switch $
+      long "force" <>
+      help "Overwrite the config file if it already exists."
 
     outputOption =
       filepathOption $

--- a/tests/Test/Xrefcheck/ConfigSpec.hs
+++ b/tests/Test/Xrefcheck/ConfigSpec.hs
@@ -35,14 +35,14 @@ test_config =
 
   , testGroup "Filled default config matches the expected format"
     -- The config we match against can be regenerated with
-    -- stack exec xrefcheck -- dump-config -t GitHub -o tests/configs/github-config.yaml
+    -- stack exec xrefcheck -- dump-config -t GitHub -o tests/configs/github-config.yaml --force
       [ testCase "Config matches" $ do
         config <- readFile "tests/configs/github-config.yaml"
         when (config /= defConfigText GitHub) $
           assertFailure $ toString $ unwords
             [ "Config does not match the expected format."
             , "Run"
-            , "`stack exec xrefcheck -- dump-config -t GitHub -o tests/configs/github-config.yaml`"
+            , "`stack exec xrefcheck -- dump-config -t GitHub -o tests/configs/github-config.yaml --force`"
             , "and verify changes"
             ]
       ]

--- a/tests/golden/check-dump-config/.config.yaml
+++ b/tests/golden/check-dump-config/.config.yaml
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: MPL-2.0

--- a/tests/golden/check-dump-config/.xrefcheck.yaml
+++ b/tests/golden/check-dump-config/.xrefcheck.yaml
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: MPL-2.0

--- a/tests/golden/check-dump-config/check-dump-config.bats
+++ b/tests/golden/check-dump-config/check-dump-config.bats
@@ -1,0 +1,75 @@
+#!/usr/bin/env bats
+
+# SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+load '../helpers/bats-support/load'
+load '../helpers/bats-assert/load'
+load '../helpers/bats-file/load'
+load '../helpers'
+
+
+@test "Dump config to stdout" {
+  to_temp xrefcheck dump-config --stdout -t GitHub
+
+  assert_diff ../../configs/github-config.yaml
+}
+
+@test "Dump config to existent default file error" {
+  run xrefcheck dump-config -t GitHub
+
+  assert_failure
+
+  assert_output "Output file exists. Use --force to overwrite."
+}
+
+@test "Dump config to existent file error" {
+  run xrefcheck dump-config -o .config.yaml -t GitHub
+
+  assert_failure
+
+  assert_output "Output file exists. Use --force to overwrite."
+}
+
+@test "Dump config to non existent default file" {
+  cd $TEST_TEMP_DIR
+
+  run xrefcheck dump-config -t GitHub
+
+  assert_success
+
+  assert_exists .xrefcheck.yaml
+}
+
+@test "Dump config to non existent file" {
+  cd $TEST_TEMP_DIR
+
+  run xrefcheck dump-config -o .config.yaml -t GitHub
+
+  assert_success
+
+  assert_exists .config.yaml
+}
+
+@test "Dump config to existent default file with force" {
+  cp .xrefcheck.yaml $TEST_TEMP_DIR
+  cd $TEST_TEMP_DIR
+
+  run xrefcheck dump-config -t GitHub --force
+
+  assert_success
+
+  assert_exists .xrefcheck.yaml
+}
+
+@test "Dump config to existent file with force" {
+  cp .config.yaml $TEST_TEMP_DIR
+  cd $TEST_TEMP_DIR
+
+  run xrefcheck dump-config -o .config.yaml -t GitHub --force
+
+  assert_success
+
+  assert_exists .config.yaml
+}


### PR DESCRIPTION
## Description

Problem: xrefcheck does not allow to print the config to stdout instead of writing it to a file. Also, it is easy to overwrite your changes by mistake by executing the command again.

Solution: provide a `--stdout` flag to print the config to stdout, and do not write it to a file unless a `--force` flag has been included.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #1 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Fixes #254 

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](https://github.com/serokell/xrefcheck/tree/master/README.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](https://github.com/serokell/xrefcheck/tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](https://github.com/serokell/style/blob/master/haskell.md).