### PR TITLE
[Chore] Update to cmark-gfm-0.2.6

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -10,7 +10,6 @@ packages:
 - .
 
 extra-deps:
-- cmark-gfm-0.2.5
 - nyan-interpolation-core-0.9.2
 - nyan-interpolation-0.9.2
 - ftp-client-0.5.1.6@sha256:fab127defe1efb165af58f84dbc0f57a39334e39cca9829946149b363a71d1ca,1694

--- a/tests/golden/check-autolinks/expected.gold
+++ b/tests/golden/check-autolinks/expected.gold
@@ -2,7 +2,7 @@
 
   file-with-autolinks.md:
     - references:
-        - reference (external):
+        - reference (external) at src:6:22-52:
             - text: "https://www.google.com/doodles"
             - link: https://www.google.com/doodles
         - reference (external) at src:8:0-18:


### PR DESCRIPTION
As a result, the reported locations are more precise and the `stack.yaml` has one fewer extra dep.