### PR TITLE
[Chore] Fix symlinks test on Windows Git Bash

### DIFF
--- a/tests/golden/check-symlinks/check-symlinks.bats
+++ b/tests/golden/check-symlinks/check-symlinks.bats
@@ -17,6 +17,11 @@ load '../helpers'
 
   cd $TEST_TEMP_DIR
   touch dir/a
+
+  # Required for Git Bash on Windows to have symlinks properly working, which also requires either
+  # to be running as an admin or having developer mode turned on.
+  export MSYS=winsymlinks:nativestrict
+
   ln -s ../d.md outside.md
   ln -s dir/b.md ok.md
   ln -s dir/c.md broken.md
@@ -35,6 +40,11 @@ load '../helpers'
 
   cd $TEST_TEMP_DIR
   touch dir/a
+
+  # Required for Git Bash on Windows to have symlinks properly working, which also requires either
+  # to be running as an admin or having developer mode turned on.
+  export MSYS=winsymlinks:nativestrict
+
   ln -s ../d.md outside.md
   ln -s dir/b.md ok.md
   ln -s dir/c.md broken.md


### PR DESCRIPTION
## Description

The current Windows CI started to fail at some point because it is running within an environment in which symlinks don't work properly.

Having symlinks working on Windows Git Bash has some requirements:

* Enable symlinks during `git for windows` installation, which is [already met](https://github.com/actions/runner-images/blob/win22/20230508.3/images/win/scripts/Installers/Install-Git.ps1#L23).
* Be either running as an admin or having Windows developer mode turned on, which is also already met.
* Use an environment variable to properly enable symlinks, which is being added with this PR.

## Related issue(s)

None

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](https://github.com/serokell/xrefcheck/tree/master/README.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](https://github.com/serokell/xrefcheck/tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](https://github.com/serokell/style/blob/master/haskell.md).
