### PR TITLE
v0.3.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,9 @@
 Unreleased
 ==========
 
+0.3.0
+==========
+
 * [#176](https://github.com/serokell/xrefcheck/pull/176)
   + Enabled `autolink` extension for `cmark-gfm`, so now we're finding strings
     like `www.google.com` or `https://google.com`, treating them as links
@@ -36,7 +39,7 @@ Unreleased
   + Now we call references to anchors in current file (e.g. `[a](#b)`) as
   `file-local` references instead of calling them `current file` (which was ambiguous).
 * [#233](https://github.com/serokell/xrefcheck/pull/233)
-  + Now xrefxcheck does not follow redirect links by default. It fails for permanent
+  + Now xrefcheck does not follow redirect links by default. It fails for permanent
     redirect responses (i.e. 301 and 308) and passes for temporary ones (i.e. 302, 303, 307).
 * [#231](https://github.com/serokell/xrefcheck/pull/231)
   + Anchor analysis takes now into account the appropriate case-sensitivity depending on

--- a/package.yaml
+++ b/package.yaml
@@ -5,7 +5,7 @@
 spec-version: 0.31.0
 
 name:                xrefcheck
-version:             0.2.2
+version:             0.3.0
 github:              serokell/xrefcheck
 license:             MPL-2.0
 license-file:        LICENSE


### PR DESCRIPTION
## Description

* #176
  + Enabled `autolink` extension for `cmark-gfm`, so now we're finding strings like `www.google.com` or `https://google.com`, treating them as links and checking.
* #175
  + Reorganize top-level config keys.
* #178
  + Rename exclusion-related config options.
* #183
  + Add support for image links.
* #199
  + Now annotation `<!-- xrefcheck: ignore all -->` instead of `<!-- xrefcheck: ignore file -->` should be used to disable checking for links in file, so it's clearer that file itself is not ignored (and links can target it).
* #215
  + Now we notify user when there are scannable files that were not added to Git yet. Also added CLI option `--include-untracked` to scan such files and treat as existing.
* #191
  + Now we consider slash `/` (and only it) as path separator in local links for all OS, so xrefcheck's report is OS-independent
  + Use utf-8 compatible codepage on Windows
* #224
  + Now the program output does not contain unicode characters that are not widely supported.
* #229
  + Now we call references to anchors in current file (e.g. `[a](#b)`) as `file-local` references instead of calling them `current file` (which was ambiguous).
* #233
  + Now xrefxcheck does not follow redirect links by default. It fails for permanent
    redirect responses (i.e. 301 and 308) and passes for temporary ones (i.e. 302, 303, 307).
* #231
  + Anchor analysis takes now into account the appropriate case-sensitivity depending on
    the configured Markdown flavour.
* #254
  + Now the `dump-config` command does not overwrite a file unless explicitly told with a `--force` flag. Also, a `--stdout` flag allows to print the config to stdout instead.
* #250
  + Now the redirect behavior for external references can be modified via rules in the configuration file with the `externalRefRedirects` parameter.
* #261
  + Symlinks are now not processed by the scanner.
* #268
  + Added CLI option `--color` that enables ANSI colors in output.
  + Changed the output coloring defaults to show colors when `CI` env variable is `true`.
* #271
  + Now Xrefcheck is able to follow relative redirects.
* #262
  + Now Xrefcheck includes a scanner that verifies the repository symlinks.
* #307
  + The output of Xrefcheck is now more legible.
  + Add the `--print-unix-paths` (`-u`) flag to print paths in Unix style (with forward slashes) on all platforms.

## ✓ Release Checklist

- [x] I updated the version number in `package.yaml`.
- [x] I updated the [changelog](https://github.com/serokell/xrefcheck/tree/master/CHANGES.md) and moved everything
      under the "Unreleased" section to a new section for this release version.
- [ ] (After merging) I edited the [auto-release](https://github.com/serokell/xrefcheck/releases/tag/auto-release).
    * Change the tag and title using the format `vX.Y.Z`.
    * Write a summary of all user-facing changes.
    * Deselect the "This is a pre-release" checkbox at the bottom.
- [ ] (After merging) I updated [`xrefcheck-action`](https://github.com/serokell/xrefcheck-action#updating-supported-versions).
- [ ] (After merging) I uploaded the package to [hackage](https://hackage.haskell.org/package/xrefcheck).
