### PR TITLE
Compatibility with `optparse-applicative-0.18`

### DIFF
--- a/src/Xrefcheck/CLI.hs
+++ b/src/Xrefcheck/CLI.hs
@@ -31,7 +31,7 @@ import Options.Applicative
   (Mod, OptionFields, Parser, ReadM, auto, command, eitherReader, execParser, flag, flag',
   footerDoc, fullDesc, help, helpDoc, helper, hsubparser, info, infoOption, long, metavar, option,
   progDesc, short, strOption, switch, value)
-import Options.Applicative.Help.Pretty (Doc, displayS, fill, fillSep, indent, renderPretty, text)
+import Options.Applicative.Help.Pretty (Doc, fill, fillSep, indent, pretty)
 import Options.Applicative.Help.Pretty qualified as Pretty
 import Text.Interpolation.Nyan
 
@@ -289,18 +289,14 @@ getCommand = do
     footerDoc (pure ignoreModesMsg)
 
 ignoreModesMsg :: Doc
-ignoreModesMsg = text $ header <> body
+ignoreModesMsg = header <> body
   where
     header = "To ignore a link in your markdown, \
              \include \"<!-- xrefcheck: ignore <mode> -->\"\n\
              \comment with one of these modes:\n"
-    body = displayS (renderPretty pageParam pageWidth doc) ""
+    body = fillSep $ map formatDesc modeDescr
 
-    pageWidth = 80
-    pageParam = 1
-
-    doc = fillSep $ map formatDesc modeDescr
-
+    modeDescr :: [(String, [String])]
     modeDescr =
       [ ("  \"link\"",      L.words "Ignore the link right after the comment.")
       , ("  \"paragraph\"", L.words "Ignore the whole paragraph after the comment.")
@@ -312,5 +308,5 @@ ignoreModesMsg = text $ header <> body
     descrIndent = 27 - modeIndent
 
     formatDesc (mode, descr) =
-      fill modeIndent (text mode) <>
-      indent descrIndent (fillSep $ map text descr)
+      fill modeIndent (pretty mode) <>
+      indent descrIndent (fillSep $ map pretty descr)

--- a/src/Xrefcheck/Verify.hs
+++ b/src/Xrefcheck/Verify.hs
@@ -768,7 +768,7 @@ checkExternalResource followed config@Config{..} link
           other -> throwError $ ExternalResourceSomeError $ show other
       where
         retryAfterInfo :: Response a -> Maybe RetryAfter
-        retryAfterInfo = readMaybe . decodeUtf8 <=< L.lookup hRetryAfter . responseHeaders
+        retryAfterInfo = readMaybe . decodeUtf8 @Text <=< L.lookup hRetryAfter . responseHeaders
 
     checkFtp :: URI -> Bool -> ExceptT VerifyError IO ()
     checkFtp uri secure = do


### PR DESCRIPTION
`optparse-applicative-0.18` switched to `prettyprinter`, so some reexports are missing now.
- https://github.com/pcapriotti/optparse-applicative/issues/481

```
Building library for xrefcheck-0.2.2..
[17 of 19] Compiling Xrefcheck.CLI    ( src/Xrefcheck/CLI.hs, /Users/abel/bin/src/xrefcheck/dist-newstyle/build/x86_64-osx/ghc-9.2.8/xrefcheck-0.2.2/build/Xrefcheck/CLI.o, /Users/abel/bin/src/xrefcheck/dist-newstyle/build/x86_64-osx/ghc-9.2.8/xrefcheck-0.2.2/build/Xrefcheck/CLI.dyn_o )

src/Xrefcheck/CLI.hs:34:46: error:
    Module ‘Options.Applicative.Help.Pretty’ does not export ‘displayS’
   |
34 | import Options.Applicative.Help.Pretty (Doc, displayS, fill, fillSep, indent, renderPretty, text)
   |                                              ^^^^^^^^

src/Xrefcheck/CLI.hs:34:79: error:
    Module
    ‘Options.Applicative.Help.Pretty’
    does not export
    ‘renderPretty’
   |
34 | import Options.Applicative.Help.Pretty (Doc, displayS, fill, fillSep, indent, renderPretty, text)
   |                                                                               ^^^^^^^^^^^^

src/Xrefcheck/CLI.hs:34:93: error:
    Module ‘Options.Applicative.Help.Pretty’ does not export ‘text’
   |
34 | import Options.Applicative.Help.Pretty (Doc, displayS, fill, fillSep, indent, renderPretty, text)
   |                                                                                             ^^^^
Error: cabal: Failed to build xrefcheck-0.2.2
```


This PR restores compatibility with the latest `optparse-applicative`.

I simplified the code to display the help text, but the rendering still looks fine:
```
To ignore a link in your markdown, include "<!-- xrefcheck: ignore <mode> -->"
comment with one of these modes:
  "link"                   Ignore the link right after the comment.
  "paragraph"              Ignore the whole paragraph after the comment.
  "file"                   This mode can only be used at the top of markdown or
                           right after comments at the top.
```
So maybe the code was unnecessary complicated to begin with.

On hackage I added upper bound `optparse-applicative < 0.18`, e.g. https://hackage.haskell.org/package/xrefcheck-0.2.2/revisions/.