### PR TITLE
[Chore] Tests: golden files, add BATS_ACCEPT

### DIFF
--- a/tests/golden/check-anchors/check-anchors.bats
+++ b/tests/golden/check-anchors/check-anchors.bats
@@ -10,72 +10,13 @@ load '../helpers/bats-file/load'
 load '../helpers'
 
 @test "We report ambiguous anchor references" {
+  golden_file=$(realpath expected1.gold)
   to_temp xrefcheck -r ambiguous-anchors
-assert_diff - <<EOF
-=== Invalid references found ===
-
-  ➥  In file a.md
-     bad reference (file-local) at src:16:1-43:
-       - text: "ambiguous anchor in this file"
-       - anchor: some-text
-
-     Ambiguous reference to anchor 'some-text'
-       In file a.md
-       It could refer to either:
-         - some-text (header I) at src:6:1-11
-         - some-text (header I) at src:8:1-15
-         - some-text (header II) at src:12:1-12
-       Use of ambiguous anchors is discouraged because the target
-       can change silently while the document containing it evolves.
-
-  ➥  In file b.md
-     bad reference (relative) at src:7:1-48:
-       - text: "ambiguous anchor in other file"
-       - link: a.md
-       - anchor: some-text
-
-     Ambiguous reference to anchor 'some-text'
-       In file a.md
-       It could refer to either:
-         - some-text (header I) at src:6:1-11
-         - some-text (header I) at src:8:1-15
-         - some-text (header II) at src:12:1-12
-       Use of ambiguous anchors is discouraged because the target
-       can change silently while the document containing it evolves.
-
-Invalid references dumped, 2 in total.
-EOF
+  assert_diff
 }
 
 @test "We report references to non-existing anchors, giving hints about similar ones" {
+  golden_file=$(realpath expected2.gold)
   to_temp xrefcheck -r non-existing-anchors
-assert_diff - <<EOF
-=== Invalid references found ===
-
-  ➥  In file a.md
-     bad reference (file-local) at src:12:1-13:
-       - text: "broken"
-       - anchor: h3
-
-     Anchor 'h3' is not present, did you mean:
-         - h1 (header I) at src:6:1-4
-         - h2 (header II) at src:8:1-5
-
-  ➥  In file a.md
-     bad reference (file-local) at src:14:1-18:
-       - text: "broken"
-       - anchor: heading
-
-     Anchor 'heading' is not present, did you mean:
-         - the-heading (header I) at src:10:1-13
-
-  ➥  In file a.md
-     bad reference (file-local) at src:16:1-31:
-       - text: "broken"
-       - anchor: really-unique-anchor
-
-     Anchor 'really-unique-anchor' is not present
-
-Invalid references dumped, 3 in total.
-EOF
+  assert_diff
 }

--- a/tests/golden/check-anchors/expected1.gold
+++ b/tests/golden/check-anchors/expected1.gold
@@ -1,0 +1,32 @@
+=== Invalid references found ===
+
+  ➥  In file a.md
+     bad reference (file-local) at src:16:1-43:
+       - text: "ambiguous anchor in this file"
+       - anchor: some-text
+
+     Ambiguous reference to anchor 'some-text'
+       In file a.md
+       It could refer to either:
+         - some-text (header I) at src:6:1-11
+         - some-text (header I) at src:8:1-15
+         - some-text (header II) at src:12:1-12
+       Use of ambiguous anchors is discouraged because the target
+       can change silently while the document containing it evolves.
+
+  ➥  In file b.md
+     bad reference (relative) at src:7:1-48:
+       - text: "ambiguous anchor in other file"
+       - link: a.md
+       - anchor: some-text
+
+     Ambiguous reference to anchor 'some-text'
+       In file a.md
+       It could refer to either:
+         - some-text (header I) at src:6:1-11
+         - some-text (header I) at src:8:1-15
+         - some-text (header II) at src:12:1-12
+       Use of ambiguous anchors is discouraged because the target
+       can change silently while the document containing it evolves.
+
+Invalid references dumped, 2 in total.

--- a/tests/golden/check-anchors/expected2.gold
+++ b/tests/golden/check-anchors/expected2.gold
@@ -1,0 +1,27 @@
+=== Invalid references found ===
+
+  ➥  In file a.md
+     bad reference (file-local) at src:12:1-13:
+       - text: "broken"
+       - anchor: h3
+
+     Anchor 'h3' is not present, did you mean:
+         - h1 (header I) at src:6:1-4
+         - h2 (header II) at src:8:1-5
+
+  ➥  In file a.md
+     bad reference (file-local) at src:14:1-18:
+       - text: "broken"
+       - anchor: heading
+
+     Anchor 'heading' is not present, did you mean:
+         - the-heading (header I) at src:10:1-13
+
+  ➥  In file a.md
+     bad reference (file-local) at src:16:1-31:
+       - text: "broken"
+       - anchor: really-unique-anchor
+
+     Anchor 'really-unique-anchor' is not present
+
+Invalid references dumped, 3 in total.

--- a/tests/golden/check-autolinks/check-autolinks.bats
+++ b/tests/golden/check-autolinks/check-autolinks.bats
@@ -10,33 +10,7 @@ load '../helpers/bats-file/load'
 load '../helpers'
 
 @test "We're finding and checking autolinks" {
+  golden_file=$(realpath expected.gold)
   to_temp xrefcheck -v
-assert_diff - <<EOF
-=== Repository data ===
-
-  file-with-autolinks.md:
-    - references:
-        - reference (external):
-            - text: "https://www.google.com/doodles"
-            - link: https://www.google.com/doodles
-        - reference (external) at src:8:0-18:
-            - text: "www.commonmark.org"
-            - link: http://www.commonmark.org
-    - anchors:
-        none
-
-=== Invalid references found ===
-
-  ➥  In file file-with-autolinks.md
-     bad reference (external) at src:8:0-18:
-       - text: "www.commonmark.org"
-       - link: http://www.commonmark.org
-
-     Permanent redirect found:
-       -| http://www.commonmark.org
-       -> https://commonmark.org
-          ^-- stopped before this one
-
-Invalid references dumped, 1 in total.
-EOF
+  assert_diff
 }

--- a/tests/golden/check-autolinks/expected.gold
+++ b/tests/golden/check-autolinks/expected.gold
@@ -1,0 +1,26 @@
+=== Repository data ===
+
+  file-with-autolinks.md:
+    - references:
+        - reference (external):
+            - text: "https://www.google.com/doodles"
+            - link: https://www.google.com/doodles
+        - reference (external) at src:8:0-18:
+            - text: "www.commonmark.org"
+            - link: http://www.commonmark.org
+    - anchors:
+        none
+
+=== Invalid references found ===
+
+  ➥  In file file-with-autolinks.md
+     bad reference (external) at src:8:0-18:
+       - text: "www.commonmark.org"
+       - link: http://www.commonmark.org
+
+     Permanent redirect found:
+       -| http://www.commonmark.org
+       -> https://commonmark.org
+          ^-- stopped before this one
+
+Invalid references dumped, 1 in total.

--- a/tests/golden/check-backslash/check-backslash.bats
+++ b/tests/golden/check-backslash/check-backslash.bats
@@ -11,8 +11,9 @@ load '../helpers'
 
 
 @test "Checking files with backslash" {
+  golden_file=$(realpath expected.gold)
+
   cp a.md $TEST_TEMP_DIR
-  cp expected.gold $TEST_TEMP_DIR
   touch "$TEST_TEMP_DIR/a\a.md" || \
     return 0 # Cannot be tested on Windows
 
@@ -29,5 +30,5 @@ EOF
 
   to_temp xrefcheck -v
 
-  assert_diff expected.gold
+  assert_diff
 }

--- a/tests/golden/check-case-sensitivity-anchor/check-case-sensitivity-anchor.bats
+++ b/tests/golden/check-case-sensitivity-anchor/check-case-sensitivity-anchor.bats
@@ -11,13 +11,13 @@ load '../helpers'
 
 
 @test "GitHub anchors: check, ambiguous and similar detection is case-insensitive" {
+  golden_file=$(realpath expected1.gold)
   to_temp xrefcheck -c config-github.yaml
-
-  assert_diff expected1.gold
+  assert_diff
 }
 
 @test "GitLab anchors: check and ambiguous detection is case-sensitive, but similar detection is not"  {
+  golden_file=$(realpath expected2.gold)
   to_temp xrefcheck -c config-gitlab.yaml
-
-  assert_diff expected2.gold
+  assert_diff
 }

--- a/tests/golden/check-case-sensitivity-path/check-case-sensitivity-path.bats
+++ b/tests/golden/check-case-sensitivity-path/check-case-sensitivity-path.bats
@@ -11,13 +11,13 @@ load '../helpers'
 
 
 @test "GitHub paths: case-sensitive" {
+  golden_file=$(realpath expected.gold)
   to_temp xrefcheck -v -c config-github.yaml
-
-  assert_diff expected.gold
+  assert_diff
 }
 
 @test "GitLab paths: case-sensitive"  {
+  golden_file=$(realpath expected.gold)
   to_temp xrefcheck -v -c config-gitlab.yaml
-
-  assert_diff expected.gold
+  assert_diff
 }

--- a/tests/golden/check-cli/check-cli.bats
+++ b/tests/golden/check-cli/check-cli.bats
@@ -42,60 +42,21 @@ load '../helpers'
 }
 
 @test "Basic root, check errors report" {
+  golden_file=$(realpath expected1.gold)
   to_temp xrefcheck --root .
-
-  assert_diff - <<EOF
-=== Invalid references found ===
-
-  ➥  In file to-ignore/broken-link.md
-     bad reference (absolute) at src:7:1-25:
-       - text: "my link"
-       - link: /one/two/three
-       - anchor: -
-
-     File does not exist:
-       one/two/three
-
-Invalid references dumped, 1 in total.
-EOF
+  assert_diff
 }
 
 @test "Root with redundant slashes, check errors report" {
+  golden_file=$(realpath expected2.gold)
   to_temp xrefcheck --root ././///././././//./
-
-  assert_diff - <<EOF
-=== Invalid references found ===
-
-  ➥  In file to-ignore/broken-link.md
-     bad reference (absolute) at src:7:1-25:
-       - text: "my link"
-       - link: /one/two/three
-       - anchor: -
-
-     File does not exist:
-       one/two/three
-
-Invalid references dumped, 1 in total.
-EOF
+  assert_diff
 }
 
 @test "No root, check errors report" {
+  golden_file=$(realpath expected3.gold)
   to_temp xrefcheck
-
-  assert_diff - <<EOF
-=== Invalid references found ===
-
-  ➥  In file to-ignore/broken-link.md
-     bad reference (absolute) at src:7:1-25:
-       - text: "my link"
-       - link: /one/two/three
-       - anchor: -
-
-     File does not exist:
-       one/two/three
-
-Invalid references dumped, 1 in total.
-EOF
+  assert_diff
 }
 
 @test "Single file as root" {

--- a/tests/golden/check-cli/expected1.gold
+++ b/tests/golden/check-cli/expected1.gold
@@ -1,0 +1,12 @@
+=== Invalid references found ===
+
+  ➥  In file to-ignore/broken-link.md
+     bad reference (absolute) at src:7:1-25:
+       - text: "my link"
+       - link: /one/two/three
+       - anchor: -
+
+     File does not exist:
+       one/two/three
+
+Invalid references dumped, 1 in total.

--- a/tests/golden/check-cli/expected2.gold
+++ b/tests/golden/check-cli/expected2.gold
@@ -1,0 +1,12 @@
+=== Invalid references found ===
+
+  ➥  In file to-ignore/broken-link.md
+     bad reference (absolute) at src:7:1-25:
+       - text: "my link"
+       - link: /one/two/three
+       - anchor: -
+
+     File does not exist:
+       one/two/three
+
+Invalid references dumped, 1 in total.

--- a/tests/golden/check-cli/expected3.gold
+++ b/tests/golden/check-cli/expected3.gold
@@ -1,0 +1,12 @@
+=== Invalid references found ===
+
+  ➥  In file to-ignore/broken-link.md
+     bad reference (absolute) at src:7:1-25:
+       - text: "my link"
+       - link: /one/two/three
+       - anchor: -
+
+     File does not exist:
+       one/two/three
+
+Invalid references dumped, 1 in total.

--- a/tests/golden/check-color/check-color.bats
+++ b/tests/golden/check-color/check-color.bats
@@ -14,21 +14,36 @@ load '../helpers'
 # in CI)") may be running in CI).
 
 @test "Color flag (not in CI)" {
-  CI=false xrefcheck -v --no-progress --color | diff - expected-color.gold
+  golden_file=$(realpath expected-color.gold)
+  output_file="$TEST_TEMP_DIR/temp_file.test"
+  CI=false xrefcheck -v --no-progress --color > $output_file
+  assert_diff
 }
 
 @test "No color flag (not in CI)" {
-  CI=false xrefcheck -v --no-progress --no-color | diff - expected-no-color.gold
+  golden_file=$(realpath expected-no-color.gold)
+  output_file="$TEST_TEMP_DIR/temp_file.test"
+  CI=false xrefcheck -v --no-progress --no-color > $output_file
+  assert_diff
 }
 
 @test "No color default when pipe (not in CI)" {
-  CI=false xrefcheck -v --no-progress | diff - expected-no-color.gold
+  golden_file=$(realpath expected-no-color.gold)
+  output_file="$TEST_TEMP_DIR/temp_file.test"
+  CI=false xrefcheck -v --no-progress > $output_file
+  assert_diff
 }
 
 @test "Color default when CI" {
-  CI=true xrefcheck -v --no-progress | diff - expected-color.gold
+  golden_file=$(realpath expected-color.gold)
+  output_file="$TEST_TEMP_DIR/temp_file.test"
+  CI=true xrefcheck -v --no-progress > $output_file
+  assert_diff
 }
 
 @test "No color flag in CI" {
-  CI=true xrefcheck -v --no-progress --no-color | diff - expected-no-color.gold
+  golden_file=$(realpath expected-no-color.gold)
+  output_file="$TEST_TEMP_DIR/temp_file.test"
+  CI=true xrefcheck -v --no-progress --no-color > $output_file
+  assert_diff
 }

--- a/tests/golden/check-dump-config/check-dump-config.bats
+++ b/tests/golden/check-dump-config/check-dump-config.bats
@@ -11,9 +11,9 @@ load '../helpers'
 
 
 @test "Dump config to stdout" {
+  golden_file=$(realpath ../../configs/github-config.yaml)
   to_temp xrefcheck dump-config --stdout -t GitHub
-
-  assert_diff ../../configs/github-config.yaml
+  assert_diff
 }
 
 @test "Dump config to existent default file error" {

--- a/tests/golden/check-footnotes/check-footnotes.bats
+++ b/tests/golden/check-footnotes/check-footnotes.bats
@@ -11,9 +11,9 @@ load '../helpers'
 
 
 @test "We report broken links inside footnotes" {
+  golden_file=$(realpath expected.gold)
   to_temp xrefcheck -r broken-link-in-footnote
-
-  assert_diff expected.gold
+  assert_diff
 }
 
 @test  "We're not treating footnotes as 'shortcut reference links'"  {

--- a/tests/golden/check-git/check-git.bats
+++ b/tests/golden/check-git/check-git.bats
@@ -38,6 +38,8 @@ load '../helpers'
 }
 
 @test "Git: bad file not tracked, --include-untracked enabled, check failure" {
+  golden_file=$(realpath expected1.gold)
+
   cd $TEST_TEMP_DIR
 
   git init
@@ -46,23 +48,12 @@ load '../helpers'
 
   to_temp xrefcheck --include-untracked
 
-  assert_diff - <<EOF
-=== Invalid references found ===
-
-  ➥  In file git.md
-     bad reference (relative) at src:1:1-11:
-       - text: "a"
-       - link: ./a.md
-       - anchor: -
-
-     File does not exist:
-       ./a.md
-
-Invalid references dumped, 1 in total.
-EOF
+  assert_diff
 }
 
 @test "Git: bad file tracked, check failure" {
+  golden_file=$(realpath expected2.gold)
+
   cd $TEST_TEMP_DIR
 
   git init
@@ -73,24 +64,13 @@ EOF
 
   to_temp xrefcheck
 
-  assert_diff - <<EOF
-=== Invalid references found ===
-
-  ➥  In file git.md
-     bad reference (relative) at src:1:1-11:
-       - text: "a"
-       - link: ./a.md
-       - anchor: -
-
-     File does not exist:
-       ./a.md
-
-Invalid references dumped, 1 in total.
-EOF
+  assert_diff
 }
 
 
 @test "Git: link to untracked file, check failure" {
+  golden_file=$(realpath expected3.gold)
+
   cd $TEST_TEMP_DIR
 
   git init
@@ -103,21 +83,7 @@ EOF
 
   to_temp xrefcheck
 
-  assert_diff - <<EOF
-=== Invalid references found ===
-
-  ➥  In file git.md
-     bad reference (relative) at src:1:1-11:
-       - text: "a"
-       - link: ./a.md
-       - anchor: -
-
-     Link target is not tracked by Git:
-       ./a.md
-       Please run "git add" before running xrefcheck or enable --include-untracked CLI option.
-
-Invalid references dumped, 1 in total.
-EOF
+  assert_diff
 }
 
 @test "Git: link to untracked file, --include-untracked enabled" {

--- a/tests/golden/check-git/expected1.gold
+++ b/tests/golden/check-git/expected1.gold
@@ -1,0 +1,12 @@
+=== Invalid references found ===
+
+  ➥  In file git.md
+     bad reference (relative) at src:1:1-11:
+       - text: "a"
+       - link: ./a.md
+       - anchor: -
+
+     File does not exist:
+       ./a.md
+
+Invalid references dumped, 1 in total.

--- a/tests/golden/check-git/expected2.gold
+++ b/tests/golden/check-git/expected2.gold
@@ -1,0 +1,12 @@
+=== Invalid references found ===
+
+  ➥  In file git.md
+     bad reference (relative) at src:1:1-11:
+       - text: "a"
+       - link: ./a.md
+       - anchor: -
+
+     File does not exist:
+       ./a.md
+
+Invalid references dumped, 1 in total.

--- a/tests/golden/check-git/expected3.gold
+++ b/tests/golden/check-git/expected3.gold
@@ -1,0 +1,13 @@
+=== Invalid references found ===
+
+  ➥  In file git.md
+     bad reference (relative) at src:1:1-11:
+       - text: "a"
+       - link: ./a.md
+       - anchor: -
+
+     Link target is not tracked by Git:
+       ./a.md
+       Please run "git add" before running xrefcheck or enable --include-untracked CLI option.
+
+Invalid references dumped, 1 in total.

--- a/tests/golden/check-ignore/check-ignore.bats
+++ b/tests/golden/check-ignore/check-ignore.bats
@@ -35,46 +35,17 @@ load '../helpers'
 }
 
 @test "Ignore file with broken xrefcheck annotation: directory, check failure" {
+  golden_file=$(realpath expected1.gold)
   to_temp xrefcheck --ignore ./to-ignore/inner-directory/
-
-  assert_diff - <<EOF
-=== Scan errors found ===
-
-  ➥  In file to-ignore/inner-directory/broken_annotation.md
-     scan error at src:9:1-29:
-
-     Annotation "ignore all" must be at the top of markdown or right after comments at the top
-
-Scan errors dumped, 1 in total.
-EOF
+  assert_diff
 }
 
 @test "Ignore referenced file, check error" {
+  golden_file=$(realpath expected2.gold)
+
   to_temp xrefcheck --ignore referenced-file.md
 
-  assert_diff - <<EOF
-=== Scan errors found ===
-
-  ➥  In file to-ignore/inner-directory/broken_annotation.md
-     scan error at src:9:1-29:
-
-     Annotation "ignore all" must be at the top of markdown or right after comments at the top
-
-Scan errors dumped, 1 in total.
-
-=== Invalid references found ===
-
-  ➥  In file check-ignore.md
-     bad reference (absolute) at src:7:1-37:
-       - text: "Good reference"
-       - link: /referenced-file.md
-       - anchor: -
-
-     File does not exist:
-       referenced-file.md
-
-Invalid references dumped, 1 in total.
-EOF
+  assert_diff
 }
 
 @test "Config: Absolute fiepath in \"ignore\" error" {

--- a/tests/golden/check-ignore/expected1.gold
+++ b/tests/golden/check-ignore/expected1.gold
@@ -1,6 +1,6 @@
 === Scan errors found ===
 
-  ➥  In file ./to-ignore/inner-directory/broken_annotation.md
+  ➥  In file to-ignore/inner-directory/broken_annotation.md
      scan error at src:9:1-29:
 
      Annotation "ignore all" must be at the top of markdown or right after comments at the top

--- a/tests/golden/check-ignore/expected2.gold
+++ b/tests/golden/check-ignore/expected2.gold
@@ -1,0 +1,21 @@
+=== Scan errors found ===
+
+  ➥  In file to-ignore/inner-directory/broken_annotation.md
+     scan error at src:9:1-29:
+
+     Annotation "ignore all" must be at the top of markdown or right after comments at the top
+
+Scan errors dumped, 1 in total.
+
+=== Invalid references found ===
+
+  ➥  In file check-ignore.md
+     bad reference (absolute) at src:7:1-37:
+       - text: "Good reference"
+       - link: /referenced-file.md
+       - anchor: -
+
+     File does not exist:
+       referenced-file.md
+
+Invalid references dumped, 1 in total.

--- a/tests/golden/check-ignoreExternalRefsTo/check-ignoreExternalRefsTo.bats
+++ b/tests/golden/check-ignoreExternalRefsTo/check-ignoreExternalRefsTo.bats
@@ -18,11 +18,24 @@ load '../helpers'
 }
 
 @test "Ignore localhost, check errors" {
+  uname_out=$(uname)
+  case "${uname_out}" in
+      Linux*)     platform_suffix=linux;;
+      Darwin*)    platform_suffix=darwin;;
+      CYGWIN*)    platform_suffix=windows;;
+      MINGW*)     platform_suffix=windows;;
+      MSYS_NT*)   platform_suffix=windows;;
+      *)          machine="UNKNOWN:${unameOut}"
+  esac
+  echo "platform_suffix=${platform_suffix}"
+
+  golden_file=$(realpath expected_${platform_suffix}.gold)
+
   to_temp xrefcheck \
     -c config-check-enabled.yaml \
     -r .
 
-  assert_diff expected_linux.gold || assert_diff expected_windows.gold
+  assert_diff
 }
 
 @test "Ignore localhost, no config specified" {

--- a/tests/golden/check-ignoreLocalRefsTo/check-ignoreLocalRefsTo.bats
+++ b/tests/golden/check-ignoreLocalRefsTo/check-ignoreLocalRefsTo.bats
@@ -17,7 +17,7 @@ load '../helpers'
 }
 
 @test "IgnoreLocalRefsTo: check failure" {
+  golden_file=$(realpath expected.gold)
   to_temp xrefcheck
-
-  assert_diff expected.gold
+  assert_diff
 }

--- a/tests/golden/check-ignoreRefsFrom/check-ignoreRefsFrom.bats
+++ b/tests/golden/check-ignoreRefsFrom/check-ignoreRefsFrom.bats
@@ -29,20 +29,7 @@ load '../helpers'
 }
 
 @test "ignoreRefsFrom: directory, check failure" {
+  golden_file=$(realpath expected.gold)
   to_temp xrefcheck -c config-directory.yaml
-
-  assert_diff - <<EOF
-=== Invalid references found ===
-
-  ➥  In file ignoreRefsFrom/inner-directory/bad-reference.md
-     bad reference (absolute) at src:7:1-28:
-       - text: "Bad reference"
-       - link: /no-file.md
-       - anchor: -
-
-     File does not exist:
-       no-file.md
-
-Invalid references dumped, 1 in total.
-EOF
+  assert_diff
 }

--- a/tests/golden/check-ignoreRefsFrom/expected.gold
+++ b/tests/golden/check-ignoreRefsFrom/expected.gold
@@ -1,0 +1,12 @@
+=== Invalid references found ===
+
+  ➥  In file ignoreRefsFrom/inner-directory/bad-reference.md
+     bad reference (absolute) at src:7:1-28:
+       - text: "Bad reference"
+       - link: /no-file.md
+       - anchor: -
+
+     File does not exist:
+       no-file.md
+
+Invalid references dumped, 1 in total.

--- a/tests/golden/check-images/check-images.bats
+++ b/tests/golden/check-images/check-images.bats
@@ -10,7 +10,7 @@ load '../helpers/bats-file/load'
 load '../helpers'
 
 @test "Check images" {
+  golden_file=$(realpath expected.gold)
   to_temp xrefcheck -v
-
-  assert_diff expected.gold
+  assert_diff
 }

--- a/tests/golden/check-local-refs/check-local-refs.bats
+++ b/tests/golden/check-local-refs/check-local-refs.bats
@@ -11,19 +11,19 @@ load '../helpers'
 
 
 @test "Checking local references, root = \".\"" {
+  golden_file=$(realpath expected1.gold)
   to_temp xrefcheck
-
-  assert_diff expected1.gold
+  assert_diff
 }
 
 @test "Checking local references, root = \"dir1\"" {
+  golden_file=$(realpath expected2.gold)
   to_temp xrefcheck -r dir1
-
-  assert_diff expected2.gold
+  assert_diff
 }
 
 @test "Checking behavior when there are virtual files, root = \"dir1\"" {
+  golden_file=$(realpath expected3.gold)
   to_temp xrefcheck -r dir1 -c config-with-virtual-files.yaml
-
-  assert_diff expected3.gold
+  assert_diff
 }

--- a/tests/golden/check-redirect-parse/check-redirect-parse.bats
+++ b/tests/golden/check-redirect-parse/check-redirect-parse.bats
@@ -11,43 +11,33 @@ load '../helpers'
 
 
 @test "No redirect rules" {
+  golden_file=$(realpath expected1.gold)
   to_temp xrefcheck -c no-rules.yaml
-
-assert_diff - <<EOF
-All repository links are valid.
-EOF
+  assert_diff
 }
 
 @test "Only outcome" {
+  golden_file=$(realpath expected2.gold)
   to_temp xrefcheck -c only-outcome.yaml
-
-assert_diff - <<EOF
-All repository links are valid.
-EOF
+  assert_diff
 }
 
 @test "Only outcome and to" {
+  golden_file=$(realpath expected3.gold)
   to_temp xrefcheck -c only-outcome-to.yaml
-
-assert_diff - <<EOF
-All repository links are valid.
-EOF
+  assert_diff
 }
 
 @test "Only outcome and on" {
+  golden_file=$(realpath expected4.gold)
   to_temp xrefcheck -c only-outcome-to.yaml
-
-assert_diff - <<EOF
-All repository links are valid.
-EOF
+  assert_diff
 }
 
 @test "Full rule" {
+  golden_file=$(realpath expected5.gold)
   to_temp xrefcheck -c full-rule.yaml
-
-assert_diff - <<EOF
-All repository links are valid.
-EOF
+  assert_diff
 }
 
 @test "Rules not an array error" {

--- a/tests/golden/check-redirect-parse/expected1.gold
+++ b/tests/golden/check-redirect-parse/expected1.gold
@@ -1,0 +1,1 @@
+All repository links are valid.

--- a/tests/golden/check-redirect-parse/expected2.gold
+++ b/tests/golden/check-redirect-parse/expected2.gold
@@ -1,0 +1,1 @@
+All repository links are valid.

--- a/tests/golden/check-redirect-parse/expected3.gold
+++ b/tests/golden/check-redirect-parse/expected3.gold
@@ -1,0 +1,1 @@
+All repository links are valid.

--- a/tests/golden/check-redirect-parse/expected4.gold
+++ b/tests/golden/check-redirect-parse/expected4.gold
@@ -1,0 +1,1 @@
+All repository links are valid.

--- a/tests/golden/check-redirect-parse/expected5.gold
+++ b/tests/golden/check-redirect-parse/expected5.gold
@@ -1,0 +1,1 @@
+All repository links are valid.

--- a/tests/golden/check-scan-errors/check-scan-errors.bats
+++ b/tests/golden/check-scan-errors/check-scan-errors.bats
@@ -11,7 +11,7 @@ load '../helpers'
 
 
 @test "Dump all errors along with broken links" {
+  golden_file=$(realpath expected.gold)
   to_temp xrefcheck
-
-  assert_diff expected.gold
+  assert_diff
 }

--- a/tests/golden/check-symlinks/check-symlinks.bats
+++ b/tests/golden/check-symlinks/check-symlinks.bats
@@ -11,8 +11,9 @@ load '../helpers'
 
 
 @test "Checking that symlinks are not processed as md files" {
+  golden_file=$(realpath expected1.gold)
+
   cp config-ignore.yaml $TEST_TEMP_DIR
-  cp expected1.gold $TEST_TEMP_DIR
   cp -R dir $TEST_TEMP_DIR
 
   cd $TEST_TEMP_DIR
@@ -31,11 +32,12 @@ load '../helpers'
 
   to_temp xrefcheck -v -c config-ignore.yaml
 
-  assert_diff expected1.gold
+  assert_diff $golden_file
 }
 
 @test "Symlinks validation" {
-  cp expected2.gold $TEST_TEMP_DIR
+  golden_file=$(realpath expected2.gold)
+
   cp -R dir $TEST_TEMP_DIR
 
   cd $TEST_TEMP_DIR
@@ -54,5 +56,5 @@ load '../helpers'
 
   to_temp xrefcheck -v
 
-  assert_diff expected2.gold
+  assert_diff
 }

--- a/tests/golden/helpers.bash
+++ b/tests/golden/helpers.bash
@@ -30,43 +30,30 @@ to_temp() {
 }
 
 # Uses `diff` to compare output file created by `to_temp` against expected output.
-# Expected output could be given either:
-# - in the form of a filepath, e.g. `assert_diff expected.gold`
-# - via stdin when `-` is used, e.g. `assert_diff -`
-# Usage examples:
+# Expected output must be given by setting the `golden_file` variable to an
+# absolute path.
+#
+# Usage example:
 # - filepath:
 #
 # @test "Ignore localhost, check errors" {
+#   golden_file=$(realpath expected.gold)
+#
 #   to_temp xrefcheck \
 #     -c config-check-enabled.yaml \
 #     -r .
 #
-#   assert_diff expected.gold
-# }
-#
-# - stdin:
-# @test "Relative anchor, check error report" {
-#   to_temp xrefcheck
-#
-#   assert_diff - <<EOF
-# === Invalid references found ===
-#
-#        ➥  In file check-relative-anchor.md
-#           bad reference (relative) at src:7:1-40:
-#             - text: "no-anchor"
-#             - link: no-anchor.md
-#             - anchor: invalid-anchor
-#
-#           Anchor 'invalid-anchor' is not present
-#
-#
-# Invalid references dumped, 1 in total.
-# EOF
+#   assert_diff
 # }
 assert_diff() {
+  : "{golden_file?}"
   : "{output_file?}"
 
-  diff $output_file $1 \
+  if [ "${BATS_ACCEPT}" = "1" ]; then
+    cp $output_file $golden_file
+  fi
+
+  diff $output_file $golden_file \
     --ignore-tab-expansion \
     --strip-trailing-cr
 }


### PR DESCRIPTION
**Problem:** in golden tests, it was impossible to automatically accept changes en masse, e.g. if formatting changed.

**Solution:** factor out golden files (i.e. don't inline the expected output directly in `*.bats`) and introduce a `BATS_ACCEPT=1` option to update the expected output.

The main change is in `assert_diff`, and the rest of the patch updates its use sites accordingly.