### PR TITLE
[Chore] Update "actions/checkout"

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -13,7 +13,7 @@ jobs:
   release:
     runs-on: [self-hosted, nix]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Create a pre-release
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
   validate:
     runs-on: [self-hosted, nix]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: reuse
         run: nix build -L .#checks.x86_64-linux.reuse-lint
@@ -49,7 +49,7 @@ jobs:
           - ghc: "9.0.2"
             stackyaml: stack.yaml
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: 'true'
 
@@ -109,7 +109,7 @@ jobs:
   xrefcheck-build-and-test-nix:
     runs-on: [self-hosted, nix]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -128,7 +128,7 @@ jobs:
           echo "WINDOWS_BINARY_PATH=$(readlink -f result)" >> $GITHUB_ENV
 
       - name: Upload windows executable
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: xrefcheck-windows
           path: ${{ env.WINDOWS_BINARY_PATH }}/bin/*
@@ -142,7 +142,7 @@ jobs:
           echo "STATIC_BINARY_PATH=$(readlink -f result)" >> $GITHUB_ENV
 
       - name: Upload static binary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: xrefcheck-static
           path: ${{ env.STATIC_BINARY_PATH }}/bin/xrefcheck

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -10,7 +10,7 @@ jobs:
   run-danger-checks:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - uses: ruby/setup-ruby@v1

--- a/.github/workflows/dockerhub-release.yml
+++ b/.github/workflows/dockerhub-release.yml
@@ -13,7 +13,7 @@ jobs:
   dockerhub-release:
     runs-on: [self-hosted, nix]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Push release image to dockerhub
         run: |


### PR DESCRIPTION
Problem: node16 is now deprecated and github-runner provided by nixpkgs
no longer supports this runtime. However, "actions/checkout@v3" uses
this runtime.

Solution: Update CI pipeline to use "actions/checkout@v4".
