### PR TITLE
[#235] Refactor progress bar interface

### DIFF
--- a/src/Xrefcheck/Core.hs
+++ b/src/Xrefcheck/Core.hs
@@ -357,8 +357,8 @@ stripAnchorDupNo t = do
 -----------------------------------------------------------
 
 data VerifyProgress = VerifyProgress
-  { vrLocal    :: !(Progress Int)
-  , vrExternal :: !(Progress Int)
+  { vrLocal    :: !(Progress Int Text)
+  , vrExternal :: !(Progress Int Text)
   } deriving stock (Show)
 
 initVerifyProgress :: [Reference] -> VerifyProgress

--- a/src/Xrefcheck/Util.hs
+++ b/src/Xrefcheck/Util.hs
@@ -9,12 +9,10 @@ module Xrefcheck.Util
   , postfixFields
   , (-:)
   , aesonConfigOption
-  , composeFuncList
   , doesMatchAnyRegex
   , posixTimeToTimeSecond
   , utcTimeToTimeSecond
-  , unlessFunc
-  , whenFunc
+
   , module Xrefcheck.Util.Colorize
   , module Xrefcheck.Util.Interpolate
   ) where
@@ -64,16 +62,6 @@ posixTimeToTimeSecond posixTime =
 
 utcTimeToTimeSecond :: UTCTime -> Time Second
 utcTimeToTimeSecond = posixTimeToTimeSecond . utcTimeToPOSIXSeconds
-
-composeFuncList :: [a -> a] -> a -> a
-composeFuncList = foldr (.) id
-
-whenFunc :: Bool -> (a -> a) -> (a -> a)
-whenFunc True f = f
-whenFunc False _ = id
-
-unlessFunc :: Bool -> (a -> a) -> (a -> a)
-unlessFunc = whenFunc . not
 
 doesMatchAnyRegex :: Text -> ([Regex] -> Bool)
 doesMatchAnyRegex src = any $ \regex ->

--- a/tests/Test/Xrefcheck/RedirectChainSpec.hs
+++ b/tests/Test/Xrefcheck/RedirectChainSpec.hs
@@ -77,14 +77,8 @@ test_redirectRequests = testGroup "Redirect chain tests"
     chain :: [Text] -> RedirectChain
     chain = fromList . fmap link
 
-    progress :: Progress Int
-    progress = Progress
-      { pTotal = 1
-      , pCurrent = 1
-      , pErrorsUnfixable = 1
-      , pErrorsFixable = 0
-      , pTaskTimestamp = Nothing
-      }
+    progress :: Progress Int Text
+    progress = reportError "" $ initProgress 1
 
     configMod :: Int -> Config -> Config
     configMod limit config = config

--- a/tests/Test/Xrefcheck/RedirectDefaultSpec.hs
+++ b/tests/Test/Xrefcheck/RedirectDefaultSpec.hs
@@ -71,13 +71,8 @@ test_redirectRequests = testGroup "Redirect response defaults"
         setRef
         (mockRedirect expectedLocation expectedStatus)
         url
-        (Progress
-          { pTotal = 1
-          , pCurrent = 1
-          , pErrorsUnfixable = length $ maybeToList expectedError
-          , pErrorsFixable = 0
-          , pTaskTimestamp = Nothing
-          }
+        ( (if isNothing expectedError then reportSuccess else reportError) "" $
+            initProgress 1
         )
         (VerifyResult $ maybeToList expectedError)
 

--- a/tests/Test/Xrefcheck/TimeoutSpec.hs
+++ b/tests/Test/Xrefcheck/TimeoutSpec.hs
@@ -95,14 +95,12 @@ test_timeout = testGroup "Timeout tests"
   where
     setAllowedTimeout = cNetworkingL . ncExternalRefCheckTimeoutL .~ (sec 0.25)
 
-    mkProgressWithOneTask shouldSucceed =
-      Progress
-        { pTotal = 1
-        , pCurrent = 1
-        , pErrorsUnfixable = if shouldSucceed then 0 else 1
-        , pErrorsFixable = 0
-        , pTaskTimestamp = Nothing
-        }
+    mkProgressWithOneTask shouldSucceed = report "" $ initProgress 1
+      where
+        report =
+          if shouldSucceed
+          then reportSuccess
+          else reportError
 
     timeoutTestCase mockResponses shouldSucceed configModifier = do
       let prog = mkProgressWithOneTask shouldSucceed


### PR DESCRIPTION
## Description

Problem: the current progress bar interface is quite low-level and error-prone.

Solution: the proposed solution here modifies both the progress bar internal model and interface by representing progress units by witnesses. It does not require great changes, but the resulting interface is clearer and less error-prone.

## Related issue(s)

Relates #235

## :white_check_mark: Checklist for your Pull Request

#### Related changes

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](https://github.com/serokell/xrefcheck/tree/master/README.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](https://github.com/serokell/xrefcheck/tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](https://github.com/serokell/style/blob/master/haskell.md).
