### PR TITLE
[Chore] Use LTS-21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        stack: ["2.7.5"]
+        stack: ["2.15.7"]
         ghc: ["9.4.8"]
         include:
           - ghc: "9.4.8"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,9 @@ jobs:
     strategy:
       matrix:
         stack: ["2.7.5"]
-        ghc: ["9.0.2"]
+        ghc: ["9.4.8"]
         include:
-          - ghc: "9.0.2"
+          - ghc: "9.4.8"
             stackyaml: stack.yaml
     steps:
     - uses: actions/checkout@v4

--- a/flake.lock
+++ b/flake.lock
@@ -470,43 +470,6 @@
         "type": "github"
       }
     },
-    "ghc98X": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696643148,
-        "narHash": "sha256-E02DfgISH7EvvNAu0BHiPvl1E5FGMDi0pWdNZtIBC9I=",
-        "ref": "ghc-9.8",
-        "rev": "443e870d977b1ab6fc05f47a9a17bc49296adbd6",
-        "revCount": 61642,
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      },
-      "original": {
-        "ref": "ghc-9.8",
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      }
-    },
-    "ghc99": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1701580282,
-        "narHash": "sha256-drA01r3JrXnkKyzI+owMZGxX0JameMzjK0W5jJE/+V4=",
-        "ref": "refs/heads/master",
-        "rev": "f5eb0f2982e9cf27515e892c4bdf634bcfb28459",
-        "revCount": 62197,
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      },
-      "original": {
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      }
-    },
     "gitignore-nix": {
       "flake": false,
       "locked": {
@@ -545,11 +508,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1704846187,
-        "narHash": "sha256-eCxEI6PXPsxHSTgnnpEg2fxVbGxIn4ZFYX1M394Tcwc=",
+        "lastModified": 1722990360,
+        "narHash": "sha256-FkfLz/+j02/3t9QZaZBOXmn/noA2Gt0MlkvSNlhT4QM=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "5889a4e063c158261aaad4ad0720ddc4ee6a4a20",
+        "rev": "b21329e3b7431ad475ffc848e55be3b7a795ea9c",
         "type": "github"
       },
       "original": {
@@ -583,14 +546,17 @@
         "cardano-shell": "cardano-shell",
         "flake-compat": "flake-compat",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
-        "ghc98X": "ghc98X",
-        "ghc99": "ghc99",
         "hackage": "hackage",
         "hls-1.10": "hls-1.10",
         "hls-2.0": "hls-2.0",
         "hls-2.2": "hls-2.2",
         "hls-2.3": "hls-2.3",
         "hls-2.4": "hls-2.4",
+        "hls-2.5": "hls-2.5",
+        "hls-2.6": "hls-2.6",
+        "hls-2.7": "hls-2.7",
+        "hls-2.8": "hls-2.8",
+        "hls-2.9": "hls-2.9",
         "hpc-coveralls": "hpc-coveralls",
         "hydra": "hydra",
         "iserv-proxy": "iserv-proxy",
@@ -605,16 +571,17 @@
         "nixpkgs-2211": "nixpkgs-2211",
         "nixpkgs-2305": "nixpkgs-2305",
         "nixpkgs-2311": "nixpkgs-2311",
+        "nixpkgs-2405": "nixpkgs-2405",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "old-ghc-nix": "old-ghc-nix",
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1704847818,
-        "narHash": "sha256-LQzIY21CkCirSSR+7fB5uQjlFGBzCvjA0x/TuPXT3V8=",
+        "lastModified": 1722991826,
+        "narHash": "sha256-iCUh65fJZq9XbEUNTWrpOeC07kYR8rSboD9hg9CIhFE=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "28fceff2ef63b5bd0717371df5500a58ace98ee6",
+        "rev": "ed955c92e9bc2240b3d402ff1c9c8479e3fa1e4a",
         "type": "github"
       },
       "original": {
@@ -749,6 +716,91 @@
         "type": "github"
       }
     },
+    "hls-2.5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1701080174,
+        "narHash": "sha256-fyiR9TaHGJIIR0UmcCb73Xv9TJq3ht2ioxQ2mT7kVdc=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "27f8c3d3892e38edaef5bea3870161815c4d014c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.5.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1705325287,
+        "narHash": "sha256-+P87oLdlPyMw8Mgoul7HMWdEvWP/fNlo8jyNtwME8E8=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "6e0b342fa0327e628610f2711f8c3e4eaaa08b1e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.6.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1708965829,
+        "narHash": "sha256-LfJ+TBcBFq/XKoiNI7pc4VoHg4WmuzsFxYJ3Fu+Jf+M=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "50322b0a4aefb27adc5ec42f5055aaa8f8e38001",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.7.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.8": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1715153580,
+        "narHash": "sha256-Vi/iUt2pWyUJlo9VrYgTcbRviWE0cFO6rmGi9rmALw0=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "dd1be1beb16700de59e0d6801957290bcf956a0a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.8.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.9": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1718469202,
+        "narHash": "sha256-THXSz+iwB1yQQsr/PY151+2GvtoJnTIB2pIQ4OzfjD4=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "40891bccb235ebacce020b598b083eab9dda80f1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.9.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hpc-coveralls": {
       "flake": false,
       "locked": {
@@ -855,18 +907,18 @@
     "iserv-proxy": {
       "flake": false,
       "locked": {
-        "lastModified": 1691634696,
-        "narHash": "sha256-MZH2NznKC/gbgBu8NgIibtSUZeJ00HTLJ0PlWKCBHb0=",
-        "ref": "hkm/remote-iserv",
-        "rev": "43a979272d9addc29fbffc2e8542c5d96e993d73",
-        "revCount": 14,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
+        "lastModified": 1717479972,
+        "narHash": "sha256-7vE3RQycHI1YT9LHJ1/fUaeln2vIpYm6Mmn8FTpYeVo=",
+        "owner": "stable-haskell",
+        "repo": "iserv-proxy",
+        "rev": "2ed34002247213fc435d0062350b91bab920626e",
+        "type": "github"
       },
       "original": {
-        "ref": "hkm/remote-iserv",
-        "type": "git",
-        "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
+        "owner": "stable-haskell",
+        "ref": "iserv-syms",
+        "repo": "iserv-proxy",
+        "type": "github"
       }
     },
     "iserv-proxy_2": {
@@ -1298,11 +1350,11 @@
     },
     "nixpkgs-2305": {
       "locked": {
-        "lastModified": 1701362232,
-        "narHash": "sha256-GVdzxL0lhEadqs3hfRLuj+L1OJFGiL/L7gCcelgBlsw=",
+        "lastModified": 1705033721,
+        "narHash": "sha256-K5eJHmL1/kev6WuqyqqbS1cdNnSidIZ3jeqJ7GbrYnQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d2332963662edffacfddfad59ff4f709dde80ffe",
+        "rev": "a1982c92d8980a0114372973cbdfe0a307f1bdea",
         "type": "github"
       },
       "original": {
@@ -1314,16 +1366,32 @@
     },
     "nixpkgs-2311": {
       "locked": {
-        "lastModified": 1701386440,
-        "narHash": "sha256-xI0uQ9E7JbmEy/v8kR9ZQan6389rHug+zOtZeZFiDJk=",
+        "lastModified": 1719957072,
+        "narHash": "sha256-gvFhEf5nszouwLAkT9nWsDzocUTqLWHuL++dvNjMp9I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "293822e55ec1872f715a66d0eda9e592dc14419f",
+        "rev": "7144d6241f02d171d25fba3edeaf15e0f2592105",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-23.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2405": {
+      "locked": {
+        "lastModified": 1720122915,
+        "narHash": "sha256-Nby8WWxj0elBu1xuRaUcRjPi/rU3xVbkAt2kj4QwX2U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "835cf2d3f37989c5db6585a28de967a667a75fb1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-24.05-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -1362,17 +1430,17 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1694822471,
-        "narHash": "sha256-6fSDCj++lZVMZlyqOe9SIOL8tYSBz1bI8acwovRwoX8=",
+        "lastModified": 1720181791,
+        "narHash": "sha256-i4vJL12/AdyuQuviMMd1Hk2tsGt02hDNhA0Zj1m16N8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
+        "rev": "4284c2b73c8bce4b46a6adf23e16d9e2ec8da4bb",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
-        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
         "type": "github"
       }
     },
@@ -1583,11 +1651,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1704845382,
-        "narHash": "sha256-nzbV0Z9KIEjglN/I1qNIRvi80y8EqebxLI7hn8EvJMI=",
+        "lastModified": 1722989507,
+        "narHash": "sha256-5jKfvNA9HW7juL7z1Hf6827FbzCy5S9RmMBG4jGqLdw=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "518634e42dfbecf2bae7f3af3eb6fa8fe4fcdca2",
+        "rev": "cb1856fdb81fa9a5b1fb5cd8e48db1fa131699d5",
         "type": "github"
       },
       "original": {

--- a/ftp-tests/Test/Xrefcheck/FtpLinks.hs
+++ b/ftp-tests/Test/Xrefcheck/FtpLinks.hs
@@ -7,8 +7,9 @@ module Test.Xrefcheck.FtpLinks
   , test_FtpLinks
   ) where
 
-import Universum
+import Universum hiding ((.~))
 
+import Control.Lens ((.~))
 import Data.Tagged (Tagged, untag)
 import Options.Applicative (help, long, strOption)
 import Test.Tasty (TestTree, askOption, testGroup)

--- a/package.yaml
+++ b/package.yaml
@@ -65,6 +65,7 @@ ghc-options:
   - -Wno-all-missed-specialisations
   - -Wno-prepositive-qualified-module
   - -Wno-monomorphism-restriction
+  - -Wno-missing-kind-signatures
 
   # This option avoids a warning on case-insensitive systems:
   # https://github.com/haskell/cabal/issues/4739

--- a/package.yaml
+++ b/package.yaml
@@ -149,6 +149,7 @@ tests:
       - directory
       - firefly
       - http-types
+      - lens
       - modern-uri
       - nyan-interpolation
       - o-clock
@@ -170,6 +171,7 @@ tests:
     generated-other-modules:
       - Paths_xrefcheck
     dependencies:
+      - lens
       - optparse-applicative
       - tagged
       - tasty

--- a/src/Xrefcheck/Config.hs
+++ b/src/Xrefcheck/Config.hs
@@ -11,9 +11,9 @@ module Xrefcheck.Config
   , defConfigText
   ) where
 
-import Universum
+import Universum hiding ((.~))
 
-import Control.Lens (makeLensesWith)
+import Control.Lens (makeLensesWith, (.~))
 import Data.Aeson (genericParseJSON)
 import Data.Yaml (FromJSON (..), decodeEither', prettyPrintParseException, withText)
 import Text.Regex.TDFA.Text ()

--- a/src/Xrefcheck/Core.hs
+++ b/src/Xrefcheck/Core.hs
@@ -9,9 +9,9 @@
 
 module Xrefcheck.Core where
 
-import Universum
+import Universum hiding ((^..))
 
-import Control.Lens (folded, makeLenses, makePrisms, to, united)
+import Control.Lens (folded, makeLenses, makePrisms, to, united, (^..))
 import Data.Aeson (FromJSON (..), withText)
 import Data.Char (isAlphaNum)
 import Data.Char qualified as C

--- a/src/Xrefcheck/Scan.hs
+++ b/src/Xrefcheck/Scan.hs
@@ -31,9 +31,9 @@ module Xrefcheck.Scan
   , scanRepo
   ) where
 
-import Universum
+import Universum hiding (_1, (%~))
 
-import Control.Lens (makeLensesWith)
+import Control.Lens (_1, makeLensesWith, (%~))
 import Data.Aeson (FromJSON (..), genericParseJSON, withText)
 import Data.Map qualified as M
 import Data.Reflection (Given)

--- a/src/Xrefcheck/Scanners/Markdown.hs
+++ b/src/Xrefcheck/Scanners/Markdown.hs
@@ -16,11 +16,11 @@ module Xrefcheck.Scanners.Markdown
   , makeError
   ) where
 
-import Universum
+import Universum hiding (use)
 
 import CMarkGFM
   (Node (..), NodeType (..), PosInfo (..), commonmarkToNode, extAutolink, optFootnotes)
-import Control.Lens (_Just, makeLenses, makeLensesFor, (.=))
+import Control.Lens (_Just, makeLenses, makeLensesFor, use, (.=))
 import Control.Monad.Trans.Writer.CPS (Writer, runWriter, tell)
 import Data.Aeson (FromJSON (..), genericParseJSON)
 import Data.ByteString.Lazy qualified as BSL

--- a/src/Xrefcheck/Util.hs
+++ b/src/Xrefcheck/Util.hs
@@ -17,9 +17,9 @@ module Xrefcheck.Util
   , module Xrefcheck.Util.Interpolate
   ) where
 
-import Universum
+import Universum hiding ((.~))
 
-import Control.Lens (LensRules, lensField, lensRules, mappingNamer)
+import Control.Lens (LensRules, lensField, lensRules, mappingNamer, (.~))
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Casing (aesonPrefix, camelCase)
 import Data.Fixed (Fixed (MkFixed), HasResolution (resolution))

--- a/src/Xrefcheck/Verify.hs
+++ b/src/Xrefcheck/Verify.hs
@@ -768,7 +768,9 @@ checkExternalResource followed config@Config{..} link
           other -> throwError $ ExternalResourceSomeError $ show other
       where
         retryAfterInfo :: Response a -> Maybe RetryAfter
-        retryAfterInfo = readMaybe . decodeUtf8 <=< L.lookup hRetryAfter . responseHeaders
+        retryAfterInfo =
+          readMaybe @_ @Text . decodeUtf8 <=<
+          L.lookup hRetryAfter . responseHeaders
 
     checkFtp :: URI -> Bool -> ExceptT VerifyError IO ()
     checkFtp uri secure = do

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,8 +12,5 @@ packages:
 extra-deps:
 - firefly-0.2.1.0@sha256:e9d73486464c3e223ec457e02b30ddd5b550fdbf6292b268c64581e2b07d888b,1519
 - cmark-gfm-0.2.5
-- git: https://github.com/serokell/nyan-interpolation
-  commit: 348355385466d6d0116251b463a2842ecce0360d
-  subdirs:
-  - full
-  - core
+- nyan-interpolation-core-0.9.2
+- nyan-interpolation-0.9.2

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,10 +1,10 @@
-# SPDX-FileCopyrightText: 2018-2020 Serokell <https://serokell.io>
+# SPDX-FileCopyrightText: 2018-2023 Serokell <https://serokell.io>
 #
 # SPDX-License-Identifier: MPL-2.0
 
 # To update hackage and stackage indexes used by CI run:
 # $ niv update hackage.nix; niv update stackage.nix
-resolver: lts-19.13
+resolver: lts-21.25
 
 packages:
 - .

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-# To update hackage and stackage indexes used by CI run:
-# $ niv update hackage.nix; niv update stackage.nix
 resolver: lts-21.25
 
 packages:
@@ -11,6 +9,5 @@ packages:
 
 extra-deps:
 - firefly-0.2.1.0@sha256:e9d73486464c3e223ec457e02b30ddd5b550fdbf6292b268c64581e2b07d888b,1519
-- cmark-gfm-0.2.5
 - nyan-interpolation-core-0.9.2
 - nyan-interpolation-0.9.2

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -34,7 +34,7 @@ packages:
     hackage: nyan-interpolation-0.9.2
 snapshots:
 - completed:
-    sha256: ef98d70e4018bf01feb00ccdcd33ab26d056dbb71b38057c78fdd0d1ec671c85
-    size: 618740
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/13.yaml
-  original: lts-19.13
+    sha256: a81fb3877c4f9031e1325eb3935122e608d80715dc16b586eb11ddbff8671ecd
+    size: 640086
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/21/25.yaml
+  original: lts-21.25

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -12,13 +12,6 @@ packages:
   original:
     hackage: firefly-0.2.1.0@sha256:e9d73486464c3e223ec457e02b30ddd5b550fdbf6292b268c64581e2b07d888b,1519
 - completed:
-    hackage: cmark-gfm-0.2.5@sha256:a53b3c6ed20b5476ae18df5f28ababbb6ec8543f9a0758f0381a532d7a879fc0,5188
-    pantry-tree:
-      sha256: 8d137f125ee673d5c6b193c85657ea94124c90869edada72633df282e33058e0
-      size: 4556
-  original:
-    hackage: cmark-gfm-0.2.5
-- completed:
     hackage: nyan-interpolation-core-0.9.2@sha256:930202fafc4e9472f9aed3d216a459e23454db500bfd0e0a5af2a4e5c5202096,4523
     pantry-tree:
       sha256: 5781e80383996a6bea95a545e4f0e70466bebf0fe2d388f334cd42e9f35469d5

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -19,31 +19,19 @@ packages:
   original:
     hackage: cmark-gfm-0.2.5
 - completed:
-    commit: 348355385466d6d0116251b463a2842ecce0360d
-    git: https://github.com/serokell/nyan-interpolation
-    name: nyan-interpolation
+    hackage: nyan-interpolation-core-0.9.2@sha256:930202fafc4e9472f9aed3d216a459e23454db500bfd0e0a5af2a4e5c5202096,4523
     pantry-tree:
-      sha256: ede424e6010640f31a223865f2136570ca1870b5ae5ffeeebfc499c4f7043482
-      size: 714
-    subdir: full
-    version: '0.9'
+      sha256: 5781e80383996a6bea95a545e4f0e70466bebf0fe2d388f334cd42e9f35469d5
+      size: 1464
   original:
-    commit: 348355385466d6d0116251b463a2842ecce0360d
-    git: https://github.com/serokell/nyan-interpolation
-    subdir: full
+    hackage: nyan-interpolation-core-0.9.2
 - completed:
-    commit: 348355385466d6d0116251b463a2842ecce0360d
-    git: https://github.com/serokell/nyan-interpolation
-    name: nyan-interpolation-core
+    hackage: nyan-interpolation-0.9.2@sha256:fb0b07ef6a9f8ca4d2e1db2f2df841c649556d9f6cff894ebf6b9ffbb7c25003,4276
     pantry-tree:
-      sha256: 4802161ce5d38f895e3b5106c789bfbe20b8d12c2f6c5fcba3999bec105283bc
-      size: 1516
-    subdir: core
-    version: '0.9'
+      sha256: 258878b8660782bef633fe3800c08fff2fa90165fd2a0793fa73836d8ff274c3
+      size: 662
   original:
-    commit: 348355385466d6d0116251b463a2842ecce0360d
-    git: https://github.com/serokell/nyan-interpolation
-    subdir: core
+    hackage: nyan-interpolation-0.9.2
 snapshots:
 - completed:
     sha256: ef98d70e4018bf01feb00ccdcd33ab26d056dbb71b38057c78fdd0d1ec671c85

--- a/tests/Test/Xrefcheck/AnchorsInHeadersSpec.hs
+++ b/tests/Test/Xrefcheck/AnchorsInHeadersSpec.hs
@@ -5,8 +5,9 @@
 
 module Test.Xrefcheck.AnchorsInHeadersSpec where
 
-import Universum
+import Universum hiding ((^.))
 
+import Control.Lens ((^.))
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (testCase, (@?=))
 

--- a/tests/Test/Xrefcheck/AnchorsSpec.hs
+++ b/tests/Test/Xrefcheck/AnchorsSpec.hs
@@ -5,8 +5,9 @@
 
 module Test.Xrefcheck.AnchorsSpec where
 
-import Universum
+import Universum hiding ((^.))
 
+import Control.Lens ((^.))
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (testCase, (@?=))
 

--- a/tests/Test/Xrefcheck/ConfigSpec.hs
+++ b/tests/Test/Xrefcheck/ConfigSpec.hs
@@ -5,10 +5,11 @@
 
 module Test.Xrefcheck.ConfigSpec where
 
-import Universum
+import Universum hiding ((.~))
 
 import Control.Concurrent (forkIO, killThread)
 import Control.Exception qualified as E
+import Control.Lens ((.~))
 
 import Data.List (isInfixOf)
 import Data.Yaml (ParseException (..), decodeEither')

--- a/tests/Test/Xrefcheck/IgnoreAnnotationsSpec.hs
+++ b/tests/Test/Xrefcheck/IgnoreAnnotationsSpec.hs
@@ -5,9 +5,10 @@
 
 module Test.Xrefcheck.IgnoreAnnotationsSpec where
 
-import Universum
+import Universum hiding ((^.))
 
 import CMarkGFM (PosInfo (..))
+import Control.Lens ((^.))
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (testCase, (@?=))
 

--- a/tests/Test/Xrefcheck/IgnoreRegexSpec.hs
+++ b/tests/Test/Xrefcheck/IgnoreRegexSpec.hs
@@ -5,8 +5,9 @@
 
 module Test.Xrefcheck.IgnoreRegexSpec where
 
-import Universum
+import Universum hiding ((.~), (^.))
 
+import Control.Lens ((.~), (^.))
 import Data.Reflection (give)
 import Data.Yaml (decodeEither')
 import Test.Tasty (TestTree, testGroup)

--- a/tests/Test/Xrefcheck/RedirectChainSpec.hs
+++ b/tests/Test/Xrefcheck/RedirectChainSpec.hs
@@ -5,8 +5,9 @@
 
 module Test.Xrefcheck.RedirectChainSpec where
 
-import Universum
+import Universum hiding ((.~))
 
+import Control.Lens ((.~))
 import Data.CaseInsensitive qualified as CI
 import Data.Map qualified as M
 import Network.HTTP.Types (mkStatus)

--- a/tests/Test/Xrefcheck/RedirectConfigSpec.hs
+++ b/tests/Test/Xrefcheck/RedirectConfigSpec.hs
@@ -5,8 +5,9 @@
 
 module Test.Xrefcheck.RedirectConfigSpec where
 
-import Universum
+import Universum hiding ((%~), (.~))
 
+import Control.Lens ((%~), (.~))
 import Data.CaseInsensitive qualified as CI
 import Data.Map qualified as M
 import Network.HTTP.Types (mkStatus)

--- a/tests/Test/Xrefcheck/TimeoutSpec.hs
+++ b/tests/Test/Xrefcheck/TimeoutSpec.hs
@@ -5,8 +5,9 @@
 
 module Test.Xrefcheck.TimeoutSpec where
 
-import Universum
+import Universum hiding ((.~))
 
+import Control.Lens ((.~))
 import Data.CaseInsensitive qualified as CI
 import Data.Map qualified as M
 import Data.Set qualified as S

--- a/tests/Test/Xrefcheck/TrailingSlashSpec.hs
+++ b/tests/Test/Xrefcheck/TrailingSlashSpec.hs
@@ -5,8 +5,9 @@
 
 module Test.Xrefcheck.TrailingSlashSpec where
 
-import Universum
+import Universum hiding ((.~))
 
+import Control.Lens ((.~))
 import System.Directory (doesFileExist)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (assertFailure, testCase)

--- a/tests/Test/Xrefcheck/UtilRequests.hs
+++ b/tests/Test/Xrefcheck/UtilRequests.hs
@@ -15,10 +15,11 @@ module Test.Xrefcheck.UtilRequests
   , VerifyLinkTestEntry (..)
   ) where
 
-import Universum
+import Universum hiding ((.~))
 
 import Control.Concurrent (forkIO, killThread)
 import Control.Exception qualified as E
+import Control.Lens ((.~))
 import Data.Map qualified as M
 import Data.Set qualified as S
 import Test.Tasty.HUnit (assertBool)

--- a/tests/golden/check-autolinks/check-autolinks.bats
+++ b/tests/golden/check-autolinks/check-autolinks.bats
@@ -16,7 +16,7 @@ assert_diff - <<EOF
 
   file-with-autolinks.md:
     - references:
-        - reference (external):
+        - reference (external) at src:6:22-52:
             - text: "https://www.google.com/doodles"
             - link: https://www.google.com/doodles
         - reference (external) at src:8:0-18:


### PR DESCRIPTION
## Description

This PR updated the Stackage resolver to the latest one and does some related cleaning.

## Related issue(s)

Resolves #285 

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](https://github.com/serokell/xrefcheck/tree/master/README.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](https://github.com/serokell/xrefcheck/tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](https://github.com/serokell/style/blob/master/haskell.md).

#### ✓ Release Checklist

- [ ] I updated the version number in `package.yaml`.
- [ ] I updated the [changelog](https://github.com/serokell/xrefcheck/tree/master/CHANGES.md) and moved everything
      under the "Unreleased" section to a new section for this release version.
- [ ] (After merging) I edited the [auto-release](https://github.com/serokell/xrefcheck/releases/tag/auto-release).
    * Change the tag and title using the format `vX.Y.Z`.
    * Write a summary of all user-facing changes.
    * Deselect the "This is a pre-release" checkbox at the bottom.
- [ ] (After merging) I updated [`xrefcheck-action`](https://github.com/serokell/xrefcheck-action#updating-supported-versions).
- [ ] (After merging) I uploaded the package to [hackage](https://hackage.haskell.org/package/xrefcheck).
