### PR TITLE
[#270] Handle relative redirects

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -52,6 +52,8 @@ Unreleased
 * [#268](https://github.com/serokell/xrefcheck/pull/268)
   + Added CLI option `--color` that enables ANSI colors in output.
   + Changed the output coloring defaults to show colors when `CI` env variable is `true`.
+* [#271](https://github.com/serokell/xrefcheck/pull/271)
+  + Now Xrefcheck is able to follow relative redirects.
 
 0.2.2
 ==========

--- a/src/Xrefcheck/Data/URI.hs
+++ b/src/Xrefcheck/Data/URI.hs
@@ -1,0 +1,74 @@
+{- SPDX-FileCopyrightText: 2023 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -}
+
+{-# LANGUAGE ExistentialQuantification #-}
+
+module Xrefcheck.Data.URI
+  ( UriParseError (..)
+  , parseUri
+  ) where
+
+import Universum
+
+import Control.Exception.Safe (handleJust)
+import Control.Monad.Except (throwError)
+import Text.URI (ParseExceptionBs, URI, mkURIBs)
+import URI.ByteString qualified as URIBS
+
+data UriParseError
+  = UPEInvalid URIBS.URIParseError
+  | UPEConversion ParseExceptionBs
+  deriving stock (Show, Eq)
+
+data AnyURIRef = forall a. AnyURIRef (URIBS.URIRef a)
+
+serializeAnyURIRef :: AnyURIRef -> ByteString
+serializeAnyURIRef (AnyURIRef uri) = URIBS.serializeURIRef' uri
+
+-- | Parse URI according to RFC 3986 extended by allowing non-encoded
+-- `[` and `]` in query string.
+--
+-- The first parameter indicates whether the parsing should admit relative
+-- URIs or not.
+parseUri :: Bool -> Text -> ExceptT UriParseError IO URI
+parseUri canBeRelative link = do
+  -- There exist two main standards of URL parsing: RFC 3986 and the Web
+  -- Hypertext Application Technology Working Group's URL standard. Ideally,
+  -- we want to be able to parse the URLs in accordance with the latter
+  -- standard, because it provides a much less ambiguous set of rules for
+  -- percent-encoding special characters, and is essentially a living
+  -- standard that gets updated constantly.
+  --
+  -- We have chosen the 'uri-bytestring' library for URI parsing because
+  -- of the 'laxURIParseOptions' parsing configuration. 'mkURI' from
+  -- the 'modern-uri' library parses URIs in accordance with RFC 3986 and does
+  -- not provide a means of parsing customization, which contrasts with
+  -- 'parseURI' that accepts a 'URIParserOptions'. One of the predefined
+  -- configurations of this type is 'strictURIParserOptions', which follows
+  -- RFC 3986, and the other -- 'laxURIParseOptions' -- allows brackets
+  -- in the queries, which draws us closer to the WHATWG URL standard.
+  --
+  -- The 'modern-uri' package can parse an URI deciding if it is absolute or
+  -- relative depending on the success or failure of the scheme parsing. By
+  -- contrast, in 'uri-bytestring' it has to be decided beforehand, resulting in
+  -- different URI types.
+  uri <- case URIBS.parseURI URIBS.laxURIParserOptions (encodeUtf8 link) of
+    Left (URIBS.MalformedScheme _) | canBeRelative ->
+      URIBS.parseRelativeRef URIBS.laxURIParserOptions (encodeUtf8 link)
+        & either (throwError . UPEInvalid) (pure . AnyURIRef)
+    Left err -> throwError $ UPEInvalid err
+    Right uri -> pure $ AnyURIRef uri
+
+  -- We stick to our infrastructure by continuing to operate on the datatypes
+  -- from 'modern-uri', which are used in the 'req' library. First we
+  -- serialize our URI parsed with 'parseURI' so it becomes a 'ByteString'
+  -- with all the necessary special characters *percent-encoded*, and then
+  -- call 'mkURIBs'.
+  mkURIBs (serializeAnyURIRef uri)
+    -- Ideally, this exception should never be thrown, as the URI
+    -- already *percent-encoded* with 'parseURI' from 'uri-bytestring'
+    -- and 'mkURIBs' is only used to convert to 'URI' type from
+    -- 'modern-uri' package.
+    & handleJust fromException (throwError . UPEConversion)

--- a/tests/Test/Xrefcheck/URIParsingSpec.hs
+++ b/tests/Test/Xrefcheck/URIParsingSpec.hs
@@ -11,9 +11,9 @@ import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (testCase, (@?=))
 import Text.URI (URI)
 import Text.URI.QQ (uri)
-import URI.ByteString (SchemaError (..), URIParseError (..))
+import URI.ByteString qualified as URIBS
 
-import Xrefcheck.Verify (VerifyError (..), parseUri)
+import Xrefcheck.Data.URI (UriParseError (..), parseUri)
 
 test_uri :: [TestTree]
 test_uri =
@@ -36,20 +36,20 @@ test_uri =
   , testGroup "URI parsing should be unsuccessful"
       [ testCase "With the special characters anywhere else" do
           parseUri' "https://exa<mple.co>m/?q=a&p=b#fra{g}ment" >>=
-            (@?= Left (ExternalResourceInvalidUri MalformedPath))
+            (@?= Left (UPEInvalid URIBS.MalformedPath))
 
           parseUri' "https://example.com/pa[t]h/to[/]smth?q=a&p=b" >>=
-            (@?= Left (ExternalResourceInvalidUri MalformedPath))
+            (@?= Left (UPEInvalid URIBS.MalformedPath))
 
       , testCase "With malformed scheme" do
           parseUri' "https//example.com/" >>=
-            (@?= Left (ExternalResourceInvalidUri $ MalformedScheme MissingColon))
+            (@?= Left (UPEInvalid $ URIBS.MalformedScheme URIBS.MissingColon))
 
       , testCase "With malformed fragment" do
           parseUri' "https://example.com/?q=a&p=b#fra{g}ment" >>=
-            (@?= Left (ExternalResourceInvalidUri MalformedFragment))
+            (@?= Left (UPEInvalid URIBS.MalformedFragment))
       ]
   ]
   where
-    parseUri' :: Text -> IO $ Either VerifyError URI
-    parseUri' = runExceptT . parseUri
+    parseUri' :: Text -> IO $ Either UriParseError URI
+    parseUri' = runExceptT . parseUri False

--- a/tests/golden/check-autolinks/check-autolinks.bats
+++ b/tests/golden/check-autolinks/check-autolinks.bats
@@ -34,7 +34,7 @@ assert_diff - <<EOF
 
      Permanent redirect found:
        -| http://www.commonmark.org
-       -> https://commonmark.org/
+       -> https://commonmark.org
           ^-- stopped before this one
 
 Invalid references dumped, 1 in total.


### PR DESCRIPTION
## Description

Problem: Currently, Xrefcheck can follow redirects with an absolute location link, but it cannot handle relative ones.

Solution: After parsing the location link, obtain the corresponding absolute link by using the original request one.

## Related issue(s)

Fixes #270 

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](https://github.com/serokell/xrefcheck/tree/master/README.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](https://github.com/serokell/xrefcheck/tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](https://github.com/serokell/style/blob/master/haskell.md).
