### PR TITLE
[Chore] Update development setup

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -62,7 +62,7 @@
 
     in
       pkgs.lib.lists.foldr pkgs.lib.recursiveUpdate {} [
-        { inherit (flake) packages apps; }
+        { inherit (flake) packages apps devShells; }
         {
           legacyPackages = pkgs;
 

--- a/ftp-tests/Test/Xrefcheck/FtpLinks.hs
+++ b/ftp-tests/Test/Xrefcheck/FtpLinks.hs
@@ -9,7 +9,7 @@ module Test.Xrefcheck.FtpLinks
 
 import Universum
 
-import Data.Tagged (Tagged, untag)
+import Data.Tagged (untag)
 import Options.Applicative (help, long, strOption)
 import Test.Tasty (TestTree, askOption, testGroup)
 import Test.Tasty.HUnit (assertBool, assertFailure, testCase, (@?=))
@@ -36,8 +36,8 @@ instance IsOption FtpHostOpt where
   optionHelp = "[Test.Xrefcheck.FtpLinks] FTP host without trailing slash"
   parseValue v = FtpHostOpt <$> safeRead v
   optionCLParser = FtpHostOpt <$> strOption
-    (  long (untag (optionName :: Tagged FtpHostOpt String))
-    <> help (untag (optionHelp :: Tagged FtpHostOpt String))
+    (  long (untag @FtpHostOpt optionName)
+    <> help (untag @FtpHostOpt optionHelp)
     )
 
 config :: Config

--- a/package.yaml
+++ b/package.yaml
@@ -142,6 +142,8 @@ tests:
     generated-other-modules:
       - Paths_xrefcheck
     dependencies:
+      - optparse-applicative
+      - tagged
       - case-insensitive
       - cmark-gfm
       - containers

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -9,7 +9,12 @@ module Main
 import Universum
 
 import Test.Tasty
+import Test.Tasty.Ingredients (Ingredient)
+import Test.Xrefcheck.Util (mockServerOptions)
 import Tree (tests)
 
 main :: IO ()
-main = tests >>= defaultMain
+main = tests >>= defaultMainWithIngredients ingredients
+
+ingredients :: [Ingredient]
+ingredients = includingOptions mockServerOptions : defaultIngredients

--- a/tests/Test/Xrefcheck/Util.hs
+++ b/tests/Test/Xrefcheck/Util.hs
@@ -7,7 +7,10 @@ module Test.Xrefcheck.Util where
 
 import Universum
 
+import Data.Tagged (untag)
 import Network.HTTP.Types (forbidden403, unauthorized401)
+import Options.Applicative (auto, help, long, option)
+import Test.Tasty.Options as Tasty (IsOption (..), OptionDescription (Option), safeRead)
 import Web.Firefly (ToResponse (..), route, run)
 
 import Xrefcheck.Core (Flavor)
@@ -18,7 +21,30 @@ parse :: Flavor -> ScanAction
 parse fl path =
   markdownScanner MarkdownConfig { mcFlavor = fl } path
 
-mockServer :: IO ()
-mockServer = run 3000 $ do
+mockServerUrl :: MockServerPort -> Text -> Text
+mockServerUrl (MockServerPort port) s = toText ("http://127.0.0.1:" <> show port <> s)
+
+mockServer :: MockServerPort -> IO ()
+mockServer (MockServerPort port) = run port $ do
   route "/401" $ pure $ toResponse ("" :: Text, unauthorized401)
   route "/403" $ pure $ toResponse ("" :: Text, forbidden403)
+
+-- | All options needed to configure the mock server.
+mockServerOptions :: [OptionDescription]
+mockServerOptions =
+  [ Tasty.Option (Proxy @MockServerPort)
+  ]
+
+-- | Option specifying FTP host.
+newtype MockServerPort = MockServerPort Int
+  deriving stock (Show, Eq)
+
+instance IsOption MockServerPort where
+  defaultValue = MockServerPort 3000
+  optionName = "mock-server-port"
+  optionHelp = "[Test.Xrefcheck.Util] Mock server port"
+  parseValue v = MockServerPort <$> safeRead v
+  optionCLParser = MockServerPort <$> option auto
+    (  long (untag @MockServerPort optionName)
+    <> help (untag @MockServerPort optionHelp)
+    )


### PR DESCRIPTION
* flake.nix: inherit devShells, so that `nix develop` works
* tests: configurable mock server port to avoid conflicts

With these changes I've been able to build the project and run its tests as follows

```
nix shell nixpkgs#haskellPackages.hpack nixpkgs#cabal-install
nix develop -c $SHELL
hpack
vsftpd \
   -orun_as_launching_user=yes \
   -olisten_port=2221 \
   -olisten=yes \
   -oftp_username=$(whoami) \
   -oanon_root=./ftp-tests/ftp_root \
   -opasv_min_port=2222 \
   -ohide_file='{.*}' \
   -odeny_file='{.*}' \
   -oseccomp_sandbox=no \
   -olog_ftp_protocol=yes \
   -oxferlog_enable=yes \
   -ovsftpd_log_file=./ftp.log &
cabal test ftp-tests --test-options="--ftp-host ftp://127.0.0.1:2221"
cabal test xrefcheck-tests --test-options="--mock-server-port 3001"
```