### PR TITLE
[#295] fix failing with OverlongHeaders

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -156,6 +156,7 @@ tests:
       - warp
       - scotty
       - http-types
+      - http-client
       - lens
       - modern-uri
       - nyan-interpolation
@@ -165,6 +166,7 @@ tests:
       - tasty
       - tasty-hunit
       - tasty-quickcheck
+      - text
       - time
       - universum
       - uri-bytestring

--- a/package.yaml
+++ b/package.yaml
@@ -95,7 +95,8 @@ library:
     - ftp-client
     - crypton-connection
     - Glob
-    - http-client
+    - http-client >= 0.7.17
+    - http-client-tls
     - http-types
     - lens
     - modern-uri

--- a/src/Xrefcheck/CLI.hs
+++ b/src/Xrefcheck/CLI.hs
@@ -103,12 +103,14 @@ addExclusionOptions ExclusionConfig{..} (ExclusionOptions ignore) =
 
 data NetworkingOptions = NetworkingOptions
   { noMaxRetries :: Maybe Int
+  , noMaxHeaderLength :: Maybe Int
   }
 
 addNetworkingOptions :: NetworkingConfig -> NetworkingOptions -> NetworkingConfig
-addNetworkingOptions NetworkingConfig{..} (NetworkingOptions maxRetries) =
+addNetworkingOptions NetworkingConfig{..} (NetworkingOptions maxRetries maxHeaderLength) =
   NetworkingConfig
   { ncMaxRetries = fromMaybe ncMaxRetries maxRetries
+  , ncMaxHeaderLength = fromMaybe ncMaxHeaderLength maxHeaderLength
   , ..
   }
 
@@ -228,6 +230,13 @@ networkingOptionsParser = do
     value Nothing <>
     help "How many attempts to retry an external link after getting \
          \a \"429 Too Many Requests\" response."
+
+  noMaxHeaderLength <- option (Just <$> auto) $
+    long "header-limit" <>
+    metavar "INT" <>
+    value Nothing <>
+    help "The maximum allowed total size of HTTP headers (in bytes) \
+         \ that can be returned by the server."
   return NetworkingOptions{..}
 
 dumpConfigOptions :: Parser Command

--- a/src/Xrefcheck/Config/Default.hs
+++ b/src/Xrefcheck/Config/Default.hs
@@ -105,6 +105,13 @@ networking:
   externalRefRedirects:
 #{interpolateIndentF 4 externalRefRedirects}
 
+  # The maximum allowed total size of HTTP headers (in bytes) that can
+  # be returned by the server.
+  #
+  # If the total size of the headers exceeds this value, the request will
+  # fail with an error to prevent the processing of excessively large headers.
+  maxHeaderLength: 4096
+
 # Parameters of scanners for various file types.
 scanners:
   # On 'anchor not found' error, how much similar anchors should be displayed as

--- a/tests/Test/Xrefcheck/MaxHeaderLengthSpec.hs
+++ b/tests/Test/Xrefcheck/MaxHeaderLengthSpec.hs
@@ -1,0 +1,74 @@
+{- SPDX-FileCopyrightText: 2021 Serokell <https://serokell.io>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -}
+
+module Test.Xrefcheck.MaxHeaderLengthSpec where
+
+import Universum hiding ((.~))
+
+import Control.Lens ((.~))
+import Data.Set qualified as S
+import Network.HTTP.Client (newManager, managerSetMaxHeaderLength, defaultManagerSettings)
+import Network.HTTP.Types (ok200)
+import Network.Wai qualified as Web
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase)
+import Web.Scotty qualified as Web
+import qualified Data.Text as T
+import qualified Data.Text.Lazy as TL
+
+import Test.Xrefcheck.UtilRequests
+import Xrefcheck.Config
+import Xrefcheck.Progress
+import Xrefcheck.Verify
+
+mockHeader :: Int -> IO Web.Application
+mockHeader size = Web.scottyApp $ do
+  Web.matchAny "/header" $ do
+    Web.setHeader "X-header" (TL.fromStrict $ T.replicate size "x")
+    Web.status ok200
+
+test_maxHeaderLength :: TestTree
+test_maxHeaderLength = testGroup "MaxHeaderLength tests"
+  [ testCase "Succeeds with small header" $ do
+      setRef <- newIORef S.empty
+      mgr <- newManager $ managerSetMaxHeaderLength mhl defaultManagerSettings
+      checkMultipleLinksWithServer
+        (5001, mockHeader (mhl `div` 2))
+        setRef
+        [ VerifyLinkTestEntry
+            { vlteConfigModifier = \c -> c
+                & cNetworkingL . ncMaxHeaderLengthL .~ mhl
+                & cNetworkingL . ncHttpManagerL .~ Just mgr
+            , vlteLink = "http://127.0.0.1:5001/header"
+            , vlteExpectedProgress = mkProgressWithOneTask True
+            , vlteExpectationErrors = VerifyResult []
+            }
+        ]
+
+  , testCase "Fails with MaxHeaderLengthError" $ do
+      setRef <- newIORef S.empty
+      mgr <- newManager $ managerSetMaxHeaderLength mhl defaultManagerSettings
+      checkMultipleLinksWithServer
+        (5002, mockHeader (mhl*2))
+        setRef
+        [ VerifyLinkTestEntry
+            { vlteConfigModifier = \c -> c
+                & cNetworkingL . ncMaxHeaderLengthL .~ mhl
+                & cNetworkingL . ncHttpManagerL .~ Just mgr
+            , vlteLink = "http://127.0.0.1:5002/header"
+            , vlteExpectedProgress = mkProgressWithOneTask False
+            , vlteExpectationErrors = VerifyResult [MaxHeaderLengthError mhl]
+            }
+        ]
+  ]
+  where
+    mhl = 4096
+
+    mkProgressWithOneTask shouldSucceed = report "" $ initProgress 1
+      where
+        report =
+          if shouldSucceed
+          then reportSuccess
+          else reportError

--- a/tests/configs/github-config.yaml
+++ b/tests/configs/github-config.yaml
@@ -94,6 +94,13 @@ networking:
     - on: permanent
       outcome: invalid
 
+  # The maximum allowed total size of HTTP headers (in bytes) that can
+  # be returned by the server.
+  #
+  # If the total size of the headers exceeds this value, the request will
+  # fail with an error to prevent the processing of excessively large headers.
+  maxHeaderLength: 4096
+
 # Parameters of scanners for various file types.
 scanners:
   # On 'anchor not found' error, how much similar anchors should be displayed as


### PR DESCRIPTION
## Description

Problem:
xrefcheck was failing with `OverlongHeaders`, making it impossible to validate web pages (e.g., Notion pages) that respond with too long headers. 

Solution:
I added a configurable parameter, `ncMaxHeaderLength`, allowing users to define the maximum header length that xrefcheck can handle.

To achieve this, I added a new field, `ncHttpManager`, which contains configurations related to `OverlongHeaders`. This field is purely internal and cannot be configured by users. Reusing a single `Manager` for the project provides maximal connection sharing.

## Related issue(s)

Fixes #295 

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](https://github.com/serokell/xrefcheck/tree/master/README.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [ ] I added an entry to the [changelog](https://github.com/serokell/xrefcheck/tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [ ] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](https://github.com/serokell/style/blob/master/haskell.md).

#### ✓ Release Checklist

- [ ] I updated the version number in `package.yaml`.
- [ ] I updated the [changelog](https://github.com/serokell/xrefcheck/tree/master/CHANGES.md) and moved everything
      under the "Unreleased" section to a new section for this release version.
- [ ] (After merging) I edited the [auto-release](https://github.com/serokell/xrefcheck/releases/tag/auto-release).
    * Change the tag and title using the format `vX.Y.Z`.
    * Write a summary of all user-facing changes.
    * Deselect the "This is a pre-release" checkbox at the bottom.
- [ ] (After merging) I updated [`xrefcheck-action`](https://github.com/serokell/xrefcheck-action#updating-supported-versions).
- [ ] (After merging) I uploaded the package to [hackage](https://hackage.haskell.org/package/xrefcheck).
