### PR TITLE
[#237] Modify coloring options

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,6 +49,9 @@ Unreleased
     configuration file with the `externalRefRedirects` parameter.
 * [#261](https://github.com/serokell/xrefcheck/pull/261)
   + Symlinks are now not processed by the scanner.
+* [#268](https://github.com/serokell/xrefcheck/pull/268)
+  + Added CLI option `--color` that enables ANSI colors in output.
+  + Changed the output coloring defaults to show colors when `CI` env variable is `true`.
 
 0.2.2
 ==========

--- a/src/Xrefcheck/CLI.hs
+++ b/src/Xrefcheck/CLI.hs
@@ -83,7 +83,7 @@ data Options = Options
   , oMode              :: VerifyMode
   , oVerbose           :: Bool
   , oShowProgressBar   :: Maybe Bool
-  , oColorMode         :: ColorMode
+  , oColorMode         :: Maybe ColorMode
   , oExclusionOptions  :: ExclusionOptions
   , oNetworkingOptions :: NetworkingOptions
   , oScanPolicy        :: ScanPolicy
@@ -185,9 +185,17 @@ optionsParser = do
         help "Do not display progress bar during verification."
     , pure Nothing
     ]
-  oColorMode <- flag WithColors WithoutColors $
-    long "no-color" <>
-    help "Disable ANSI coloring of output."
+  oColorMode <- asum
+    [ flag' (Just WithColors) $
+        long "color" <>
+        help "Enable ANSI coloring of output. \
+            \When `CI` env var is set to true or the command output corresponds to a terminal, \
+            \this option will be enabled by default."
+    , flag' (Just WithoutColors) $
+        long "no-color" <>
+        help "Disable ANSI coloring of output."
+    , pure Nothing
+    ]
   oExclusionOptions <- exclusionOptionsParser
   oNetworkingOptions <- networkingOptionsParser
   oScanPolicy <- flag OnlyTracked IncludeUntracked $

--- a/tests/golden/check-color/check-color.bats
+++ b/tests/golden/check-color/check-color.bats
@@ -1,0 +1,34 @@
+#!/usr/bin/env bats
+
+# SPDX-FileCopyrightText: 2023 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+load '../helpers/bats-support/load'
+load '../helpers/bats-assert/load'
+load '../helpers/bats-file/load'
+load '../helpers'
+
+# The CI variable must be always explicitly set in these tests because they are checking for an
+# intended behavior regardless of where they are actually being run (e.g. "No color flag (not
+# in CI)") may be running in CI).
+
+@test "Color flag (not in CI)" {
+  CI=false xrefcheck -v --no-progress --color | diff - expected-color.gold
+}
+
+@test "No color flag (not in CI)" {
+  CI=false xrefcheck -v --no-progress --no-color | diff - expected-no-color.gold
+}
+
+@test "No color default when pipe (not in CI)" {
+  CI=false xrefcheck -v --no-progress | diff - expected-no-color.gold
+}
+
+@test "Color default when CI" {
+  CI=true xrefcheck -v --no-progress | diff - expected-color.gold
+}
+
+@test "No color flag in CI" {
+  CI=true xrefcheck -v --no-progress --no-color | diff - expected-no-color.gold
+}

--- a/tests/golden/check-color/color.md
+++ b/tests/golden/check-color/color.md
@@ -1,0 +1,9 @@
+<!--
+ - SPDX-FileCopyrightText: 2023 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -->
+
+# Color
+
+[Color](#Color)

--- a/tests/golden/check-color/expected-color.gold
+++ b/tests/golden/check-color/expected-color.gold
@@ -1,0 +1,12 @@
+=== Repository data ===
+
+  [96mcolor.md[0m:
+    - references:
+        - reference ([92mfile-local[0m) [2mat src:9:1-15[0m:
+            - text: "Color"
+            - link: -
+            - anchor: Color
+    - anchors:
+        - color ([2m[92mheader I[0m[0m) [2mat src:7:1-7[0m
+
+All repository links are valid.

--- a/tests/golden/check-color/expected-no-color.gold
+++ b/tests/golden/check-color/expected-no-color.gold
@@ -1,0 +1,12 @@
+=== Repository data ===
+
+  color.md:
+    - references:
+        - reference (file-local) at src:9:1-15:
+            - text: "Color"
+            - link: -
+            - anchor: Color
+    - anchors:
+        - color (header I) at src:7:1-7
+
+All repository links are valid.


### PR DESCRIPTION
## Description

Problem: We noticed that output was not being colorized in GitLab CI due to the current implemented guesses for whether showing colors or not.

Solution: On the one hand, we extend the current guesses to also enable coloring by default when the CI env var is set to true. On the other hand, we also add a new flag, color, which avoids these guesses and enables colors.

I have tried in a GitLab CI project and the output is colored now.

## Related issue(s)

Fixes #237 

## :white_check_mark: Checklist for your Pull Request

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](https://github.com/serokell/xrefcheck/tree/master/README.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](https://github.com/serokell/xrefcheck/tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](https://github.com/serokell/style/blob/master/haskell.md).
